### PR TITLE
Improve typechecking coverage

### DIFF
--- a/.changes/unreleased/Under the Hood-20230517-164028.yaml
+++ b/.changes/unreleased/Under the Hood-20230517-164028.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Improves typechecking coverage by updgrading to MyPy 0.942 and removing blanket
+  ignore all imports setting
+time: 2023-05-17T16:40:28.603649-07:00
+custom:
+  Author: tlento
+  Issue: "536"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,17 +16,19 @@ repos:
     hooks: # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
       - id: mypy
         name: mypy_metricflow
-        args: [--ignore-missing-imports, --show-error-codes]
+        args: [--show-error-codes]
         verbose: true
         additional_dependencies:
           [
             dbt-core==1.4.0,
             more-itertools,
             pytest,
+            rapidfuzz,
             "sqlalchemy<2.0",
             sqlalchemy2-stubs,
             types-attrs,
             types-jinja2,
+            types-jsonschema,
             types-python-dateutil,
             types-PyYAML,
             types-tabulate,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,16 +20,14 @@ repos:
         verbose: true
         additional_dependencies:
           [
+            dbt-core==1.4.0,
+            more-itertools,
+            pytest,
             "sqlalchemy<2.0",
             sqlalchemy2-stubs,
-            types-flask,
-            types-requests,
-            types-PyYAML,
-            types-jinja2,
             types-attrs,
-            types-tabulate,
-            pytest,
-            python-dateutil,
+            types-jinja2,
             types-python-dateutil,
-            dbt-core==1.4.0,
+            types-PyYAML,
+            types-tabulate,
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         verbose: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy # configured via mypy.ini
-    rev: v0.931
+    rev: v0.942
     hooks: # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
       - id: mypy
         name: mypy_metricflow

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -310,7 +310,7 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
         us from processing a dataset composed of a join between two SCD semantic models. This restriction is in
         place as a temporary simplification - if there is need for this feature we can enable it.
         """
-        semantic_model_to_window: Dict[str, ValidityWindowJoinDescription] = {}
+        semantic_model_to_window: Dict[SemanticModelReference, ValidityWindowJoinDescription] = {}
         instances_by_semantic_model = bucket(
             instance_set.time_dimension_instances, lambda x: x.origin_semantic_model_reference.semantic_model_reference
         )
@@ -464,7 +464,6 @@ class FilterLinkableInstancesWithLeadingLink(InstanceSetTransform[InstanceSet]):
         )
 
     def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
-
         # Normal to not filter anything if the instance set has no instances with links.
         filtered_dimension_instances = tuple(x for x in instance_set.dimension_instances if self._should_pass(x.spec))
         filtered_time_dimension_instances = tuple(

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,63 @@ disallow_untyped_defs = True
 warn_redundant_casts = True
 namespace_packages = True
 plugins = sqlalchemy.ext.mypy.plugin
+
+
+# Overrides for missing imports
+# https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+
+# The following packages are PEP-561 compliant, but including them
+# surfaces typing errors and as such these should be fixed in independent changes
+[mypy-pandas]
+ignore_missing_imports = True
+
+[mypy-pydantic]
+ignore_missing_imports = True
+
+[mypy-git]
+ignore_missing_imports = True
+
+
+# The following packages don't appear to have an officially supported PEP-561 compliant configuration yet
+[mypy-databricks]
+ignore_missing_imports = True
+
+[mypy-dbt_metadata_client.*]
+ignore_missing_imports = True
+
+[mypy-fuzzywuzzy.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True
+
+[mypy-graphviz]
+ignore_missing_imports = True
+
+
+# ruamel.yaml is typed but for some reason its py.typed marker isn't part of its package
+[mypy-ruamel.yaml.*]
+ignore_missing_imports = True
+
+
+# The following packages are not currently using type hints
+[mypy-halo]
+ignore_missing_imports = True
+
+[mypy-mo_sql_parsing]
+ignore_missing_imports = True
+
+[mypy-rudder_analytics.*]
+ignore_missing_imports = True
+
+[mypy-update_checker]
+ignore_missing_imports = True
+
+[mypy-yamllint]
+ignore_missing_imports = True
+
+
+# dbt-semantic-interfaces is not currently accessible to pre-commit's custom environment
+
+[mypy-dbt_semantic_interfaces.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This PR improves our typechecking coverage by:

1. updating MyPy to 0.942
2. removing the blanket `--ignore-missing-imports` directive
3. cataloguing the individual import overrides
4. fixing a random type issue all of the pre-commit config re-jiggering uncovered