### PR TITLE
Replace uses of `ValidationIssueType` with `ValidationIssue`

### DIFF
--- a/.changes/unreleased/Under the Hood-20230424-122559.yaml
+++ b/.changes/unreleased/Under the Hood-20230424-122559.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Ensure use of ValidationIssue instead of ValidationIssueType. ValidationIssueType
+  was from a time before ValidationIssue classes had proper inheritance, and it's
+  continued use was become problematic for typing.
+time: 2023-04-24T12:25:59.057065-07:00
+custom:
+  Author: QMalcolm
+  Issue: None

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -28,7 +28,7 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationException,
     ModelValidationResults,
     ValidationError,
-    ValidationIssueType,
+    ValidationIssue,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ class FileParsingResult:
     """
 
     elements: List[Union[DataSource, Metric]]
-    issues: List[ValidationIssueType]
+    issues: List[ValidationIssue]
 
 
 def collect_yaml_config_file_paths(directory: str) -> List[str]:
@@ -201,7 +201,7 @@ def parse_yaml_files_to_model(
     data_sources = []
     metrics = []
     valid_object_classes = [data_source_class.__name__, metric_class.__name__]
-    issues: List[ValidationIssueType] = []
+    issues: List[ValidationIssue] = []
 
     for config_file in files:
         parsing_result = parse_config_yaml(  # parse config file
@@ -242,7 +242,7 @@ def parse_config_yaml(
     """Parses transform config file passed as string - Returns list of model objects"""
     results: List[Union[DataSource, Metric]] = []
     ctx: Optional[ParsingContext] = None
-    issues: List[ValidationIssueType] = []
+    issues: List[ValidationIssue] = []
     try:
         for config_document in YamlConfigLoader.load_all_with_context(
             name=config_yaml.filepath, contents=config_yaml.contents

--- a/metricflow/model/validations/agg_time_dimension.py
+++ b/metricflow/model/validations/agg_time_dimension.py
@@ -9,7 +9,7 @@ from metricflow.model.validations.validator_helpers import (
     DataSourceElementType,
     FileContext,
     ModelValidationRule,
-    ValidationIssueType,
+    ValidationIssue,
     validate_safely,
     ValidationError,
 )
@@ -21,8 +21,8 @@ class AggregationTimeDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for data sources in the model")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
         for data_source in model.data_sources:
             issues.extend(AggregationTimeDimensionRule._validate_data_source(data_source))
 
@@ -37,8 +37,8 @@ class AggregationTimeDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for a data source")
-    def _validate_data_source(data_source: DataSource) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_data_source(data_source: DataSource) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         for measure in data_source.measures:
             measure_context = DataSourceElementContext(

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -11,7 +11,7 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationWarning,
     validate_safely,
-    ValidationIssueType,
+    ValidationIssue,
 )
 from metricflow.references import IdentifierReference
 
@@ -37,8 +37,8 @@ class CommonIdentifiersRule(ModelValidationRule):
         identifier: Identifier,
         data_source: DataSource,
         identifiers_to_data_sources: Dict[IdentifierReference, Set[str]],
-    ) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    ) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
         # If the identifier is the dict and if the set of data sources minus this data source is empty,
         # then we warn the user that their identifier will be unused in joins
         if (
@@ -63,7 +63,7 @@ class CommonIdentifiersRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation warning if identifiers are only one one data source")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:
         """Issues a warning for any identifier that is associated with only one data_source"""
         issues = []
 

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -12,7 +12,7 @@ from metricflow.model.validations.validator_helpers import (
     DataSourceElementType,
     FileContext,
     ModelValidationRule,
-    ValidationIssueType,
+    ValidationIssue,
     ValidationError,
     validate_safely,
 )
@@ -26,8 +26,8 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring time dimensions are defined properly")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         for data_source in model.data_sources:
             issues.extend(DataSourceTimeDimensionWarningsRule._validate_data_source(data_source=data_source))
@@ -35,8 +35,8 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking validity of the data source's time dimensions")
-    def _validate_data_source(data_source: DataSource) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_data_source(data_source: DataSource) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         primary_time_dimensions = []
 
@@ -103,9 +103,9 @@ class DataSourceValidityWindowRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:
         """Checks the validity param definitions in every data source in the model"""
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         for data_source in model.data_sources:
             issues.extend(DataSourceValidityWindowRule._validate_data_source(data_source=data_source))
@@ -116,10 +116,10 @@ class DataSourceValidityWindowRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="checking the data source's validity parameters for compatibility with runtime requirements"
     )
-    def _validate_data_source(data_source: DataSource) -> List[ValidationIssueType]:
+    def _validate_data_source(data_source: DataSource) -> List[ValidationIssue]:
         """Runs assertions on data sources with validity parameters set on one or more time dimensions"""
 
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         validity_param_dims = [dim for dim in data_source.dimensions if dim.validity_params is not None]
 

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -9,7 +9,7 @@ from metricflow.model.validations.validator_helpers import (
     FileContext,
     ModelValidationRule,
     DimensionInvariants,
-    ValidationIssueType,
+    ValidationIssue,
     ValidationError,
     validate_safely,
 )
@@ -27,10 +27,10 @@ class DimensionConsistencyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring dimension consistency")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
         dimension_to_invariant: Dict[DimensionReference, DimensionInvariants] = {}
         time_dims_to_granularity: Dict[DimensionReference, TimeGranularity] = {}
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         for data_source in model.data_sources:
             issues += DimensionConsistencyRule._validate_data_source(
@@ -54,7 +54,7 @@ class DimensionConsistencyRule(ModelValidationRule):
         dimension: Dimension,
         time_dims_to_granularity: Dict[DimensionReference, TimeGranularity],
         data_source: DataSource,
-    ) -> List[ValidationIssueType]:
+    ) -> List[ValidationIssue]:
         """Checks that time dimensions of the same name that aren't primary have the same time granularity specifications
 
         Args:
