### PR TITLE
New granularity syntax + {{ }} escaping

### DIFF
--- a/metricflow/test/constraints/test_where.py
+++ b/metricflow/test/constraints/test_where.py
@@ -17,3 +17,12 @@ def test_where_constraint_with_between() -> None:
     """Testing a where constraint with a BETWEEN expression"""
     parsed_where = WhereClauseConstraint.parse("WHERE ds < CURRENT_DATE() AND price BETWEEN min_price AND 1.50")
     assert set(parsed_where.linkable_names) == {"ds", "price", "min_price"}
+
+
+def test_where_constraint_escaped() -> None:
+    """Testing a where constraint with an escaped expression"""
+    parsed_where = WhereClauseConstraint.parse(
+        "WHERE {{ds.granularity(week)}} < CURRENT_DATE() AND {{price}} BETWEEN min_price AND 1.50"
+    )
+    assert set(parsed_where.linkable_names) == {"ds.granularity(week)", "price", "min_price"}
+    assert parsed_where.where == "ds__week < CURRENT_DATE() AND price BETWEEN min_price AND 1.50"

--- a/metricflow/test/integration/test_cases/itest_granularity.yaml
+++ b/metricflow/test/integration/test_cases/itest_granularity.yaml
@@ -338,3 +338,55 @@ integration_test:
     ) b
     ON a.is_instant = b.is_instant
     GROUP BY a.is_instant
+---
+integration_test:
+  name: query_granularity_for_sum_day_new_syntax
+  description: Query a sum metric by time granularities.
+  model: EXTENDED_DATE_MODEL
+  required_features: ["DATE_TRUNC"]
+  metrics: ["bookings"]
+  group_bys: ["metric_time.granularity(day)"]
+  check_query: |
+    SELECT
+      SUM(booking) AS bookings
+      , {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time
+    FROM {{ source_schema }}.fct_bookings_extended
+    GROUP BY
+      ds
+---
+integration_test:
+  name: query_granularity_for_sum_week_new_syntax
+  description: Query a sum metric by time granularities.
+  model: EXTENDED_DATE_MODEL
+  required_features: ["DATE_TRUNC"]
+  metrics: ["bookings"]
+  group_bys: ["metric_time.granularity(week)"]
+  check_query: |
+    SELECT
+      SUM(booking) AS bookings
+      , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS metric_time__week
+    FROM {{ source_schema }}.fct_bookings_extended
+    GROUP BY
+      metric_time__week
+---
+integration_test:
+  name: query_metric_with_new_granularity_escaped_where_constraint
+  description: Query a metric with a month-granularity time dimensions.
+  model: EXTENDED_DATE_MODEL
+  required_features: ["DATE_TRUNC"]
+  metrics: ["bookings"]
+  group_bys: ["metric_time__month"]
+  where_constraint: "{{ render_time_constraint('{{metric_time.granularity(month)}}', '2020-01-01', '2020-01-31') }}"
+  check_query: |
+    SELECT
+      metric_time__month
+      , SUM(bookings) AS bookings
+    FROM (
+      SELECT
+        {{ render_date_trunc("ds", TimeGranularity.MONTH) }} AS metric_time__month
+        , 1 AS bookings
+      FROM {{ source_schema }}.fct_bookings_extended
+    ) subq_2
+    WHERE {{ render_time_constraint("metric_time__month", "2020-01-01", "2020-01-31") }}
+    GROUP BY
+      metric_time__month

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -354,6 +354,34 @@ def test_constraint_metric_parsing() -> None:
     )
 
 
+def test_escaped_constraint_metric_parsing() -> None:
+    """Test for parsing a metric specification with a constraint included"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: constraint_test
+          type: measure_proxy
+          type_params:
+            measures:
+              - input_measure
+          constraint: "{{some_dimension.granularity(month)}} > '2020.01.01'"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_model(files=[file])
+
+    assert len(build_result.model.metrics) == 1
+    metric = build_result.model.metrics[0]
+    assert metric.name == "constraint_test"
+    assert metric.type is MetricType.MEASURE_PROXY
+    assert metric.constraint == WhereClauseConstraint(
+        where="some_dimension__month > '2020.01.01'",
+        linkable_names=["some_dimension.granularity(month)"],
+        sql_params=SqlBindParameters(),
+    )
+
+
 def test_derived_metric_input_parsing() -> None:
     """Test for parsing derived metrics with metric_input properties"""
     yaml_contents = textwrap.dedent(

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -410,3 +410,25 @@ def test_query_parser_updated_granularity_syntax(time_spine_source: TimeSpineSou
             descending=False,
         ),
     )
+
+
+def test_parse_and_validate_where_constraint_updated_granularity_syntax(time_spine_source: TimeSpineSource) -> None:
+    """Test that granularity of metric_time reference in where constraint is at least that of the ds dimension."""
+    revenue_yaml_file = YamlConfigFile(filepath="inline_for_test_2", contents=REVENUE_YAML)
+
+    query_parser = query_parser_from_yaml([revenue_yaml_file], time_spine_source)
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=["revenue"],
+        group_by_names=[MTD],
+        where_constraint_str="WHERE {{metric_time.granularity(month)}} > '2020-01-01' and country = 'vanuatu'",
+    )
+
+    assert query_spec.where_constraint and (
+        TimeDimensionSpec(element_name="metric_time", identifier_links=(), time_granularity=TimeGranularity.MONTH)
+        in query_spec.where_constraint.linkable_spec_set.time_dimension_specs
+    )
+
+    assert query_spec.where_constraint and (
+        DimensionSpec(element_name="country", identifier_links=())
+        in query_spec.where_constraint.linkable_spec_set.dimension_specs
+    )


### PR DESCRIPTION
Context: Replace use of dunders and start using "function" syntax for things like granularity

**Granularity**
old: mf query —metrics revenue —dimensions metric_time__week
new : mf query —metrics revenue —dimensions metric_time.granularity(week)

- add new function style parser class
- new from_name method for dimensions+constraints/linkable specs only for granularity
- tests

**New {{ }} syntax**
Context: Since our new granularity syntax can be invoked in arbitrary where constraint strings, we need some way to differentiate our syntax from the surrounding sql. For example, if we try 
` mf query --metrics transactions --dimensions customer__billing_country --where "metric_time.granularity(week) >= '2021-10-01'"`

Since we use the moz sql parser to parse the arbitrary where string and extract all the dimension and identifier references, we need a mechanism to separate these dimension/identifier references from the surrounding sql. Otherwise, it's not valid sql and doesn't parse, and the linkable name string, in this case 'metric_time.granularity(week)', isn't extractable. Thus, the new syntax would be 
` mf query --metrics transactions --dimensions customer__billing_country --where "{{metric_time.granularity(week)}} >= '2021-10-01'"`

Internally, when we parse a string segment surrounded by the double curly braces, we parse that into a StructuredLinkableName and use the qualified_name to replace it. This is because the where string is directly appended to the end of the sql query, and it needs to match the generated column name in the select statement. Thus, the where statement becomes valid. Inside the linkable_names, which dictate what dimensions/identifiers we might need or join with, we use the original string inside the braces and exclude the new qualified_name one. 

Thus "{{metric_time.granularity(week)}} >= '2021-10-01'"` is parsed to 
WhereClauseConstraint(where = "metric_time__week >= '2021-10-01'", linkable_names = [metric_time.granularity(week)]