### PR TITLE
Stop returning the model from ModelValidator

### DIFF
--- a/.changes/unreleased/Under the Hood-20230424-122900.yaml
+++ b/.changes/unreleased/Under the Hood-20230424-122900.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Removing `model` from the `ModelValidator.validate` return type. The model isn't
+  altered, and thus doesn't need to be returned.
+time: 2023-04-24T12:29:00.760974-07:00
+custom:
+  Author: QMalcolm
+  Issue: None

--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -234,4 +234,4 @@ class MetricFlowClient:
         Returns:
             Tuple of validation issues with the model provided.
         """
-        return ModelValidator().validate_model(self.user_configured_model).issues
+        return ModelValidator().validate_model(self.user_configured_model)

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -59,10 +59,10 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
         ValidationFutureError(context=None, message="future_error_message", error_date=datetime.now()),  # type: ignore
         ValidationError(context=None, message="error_message"),  # type: ignore
     )
-    mocked_build_result = MagicMock(issues=ModelValidationResults.from_issues_sequence(issues))
+    mocked_validate_model = ModelValidationResults.from_issues_sequence(issues)
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
         with patch("metricflow.cli.main.path_to_models", return_value=""):
-            with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
+            with patch.object(ModelValidator, "validate_model", return_value=mocked_validate_model):
                 resp = cli_runner.run(validate_configs)
 
     assert "error_message" in resp.output
@@ -78,10 +78,10 @@ def test_future_errors_and_warnings_conditionally_show_up(cli_runner: MetricFlow
         ValidationFutureError(context=None, message="future_error_message", error_date=datetime.now()),  # type: ignore
         ValidationError(context=None, message="error_message"),  # type: ignore
     )
-    mocked_build_result = MagicMock(issues=ModelValidationResults.from_issues_sequence(issues))
+    mocked_validate_model = ModelValidationResults.from_issues_sequence(issues)
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
         with patch("metricflow.cli.main.path_to_models", return_value=""):
-            with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
+            with patch.object(ModelValidator, "validate_model", return_value=mocked_validate_model):
                 resp = cli_runner.run(validate_configs)
 
     assert "warning_message" not in resp.output
@@ -90,7 +90,7 @@ def test_future_errors_and_warnings_conditionally_show_up(cli_runner: MetricFlow
 
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
         with patch("metricflow.cli.main.path_to_models", return_value=""):
-            with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
+            with patch.object(ModelValidator, "validate_model", return_value=mocked_validate_model):
                 resp = cli_runner.run(validate_configs, ["--show-all"])
 
     assert "warning_message" in resp.output
@@ -106,9 +106,7 @@ def test_validate_configs_data_warehouse_validations(cli_runner: MetricFlowCliRu
     ]
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
         with patch("metricflow.cli.main.path_to_models", return_value=""):
-            with patch.object(
-                ModelValidator, "validate_model", return_value=MagicMock(issues=ModelValidationResults())
-            ):
+            with patch.object(ModelValidator, "validate_model", return_value=ModelValidationResults()):
                 with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore
                     with patch(
                         "metricflow.cli.main._run_dw_validations",

--- a/metricflow/test/model/validations/test_common_identifiers.py
+++ b/metricflow/test/model/validations/test_common_identifiers.py
@@ -20,15 +20,15 @@ def test_lonely_identifier_raises_issue(simple_model__with_primary_transforms: U
     data_source_with_identifiers, _ = find_data_source_with(model, func)
     data_source_with_identifiers.identifiers[0].name = IdentifierSpec.from_name(lonely_identifier_name).element_name
     model_validator = ModelValidator([CommonIdentifiersRule()])
-    build = model_validator.validate_model(model)
+    model_issues = model_validator.validate_model(model)
 
     found_warning = False
     warning = (
         f"Identifier `{lonely_identifier_name}` only found in one data source `{data_source_with_identifiers.name}` "
         f"which means it will be unused in joins."
     )
-    if build.issues is not None:
-        for issue in build.issues:
+    if model_issues is not None:
+        for issue in model_issues.all_issues:
             if re.search(warning, issue.message):
                 found_warning = True
 

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -24,12 +24,12 @@ def test_can_configure_model_validator_rules(  # noqa: D
     )
 
     # confirm that with the default configuration, an issue is raised
-    issues = ModelValidator().validate_model(model).issues
+    issues = ModelValidator().validate_model(model)
     assert len(issues.all_issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
 
     # confirm that a custom configuration excluding ValidMaterializationRule, no issue is raised
     rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
-    issues = ModelValidator(rules=rules).validate_model(model).issues
+    issues = ModelValidator(rules=rules).validate_model(model)
     assert len(issues.all_issues) == 0, f"ModelValidator without DerivedMetricRule returned issues {issues}"
 
 

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -46,7 +46,7 @@ def test_data_source_cant_have_more_than_one_primary_identifier(
         identifier.type = IdentifierType.PRIMARY
         identifier_references.add(identifier.reference)
 
-    build = ModelValidator([OnePrimaryIdentifierPerDataSourceRule()]).validate_model(model)
+    model_issues = ModelValidator([OnePrimaryIdentifierPerDataSourceRule()]).validate_model(model)
 
     future_issue = (
         f"Data sources can have only one primary identifier. The data source"
@@ -55,8 +55,8 @@ def test_data_source_cant_have_more_than_one_primary_identifier(
 
     found_future_issue = False
 
-    if build.issues is not None:
-        for issue in build.issues.all_issues:
+    if model_issues is not None:
+        for issue in model_issues.all_issues:
             if re.search(future_issue, issue.message):
                 found_future_issue = True
 
@@ -244,11 +244,11 @@ def test_mismatched_identifier(simple_model__with_primary_transforms: UserConfig
     )
     listings_latest.identifiers = flatten_nested_sequence([listings_latest.identifiers, [identifier_listings]])
 
-    build = ModelValidator([IdentifierConsistencyRule()]).validate_model(model)
+    model_issues = ModelValidator([IdentifierConsistencyRule()]).validate_model(model)
 
     expected_error_message_fragment = "does not have consistent sub-identifiers"
     error_count = len(
-        [issue for issue in build.issues.all_issues if re.search(expected_error_message_fragment, issue.message)]
+        [issue for issue in model_issues.all_issues if re.search(expected_error_message_fragment, issue.message)]
     )
 
     assert error_count == 1

--- a/metricflow/test/model/validations/test_measures.py
+++ b/metricflow/test/model/validations/test_measures.py
@@ -70,12 +70,12 @@ def test_measures_only_exist_in_one_data_source() -> None:  # noqa: D
     )
     base_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents_1)
     model = parse_yaml_files_to_validation_ready_model([base_file])
-    build = ModelValidator().validate_model(model.model)
+    model_issues = ModelValidator().validate_model(model.model)
     duplicate_measure_message = "Found measure with name .* in multiple data sources with names"
     found_issue = False
 
-    if build.issues is not None:
-        for issue in build.issues.all_issues:
+    if model_issues is not None:
+        for issue in model_issues.all_issues:
             if re.search(duplicate_measure_message, issue.message):
                 found_issue = True
 
@@ -107,10 +107,10 @@ def test_measures_only_exist_in_one_data_source() -> None:  # noqa: D
     )
     dup_measure_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents_2)
     dup_model = parse_yaml_files_to_validation_ready_model([base_file, dup_measure_file])
-    build = ModelValidator([DataSourceMeasuresUniqueRule()]).validate_model(dup_model.model)
+    model_issues = ModelValidator([DataSourceMeasuresUniqueRule()]).validate_model(dup_model.model)
 
-    if build.issues is not None:
-        for issue in build.issues.all_issues:
+    if model_issues is not None:
+        for issue in model_issues.all_issues:
             if re.search(duplicate_measure_message, issue.message):
                 found_issue = True
 
@@ -158,11 +158,11 @@ def test_measure_alias_is_set_when_required() -> None:
     missing_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([missing_alias_file])
 
-    build = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
     expected_error_substring = f"depends on multiple different constrained versions of measure {measure_name}"
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -207,11 +207,11 @@ def test_invalid_measure_alias_name() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    build = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
     expected_error_substring = f"Invalid name `{invalid_alias}` - names should only consist of"
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -258,14 +258,14 @@ def test_measure_alias_measure_name_conflict() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    build = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
     expected_error_substring = (
         f"Alias `{invalid_alias}` for measure `{measure_name}` conflicts with measure names "
         f"defined elsewhere in the model!"
     )
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -321,13 +321,13 @@ def test_reused_measure_alias() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    build = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
     expected_error_substring = (
         f"Measure alias {invalid_alias} conflicts with a measure alias used elsewhere in the model!"
     )
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -379,13 +379,13 @@ def test_reused_measure_alias_within_metric() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    build = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
     expected_error_substring = (
         f"Measure alias {invalid_alias} conflicts with a measure alias used elsewhere in the model!"
     )
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -448,7 +448,7 @@ def test_invalid_non_additive_dimension_properties() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    build = ModelValidator([MeasuresNonAdditiveDimensionRule()]).validate_model(transformed_model)
+    model_issues = ModelValidator([MeasuresNonAdditiveDimensionRule()]).validate_model(transformed_model)
     expected_error_substring_1 = "that is not defined as a dimension in data source 'sample_data_source_2'."
     expected_error_substring_2 = "has a non_additive_dimension with an invalid 'window_groupings'"
     expected_error_substring_3 = "that is defined as a categorical dimension which is not supported."
@@ -460,11 +460,11 @@ def test_invalid_non_additive_dimension_properties() -> None:
         expected_error_substring_3,
         expected_error_substring_4,
     ]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build.issues.errors):
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in model_issues.errors):
             missing_error_strings.add(expected_str)
     assert (
         len(missing_error_strings) == 0
-    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in build.issues.errors])}"
+    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in model_issues.errors])}"
 
 
 def test_count_measure_missing_expr() -> None:
@@ -502,14 +502,14 @@ def test_count_measure_missing_expr() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    build = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
+    model_issues = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
     expected_error_substring = (
         "Measure 'bad_measure' uses a COUNT aggregation, which requires an expr to be provided. "
         "Provide 'expr: 1' if a count of all rows is desired."
     )
-    assert len(build.issues.errors) == 1
+    assert len(model_issues.errors) == 1
 
-    actual_error = build.issues.errors[0].as_readable_str()
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -551,11 +551,11 @@ def test_count_measure_with_distinct_expr() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    build = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
+    model_issues = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
     expected_error_substring = "Measure 'distinct_count' uses a 'count' aggregation with a DISTINCT expr"
 
-    assert len(build.issues.errors) == 1
-    actual_error = build.issues.errors[0].as_readable_str()
+    assert len(model_issues.errors) == 1
+    actual_error = model_issues.errors[0].as_readable_str()
     assert (
         actual_error.find(expected_error_substring) != -1
     ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
@@ -600,7 +600,7 @@ def test_percentile_measure_missing_agg_params() -> None:
     missing_agg_params_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([missing_agg_params_file])
 
-    build = ModelValidator().validate_model(model.model)
+    model_issues = ModelValidator().validate_model(model.model)
     expected_error_substring_1 = (
         "Measure 'bad_measure_1' uses a PERCENTILE aggregation, which requires agg_params.percentile to be provided."
     )
@@ -612,11 +612,11 @@ def test_percentile_measure_missing_agg_params() -> None:
 
     missing_error_strings = set()
     for expected_str in [expected_error_substring_1, expected_error_substring_2, expected_error_substring_3]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build.issues.errors):
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in model_issues.errors):
             missing_error_strings.add(expected_str)
     assert (
         len(missing_error_strings) == 0
-    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in build.issues.errors])}"
+    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in model_issues.errors])}"
 
 
 def test_percentile_measure_bad_percentile_values() -> None:
@@ -656,7 +656,7 @@ def test_percentile_measure_bad_percentile_values() -> None:
     bad_percentile_values_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([bad_percentile_values_file])
 
-    build = ModelValidator().validate_model(model.model)
+    model_issues = ModelValidator().validate_model(model.model)
     expected_error_substring_1 = (
         "Percentile aggregation parameter for measure 'bad_measure_1' is '1.0', but"
         + "must be between 0 and 1 (non-inclusive). For example, to indicate the 65th percentile value, set 'percentile: 0.65'. "
@@ -673,8 +673,8 @@ def test_percentile_measure_bad_percentile_values() -> None:
         expected_error_substring_1,
         expected_error_substring_2,
     ]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build.issues.errors):
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in model_issues.errors):
             missing_error_strings.add(expected_str)
     assert (
         len(missing_error_strings) == 0
-    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in build.issues.errors])}"
+    ), f"Failed to match one or more expected errors: {missing_error_strings} in {set([x.as_readable_str() for x in model_issues.errors])}"

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -180,7 +180,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
 def test_derived_metric() -> None:  # noqa: D
     measure_name = "foo"
     model_validator = ModelValidator([DerivedMetricRule()])
-    result = model_validator.validate_model(
+    model_issues = model_validator.validate_model(
         UserConfiguredModel(
             data_sources=[
                 data_source_with_guaranteed_meta(
@@ -255,7 +255,7 @@ def test_derived_metric() -> None:  # noqa: D
             ],
         )
     )
-    build_issues = result.issues.errors
+    build_issues = model_issues.errors
     assert len(build_issues) == 3
     expected_substr1 = "is already being used. Please choose another alias"
     expected_substr2 = "does not exist as a configured metric in the model"

--- a/metricflow/test/model/validations/test_validity_param_definitions.py
+++ b/metricflow/test/model/validations/test_validity_param_definitions.py
@@ -39,11 +39,11 @@ def test_validity_window_configuration() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
 
-    validation_result = ModelValidator().validate_model(model.model)
+    model_issues = ModelValidator().validate_model(model.model)
 
-    assert not validation_result.issues.has_blocking_issues, (
+    assert not model_issues.has_blocking_issues, (
         f"Found blocking issues validating model with validity window properly configured: "
-        f"{[x.as_readable_str() for x in validation_result.issues.errors]}"
+        f"{[x.as_readable_str() for x in model_issues.errors]}"
     )
 
 


### PR DESCRIPTION
Model validation rules do not alter the model. By extension the ModelValidator does not alter the model. The fact that the ModelValidator was returning the model was a carry over from a now long bygone era when model validators and model transformations were much more tightly coupled.  We've, for the better, gotten away from that. This now vestigial return value's existence can muddle the mental model of how the ModelValidator works for people learning about it. Thus this change cleans this no longer needed functionality. Indeed it's desirable to stop returning the model from the ModelValidator because we want to cement the idea that the ModelValidator does not and should not modify the model.