@@ -63,7 +63,7 @@ class DimensionConsistencyRule(ModelValidationRule):
             data_source: the associated data source. Used for generated issue messages
         Throws: MdoValidationError if there is an inconsistent dimension in the data source.
         """
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
         context = DataSourceElementContext(
             file_context=FileContext.from_metadata(metadata=data_source.metadata),
             data_source_element=DataSourceElementReference(
@@ -102,7 +102,7 @@ class DimensionConsistencyRule(ModelValidationRule):
         data_source: DataSource,
         dimension_to_invariant: Dict[DimensionReference, DimensionInvariants],
         update_invariant_dict: bool,
-    ) -> List[ValidationIssueType]:
+    ) -> List[ValidationIssue]:
         """Checks that the given data source has dimensions consistent with the given invariants.
 
         Args:
@@ -111,7 +111,7 @@ class DimensionConsistencyRule(ModelValidationRule):
             update_invariant_dict: whether to insert an entry into the dict if the given dimension name doesn't exist.
         Throws: MdoValidationError if there is an inconsistent dimension in the data source.
         """
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         for dimension in data_source.dimensions:
             dimension_invariant = dimension_to_invariant.get(dimension.reference)

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -9,7 +9,7 @@ from metricflow.model.validations.validator_helpers import (
     FileContext,
     ModelValidationRule,
     ValidationError,
-    ValidationIssueType,
+    ValidationIssue,
     validate_safely,
 )
 
@@ -25,7 +25,7 @@ class ElementConsistencyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring model wide element consistency")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
         issues = []
         element_name_to_types = ElementConsistencyRule._get_element_name_to_types(model=model)
         invalid_elements = {

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -18,7 +18,6 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationIssue,
     ValidationError,
-    ValidationIssueType,
     validate_safely,
     ValidationWarning,
 )
@@ -33,7 +32,7 @@ class IdentifierConfigRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring identifiers are valid")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
         issues = []
         for data_source in model.data_sources:
             issues += IdentifierConfigRule._validate_data_source_identifiers(data_source=data_source)
@@ -41,9 +40,9 @@ class IdentifierConfigRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the data source's identifiers are valid")
-    def _validate_data_source_identifiers(data_source: DataSource) -> List[ValidationIssueType]:
+    def _validate_data_source_identifiers(data_source: DataSource) -> List[ValidationIssue]:
         """Checks validity of composite identifiers"""
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
         for ident in data_source.identifiers:
             if ident.identifiers:
                 context = DataSourceElementContext(
@@ -227,8 +226,8 @@ class IdentifierConsistencyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation to ensure identifiers have consistent sub-identifiers")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
         # build collection of sub-identifier contexts, keyed by identifier name
         identifier_to_sub_identifier_contexts: DefaultDict[str, List[SubIdentifierContext]] = defaultdict(list)
         all_contexts: List[SubIdentifierContext] = list(

--- a/metricflow/model/validations/measures.py
+++ b/metricflow/model/validations/measures.py
@@ -16,7 +16,7 @@ from metricflow.model.validations.validator_helpers import (
     FileContext,
     MetricContext,
     ModelValidationRule,
-    ValidationIssueType,
+    ValidationIssue,
     ValidationError,
     ValidationWarning,
     validate_safely,
@@ -31,8 +31,8 @@ class DataSourceMeasuresUniqueRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring measures exist in only one configured data source"
     )
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         measure_references_to_data_sources: Dict[MeasureReference, List] = defaultdict(list)
         for data_source in model.data_sources:
@@ -64,7 +64,7 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring measures aliases are set when required")
-    def _validate_required_aliases_are_set(metric: Metric, metric_context: MetricContext) -> List[ValidationIssueType]:
+    def _validate_required_aliases_are_set(metric: Metric, metric_context: MetricContext) -> List[ValidationIssue]:
         """Checks if valid aliases are set on the input measure references where they are required
 
         Aliases are required whenever there are 2 or more input measures with the same measure
