### PR TITLE
Stop updating enum values by reference in BigQuerySqlExpressionRenderer

### DIFF
--- a/.changes/unreleased/Fixes-20230517-163839.yaml
+++ b/.changes/unreleased/Fixes-20230517-163839.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes type error in BigQuerySqlExpressionRenderer
+time: 2023-05-17T16:38:39.190547-07:00
+custom:
+  Author: tlento
+  Issue: "536"

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -93,9 +93,11 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
         if node.grain_to_date:
             granularity = node.granularity
             if granularity == TimeGranularity.WEEK or granularity == TimeGranularity.YEAR:
-                granularity.value = "ISO" + granularity.value.upper()
+                granularity_value = "ISO" + granularity.value.upper()
+            else:
+                granularity_value = granularity.value
             return SqlExpressionRenderResult(
-                sql=f"DATE_TRUNC({column.sql}, {granularity.value})",
+                sql=f"DATE_TRUNC({column.sql}, {granularity_value})",
                 bind_parameters=column.bind_parameters,
             )
 


### PR DESCRIPTION
The BigQuerySqlExpressionRenderer is updating the `value` property of
an enum value. It's possible Python passes enumeration types by value,
or does some copy on write, but most likely they're passed by reference
like everything else. As such, modifying properties on an enum instance
is likely bad form.

The existing logic also blocks mypy updates to 0.940 or later. So we
fix it here.
