### PR TITLE
Validations for conversion metrics

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -24,7 +24,7 @@ from metricflow.model.validations.measures import (
     MetricMeasuresRule,
     MeasuresNonAdditiveDimensionRule,
 )
-from metricflow.model.validations.metrics import CumulativeMetricRule, DerivedMetricRule
+from metricflow.model.validations.metrics import ConversionMetricRule, CumulativeMetricRule, DerivedMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.reserved_keywords import ReservedKeywordsRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
@@ -62,6 +62,7 @@ class ModelValidator:
         AggregationTimeDimensionRule(),
         ReservedKeywordsRule(),
         MeasuresNonAdditiveDimensionRule(),
+        ConversionMetricRule(),
     )
 
     def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 1) -> None:


### PR DESCRIPTION
## Context
Validation for Conversion Metrics

### Rules:
1. Entity must exist in both the data sources that the base_measure and conversion_measure are in
2. base_measure and conversion_measure must be valid and can only be SUM(1) or COUNT or DISTINCT_COUNT measures