@@ -75,7 +75,7 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
         At this time aliases are required for ratio metrics, but eventually we could relax that requirement
         if we can find an automatic aliasing scheme for numerator/denominator that we feel comfortable using.
         """
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         if len(metric.measure_references) == len(set(metric.measure_references)):
             # All measure references are unique, so disambiguation via aliasing is not necessary
@@ -124,13 +124,13 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking constrained measures are aliased properly")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:
         """Ensures measures that might need an alias have one set, and that the alias is distinct
 
         We do not allow aliases to collide with other alias or measure names, since that could create
         ambiguity at query time or cause issues if users ever restructure their models.
         """
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         measure_names = _get_measure_names_from_model(model)
         measure_alias_to_metrics: DefaultDict[str, List[str]] = defaultdict(list)
@@ -186,8 +186,8 @@ class MetricMeasuresRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
-    def _validate_metric_measure_references(metric: Metric, valid_measure_names: Set[str]) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_metric_measure_references(metric: Metric, valid_measure_names: Set[str]) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         for measure_reference in metric.measure_references:
             if measure_reference.element_name not in valid_measure_names:
@@ -207,8 +207,8 @@ class MetricMeasuresRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
         valid_measure_names = _get_measure_names_from_model(model)
 
         for metric in model.metrics or []:
@@ -223,8 +223,8 @@ class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring that a measure's non_additive_dimensions is valid")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
         for data_source in model.data_sources or []:
             for measure in data_source.measures:
                 non_additive_dimension = measure.non_additive_dimension
@@ -371,8 +371,8 @@ class CountAggregationExprRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring expr exist for measures with count aggregation"
     )
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         for data_source in model.data_sources:
             for measure in data_source.measures:
@@ -422,8 +422,8 @@ class PercentileAggregationRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring the agg_params.percentile value exist for measures with percentile aggregation"
     )
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         for data_source in model.data_sources:
             for measure in data_source.measures:

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -10,7 +10,7 @@ from metricflow.model.validations.validator_helpers import (
     FileContext,
     MetricContext,
     ModelValidationRule,
-    ValidationIssueType,
+    ValidationIssue,
     ValidationError,
     validate_safely,
 )
@@ -21,8 +21,8 @@ class CumulativeMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the params of metric are valid if it is a cumulative sum metric")
-    def _validate_cumulative_sum_metric_params(metric: Metric) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_cumulative_sum_metric_params(metric: Metric) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         if metric.type == MetricType.CUMULATIVE:
             if metric.type_params.window and metric.type_params.grain_to_date:
@@ -55,8 +55,8 @@ class CumulativeMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring cumulative sum metrics are valid")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         for metric in model.metrics or []:
             issues += CumulativeMetricRule._validate_cumulative_sum_metric_params(metric=metric)
@@ -69,8 +69,8 @@ class DerivedMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the alias set are not unique and distinct")
-    def _validate_alias_collision(metric: Metric) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_alias_collision(metric: Metric) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         if metric.type == MetricType.DERIVED:
             metric_context = MetricContext(
@@ -93,8 +93,8 @@ class DerivedMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the input metrics exist")
-    def _validate_input_metrics_exist(model: UserConfiguredModel) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_input_metrics_exist(model: UserConfiguredModel) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         all_metrics = {m.name for m in model.metrics}
         for metric in model.metrics:
@@ -114,8 +114,8 @@ class DerivedMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that input metric time offset params are valid")
-    def _validate_time_offset_params(metric: Metric) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_time_offset_params(metric: Metric) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         for input_metric in metric.input_metrics or []:
             if input_metric.offset_window and input_metric.offset_to_grain:
@@ -135,8 +135,8 @@ class DerivedMetricRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         issues += DerivedMetricRule._validate_input_metrics_exist(model=model)
         for metric in model.metrics or []:

--- a/metricflow/model/validations/non_empty.py
+++ b/metricflow/model/validations/non_empty.py
@@ -4,7 +4,7 @@ from dbt_semantic_interfaces.objects.user_configured_model import UserConfigured
 from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationError,
-    ValidationIssueType,
+    ValidationIssue,
     validate_safely,
 )
 
@@ -14,8 +14,8 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has data sources")
-    def _check_model_has_data_sources(model: UserConfiguredModel) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _check_model_has_data_sources(model: UserConfiguredModel) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
         if not model.data_sources:
             issues.append(
                 ValidationError(
@@ -26,8 +26,8 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has metrics")
-    def _check_model_has_metrics(model: UserConfiguredModel) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _check_model_has_metrics(model: UserConfiguredModel) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         # If we are going to generate measure proxy metrics that is sufficient as well
         create_measure_proxy_metrics = False
@@ -47,8 +47,8 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely("running model validation rule ensuring metrics and data sources are defined")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
         issues += NonEmptyRule._check_model_has_data_sources(model=model)
         issues += NonEmptyRule._check_model_has_metrics(model=model)
         return issues

--- a/metricflow/model/validations/reserved_keywords.py
+++ b/metricflow/model/validations/reserved_keywords.py
@@ -12,7 +12,7 @@ from metricflow.model.validations.validator_helpers import (
     FileContext,
     ModelValidationRule,
     ValidationError,
-    ValidationIssueType,
+    ValidationIssue,
     validate_safely,
 )
 
@@ -66,8 +66,8 @@ class ReservedKeywordsRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that data source sub element names aren't reserved sql keywords")
-    def _validate_data_source_sub_elements(data_source: DataSource) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_data_source_sub_elements(data_source: DataSource) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
 
         for dimension in data_source.dimensions:
             if dimension.name.upper() in RESERVED_KEYWORDS:
@@ -126,9 +126,9 @@ class ReservedKeywordsRule(ModelValidationRule):
 
     @classmethod
     @validate_safely(whats_being_done="checking that data_source sql_tables are not sql reserved keywords")
-    def _validate_data_sources(cls, model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def _validate_data_sources(cls, model: UserConfiguredModel) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
         set_keywords = set(RESERVED_KEYWORDS)
 
         for data_source in model.data_sources:
@@ -156,5 +156,5 @@ class ReservedKeywordsRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't contain reserved keywords"
     )
-    def validate_model(cls, model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+    def validate_model(cls, model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
         return cls._validate_data_sources(model=model)

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -20,7 +20,7 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationContext,
     ValidationError,
-    ValidationIssueType,
+    ValidationIssue,
     validate_safely,
 )
 from metricflow.object_utils import assert_values_exhausted
@@ -59,10 +59,8 @@ class UniqueAndValidNameRule(ModelValidationRule):
     NAME_REGEX = re.compile(r"\A[a-z][a-z0-9_]*[a-z0-9]\Z")
 
     @staticmethod
-    def check_valid_name(  # noqa: D
-        name: str, context: Optional[ValidationContext] = None
-    ) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def check_valid_name(name: str, context: Optional[ValidationContext] = None) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
 
         if not UniqueAndValidNameRule.NAME_REGEX.match(name):
             issues.append(
@@ -93,8 +91,8 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking data source sub element names are unique")
-    def _validate_data_source_elements(data_source: DataSource) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
+    def _validate_data_source_elements(data_source: DataSource) -> List[ValidationIssue]:
+        issues: List[ValidationIssue] = []
         element_info_tuples: List[Tuple[ElementReference, str, ValidationContext]] = []
 
         if data_source.measures:
@@ -163,7 +161,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
-    def _validate_top_level_objects(model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def _validate_top_level_objects(model: UserConfiguredModel) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         object_info_tuples = []
         if model.data_sources:
@@ -181,7 +179,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
         name_to_type: Dict[str, str] = {}
 
-        issues: List[ValidationIssueType] = []
+        issues: List[ValidationIssue] = []
 
         for name, type_, context in object_info_tuples:
             if name in name_to_type:
@@ -218,7 +216,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
         issues = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(model=model)
 

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -202,9 +202,6 @@ class ValidationError(ValidationIssue, BaseModel):
         return ValidationIssueLevel.ERROR
 
 
-ValidationIssueType = Union[ValidationWarning, ValidationFutureError, ValidationError]
-
-
 class ModelValidationResults(FrozenBaseModel):
     """Class for organizating the results of running validations"""
 
@@ -218,7 +215,7 @@ class ModelValidationResults(FrozenBaseModel):
         return len(self.errors) != 0
 
     @classmethod
-    def from_issues_sequence(cls, issues: Sequence[ValidationIssueType]) -> ModelValidationResults:
+    def from_issues_sequence(cls, issues: Sequence[ValidationIssue]) -> ModelValidationResults:
         """Constructs a ModelValidationResults class from a list of ValidationIssues"""
 
         warnings: List[ValidationWarning] = []
@@ -263,7 +260,7 @@ class ModelValidationResults(FrozenBaseModel):
         )
 
     @property
-    def all_issues(self) -> Tuple[ValidationIssueType, ...]:
+    def all_issues(self) -> Tuple[ValidationIssue, ...]:
         """For when a singular list of issues is needed"""
         return self.errors + self.future_errors + self.warnings
 
@@ -308,9 +305,9 @@ def validate_safely(whats_being_done: str) -> Callable:
 
     def decorator_check_element_safely(func: Callable) -> Callable:  # noqa
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> List[ValidationIssueType]:  # type: ignore
+        def wrapper(*args: Any, **kwargs: Any) -> List[ValidationIssue]:  # type: ignore
             """Safely run a check on model elements"""
-            issues: List[ValidationIssueType]
+            issues: List[ValidationIssue]
             try:
                 issues = func(*args, **kwargs)
             except Exception as e:
@@ -345,7 +342,7 @@ class ModelValidationRule(ABC):
 
     @classmethod
     @abstractmethod
-    def validate_model(cls, model: UserConfiguredModel) -> List[ValidationIssueType]:
+    def validate_model(cls, model: UserConfiguredModel) -> List[ValidationIssue]:
         """Check the given model and return a list of validation issues"""
         pass
 
@@ -365,6 +362,6 @@ class ModelValidationRule(ABC):
 class ModelValidationException(Exception):
     """Exception raised when validation of a model fails."""
 
-    def __init__(self, issues: Tuple[ValidationIssueType, ...]) -> None:  # noqa: D
+    def __init__(self, issues: Tuple[ValidationIssue, ...]) -> None:  # noqa: D
         issues_str = "\n".join([x.as_readable_str(verbose=True) for x in issues])
         super().__init__(f"Error validating model. Issues:\n{issues_str}")

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -18,17 +18,17 @@ from metricflow.model.validations.validator_helpers import (
     ValidationError,
     ValidationFutureError,
     ValidationIssueLevel,
-    ValidationIssueType,
+    ValidationIssue,
     ValidationWarning,
 )
 
 
 @pytest.fixture
-def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
+def list_of_issues() -> List[ValidationIssue]:  # noqa: D
     file_context = FileContext(file_name="foo", line_number=1337)
     data_source_name = "My data source"
 
-    issues: List[ValidationIssueType] = []
+    issues: List[ValidationIssue] = []
     issues.append(
         ValidationWarning(
             context=DataSourceContext(
@@ -90,7 +90,7 @@ def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
 
 
 def test_creating_model_validation_results_from_issue_list(  # noqa: D
-    list_of_issues: List[ValidationIssueType],
+    list_of_issues: List[ValidationIssue],
 ) -> None:
     warnings = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.WARNING]
     future_errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FUTURE_ERROR]
@@ -107,7 +107,7 @@ def test_creating_model_validation_results_from_issue_list(  # noqa: D
 
 
 def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
-    list_of_issues: List[ValidationIssueType],
+    list_of_issues: List[ValidationIssue],
 ) -> None:
     warnings = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.WARNING]
     errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
@@ -125,7 +125,7 @@ def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
     assert set_context_types == set(new_context_types)
 
 
-def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssueType]) -> None:  # noqa: D
+def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssue]) -> None:  # noqa: D
     validation_results = ModelValidationResults.from_issues_sequence(list_of_issues)
     validation_results_dup = ModelValidationResults.from_issues_sequence(list_of_issues)
     merged = ModelValidationResults.merge([validation_results, validation_results_dup])


### PR DESCRIPTION
Our different validation issue classes (`ValidationWarning`, `ValidationFutureError`, `ValidationError`) used to be entirely separate classes (i.e. didn't inherit from a parent class). However, they now all inherit from `ValidationIssue`. Before this we needed the `ValidationIssueType` type for saying something could contain any of those separate classed. However, since we now have `ValidationIssue` as the parent class, we should be able to replace `ValidationIssueType` with it. This will make typing easier.