### PR TITLE
Clean up DataSourceSemantics and MetricSemantics.

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -254,7 +254,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
 
     def build_plan_for_distinct_values(
         self,
-        metric_specs: Tuple[MetricSpec, ...],
+        metric_specs: Sequence[MetricSpec],
         dimension_spec: Optional[DimensionSpec] = None,
         time_dimension_spec: Optional[TimeDimensionSpec] = None,
         identifier_spec: Optional[IdentifierSpec] = None,
@@ -274,7 +274,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         assert linkable_spec
 
         query_spec = MetricFlowQuerySpec(
-            metric_specs=metric_specs,
+            metric_specs=tuple(metric_specs),
             dimension_specs=(dimension_spec,) if dimension_spec else (),
             time_dimension_specs=(time_dimension_spec,) if time_dimension_spec else (),
             identifier_specs=(identifier_spec,) if identifier_spec else (),
@@ -600,7 +600,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
 
     def build_aggregated_measures(
         self,
-        metric_input_measure_specs: Tuple[MetricInputMeasureSpec, ...],
+        metric_input_measure_specs: Sequence[MetricInputMeasureSpec],
         queried_linkable_specs: LinkableSpecSet,
         where_constraint: Optional[SpecWhereClauseConstraint] = None,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
@@ -685,7 +685,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
 
     def _build_aggregated_measures_from_measure_source_node(
         self,
-        metric_input_measure_specs: Tuple[MetricInputMeasureSpec, ...],
+        metric_input_measure_specs: Sequence[MetricInputMeasureSpec],
         queried_linkable_specs: LinkableSpecSet,
         where_constraint: Optional[SpecWhereClauseConstraint] = None,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
@@ -895,5 +895,5 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             )
         return AggregateMeasuresNode[SqlDataSetT](
             parent_node=pre_aggregate_node,
-            metric_input_measure_specs=metric_input_measure_specs,
+            metric_input_measure_specs=tuple(metric_input_measure_specs),
         )

--- a/metricflow/model/semantic_model.py
+++ b/metricflow/model/semantic_model.py
@@ -1,5 +1,4 @@
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
 from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.protocols.semantics import DataSourceSemanticsAccessor, MetricSemanticsAccessor
@@ -10,9 +9,7 @@ class SemanticModel:
 
     def __init__(self, user_configured_model: UserConfiguredModel) -> None:  # noqa: D
         self._user_configured_model = user_configured_model
-        self._data_source_semantics = DataSourceSemantics(
-            user_configured_model, PydanticDataSourceContainer(user_configured_model.data_sources)
-        )
+        self._data_source_semantics = DataSourceSemantics(user_configured_model)
         self._metric_semantics = MetricSemantics(self._user_configured_model, self._data_source_semantics)
 
     @property

--- a/metricflow/model/semantics/data_source_container.py
+++ b/metricflow/model/semantics/data_source_container.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, TypeVar, Dict
-
-from dbt_semantic_interfaces.objects.data_source import DataSource
+from typing import Generic, List, TypeVar
 
 T = TypeVar("T")
 
@@ -26,27 +24,3 @@ class DataSourceContainer(ABC, Generic[T]):  # noqa: D
     @abstractmethod
     def put(self, key: str, value: T) -> None:  # noqa: D
         pass
-
-
-class PydanticDataSourceContainer(DataSourceContainer[DataSource]):  # noqa: D
-    def __init__(self, data_sources: List[DataSource]) -> None:  # noqa: D
-        self._data_source_index: Dict[str, DataSource] = {data_source.name: data_source for data_source in data_sources}
-
-    def get(self, data_source_name: str) -> DataSource:  # noqa: D
-        return self._data_source_index[data_source_name]
-
-    def values(self) -> List[DataSource]:  # noqa: D
-        return list(self._data_source_index.values())
-
-    def put(self, key: str, value: T) -> None:  # noqa: D
-        raise TypeError("Cannot call put on static data source container. Data sources are fixed on init")
-
-    def _put(self, data_source: DataSource) -> None:
-        """Dont use this unless you mean it (ie in tests). This is supposed to be static"""
-        self._data_source_index[data_source.name] = data_source
-
-    def keys(self) -> List[str]:  # noqa: D
-        return list(self._data_source_index.keys())
-
-    def __contains__(self, item: str) -> bool:  # noqa: D
-        return item in self._data_source_index

--- a/metricflow/model/semantics/data_source_semantics.py
+++ b/metricflow/model/semantics/data_source_semantics.py
@@ -58,8 +58,8 @@ class DataSourceSemantics(DataSourceSemanticsAccessor):
         for data_source in self._model.data_sources:
             self._add_data_source(data_source)
 
-    def get_dimension_references(self) -> List[DimensionReference]:  # noqa: D
-        return list(self._dimension_index.keys())
+    def get_dimension_references(self) -> Sequence[DimensionReference]:  # noqa: D
+        return tuple(self._dimension_index.keys())
 
     def get_dimension(
         self, dimension_reference: DimensionReference, origin: Optional[DataSourceOrigin] = None
@@ -94,7 +94,7 @@ class DataSourceSemantics(DataSourceSemanticsAccessor):
         assert False, f"{time_dimension_reference} should have been in the dimension index"
 
     @property
-    def measure_references(self) -> List[MeasureReference]:  # noqa: D
+    def measure_references(self) -> Sequence[MeasureReference]:  # noqa: D
         return list(self._measure_index.keys())
 
     @property
@@ -109,11 +109,11 @@ class DataSourceSemantics(DataSourceSemanticsAccessor):
         # Measures should be consistent across data sources, so just use the first one.
         return list(self._measure_index[measure_reference])[0].get_measure(measure_reference)
 
-    def get_identifier_references(self) -> List[IdentifierReference]:  # noqa: D
+    def get_identifier_references(self) -> Sequence[IdentifierReference]:  # noqa: D
         return list(self._identifier_ref_to_entity.keys())
 
     # DSC interface
-    def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> List[DataSource]:  # noqa: D
+    def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> Sequence[DataSource]:  # noqa: D
         return self._measure_index[measure_reference]
 
     def get_agg_time_dimension_for_measure(  # noqa: D

--- a/metricflow/model/semantics/data_source_semantics.py
+++ b/metricflow/model/semantics/data_source_semantics.py
@@ -122,7 +122,7 @@ class DataSourceSemantics(DataSourceSemanticsAccessor):
         return self._measure_agg_time_dimension[measure_reference]
 
     def get_identifier_in_data_source(self, ref: DataSourceElementReference) -> Optional[Identifier]:  # Noqa: d
-        data_source = self.get(ref.data_source_name)
+        data_source = self.get_by_reference(ref.data_source_reference)
         if not data_source:
             return None
 
@@ -132,11 +132,8 @@ class DataSourceSemantics(DataSourceSemanticsAccessor):
 
         return None
 
-    def get(self, data_source_name: str) -> Optional[DataSource]:  # noqa: D
-        return self._data_source_reference_to_data_source.get(DataSourceReference(data_source_name))
-
     def get_by_reference(self, data_source_reference: DataSourceReference) -> Optional[DataSource]:  # noqa: D
-        return self.get(data_source_reference.data_source_name)
+        return self._data_source_reference_to_data_source.get(data_source_reference)
 
     def _add_data_source(
         self,

--- a/metricflow/model/semantics/data_source_semantics.py
+++ b/metricflow/model/semantics/data_source_semantics.py
@@ -14,6 +14,7 @@ from dbt_semantic_interfaces.objects.user_configured_model import UserConfigured
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.element_group import ElementGrouper
 from metricflow.model.spec_converters import MeasureConverter
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.references import (
     MeasureReference,
     TimeDimensionReference,
@@ -26,7 +27,7 @@ from metricflow.specs import NonAdditiveDimensionSpec, MeasureSpec
 logger = logging.getLogger(__name__)
 
 
-class DataSourceSemantics:
+class DataSourceSemantics(DataSourceSemanticsAccessor):
     """Tracks semantic information for data source held in a set of DataSourceContainers
 
     This implements both the DataSourceSemanticsAccessors protocol, the interface type we use throughout the codebase.

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -1,18 +1,16 @@
 import logging
+from typing import Dict, List, FrozenSet, Tuple, Sequence
 
-from typing import Dict, List, FrozenSet, Set, Tuple, Sequence
-
-from metricflow.errors.errors import MetricNotFoundError, DuplicateMetricError, NonExistentMeasureError
 from dbt_semantic_interfaces.objects.metric import Metric, MetricType
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
+from metricflow.errors.errors import MetricNotFoundError, DuplicateMetricError, NonExistentMeasureError
+from metricflow.model.semantics.data_source_join_evaluator import MAX_JOIN_HOPS
 from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
-from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
 from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.references import MetricReference
 from metricflow.specs import MetricSpec, LinkableInstanceSpec, MetricInputMeasureSpec, MeasureSpec
-from metricflow.model.semantics.data_source_join_evaluator import MAX_JOIN_HOPS
-
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +22,6 @@ class MetricSemantics:  # noqa: D
         self._user_configured_model = user_configured_model
         self._metrics: Dict[MetricReference, Metric] = {}
         self._data_source_semantics = data_source_semantics
-
-        # Dict from the name of the metric to the hash.
-        self._metric_hashes: Dict[MetricReference, str] = {}
 
         for metric in self._user_configured_model.metrics:
             self.add_metric(metric)
@@ -84,12 +79,6 @@ class MetricSemantics:  # noqa: D
                     f"Metric `{metric.name}` references measure `{measure_reference}` which has not been registered"
                 )
         self._metrics[metric_reference] = metric
-        self._metric_hashes[metric_reference] = metric.definition_hash
-
-    @property
-    def valid_hashes(self) -> Set[str]:
-        """Return all of the hashes of the metric definitions."""
-        return set(self._metric_hashes.values())
 
     def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
         """Return the measure specs required to compute the metric."""

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, FrozenSet, Tuple, Sequence
+from typing import Dict, List, FrozenSet, Sequence
 
 from dbt_semantic_interfaces.objects.metric import Metric, MetricType
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
@@ -35,10 +35,10 @@ class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
 
     def element_specs_for_metrics(
         self,
-        metric_references: List[MetricReference],
+        metric_references: Sequence[MetricReference],
         with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
         without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
-    ) -> List[LinkableInstanceSpec]:
+    ) -> Sequence[LinkableInstanceSpec]:
         """Dimensions common to all metrics requested (intersection)"""
 
         all_linkable_specs = self._linkable_spec_resolver.get_linkable_elements_for_metrics(
@@ -49,7 +49,7 @@ class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
 
         return sorted(all_linkable_specs.as_tuple, key=lambda x: x.qualified_name)
 
-    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:  # noqa: D
+    def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:  # noqa: D
         res = []
         for metric_reference in metric_references:
             if metric_reference not in self._metrics:
@@ -61,7 +61,7 @@ class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
         return res
 
     @property
-    def metric_references(self) -> List[MetricReference]:  # noqa: D
+    def metric_references(self) -> Sequence[MetricReference]:  # noqa: D
         return list(self._metrics.keys())
 
     def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
@@ -81,7 +81,7 @@ class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
                 )
         self._metrics[metric_reference] = metric
 
-    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
+    def measures_for_metric(self, metric_reference: MetricReference) -> Sequence[MetricInputMeasureSpec]:
         """Return the measure specs required to compute the metric."""
         metric = self.get_metric(metric_reference)
         input_measure_specs: List[MetricInputMeasureSpec] = []
@@ -122,7 +122,7 @@ class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
                         return True
         return False
 
-    def metric_input_specs_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricSpec, ...]:
+    def metric_input_specs_for_metric(self, metric_reference: MetricReference) -> Sequence[MetricSpec]:
         """Return the metric specs referenced by the metric. Current use case is for derived metrics."""
         metric = self.get_metric(metric_reference)
         input_metric_specs: List[MetricSpec] = []

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -9,13 +9,14 @@ from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
 from metricflow.model.spec_converters import WhereConstraintConverter
+from metricflow.protocols.semantics import MetricSemanticsAccessor
 from metricflow.references import MetricReference
 from metricflow.specs import MetricSpec, LinkableInstanceSpec, MetricInputMeasureSpec, MeasureSpec
 
 logger = logging.getLogger(__name__)
 
 
-class MetricSemantics:  # noqa: D
+class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
     def __init__(  # noqa: D
         self, user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
     ) -> None:

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -9,7 +9,7 @@ than the interface specifications.
 from __future__ import annotations
 
 from abc import abstractmethod, ABC
-from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple
+from typing import Dict, FrozenSet, Optional, Sequence, Set
 
 from dbt_semantic_interfaces.objects.data_source import DataSource, DataSourceOrigin
 from dbt_semantic_interfaces.objects.elements.dimension import Dimension
@@ -45,7 +45,7 @@ class DataSourceSemanticsAccessor(ABC):
     """
 
     @abstractmethod
-    def get_dimension_references(self) -> List[DimensionReference]:
+    def get_dimension_references(self) -> Sequence[DimensionReference]:
         """Retrieve all dimension references from the collection of data sources"""
         raise NotImplementedError
 
@@ -63,7 +63,7 @@ class DataSourceSemanticsAccessor(ABC):
 
     @property
     @abstractmethod
-    def measure_references(self) -> List[MeasureReference]:
+    def measure_references(self) -> Sequence[MeasureReference]:
         """Return all measure references from the collection of data sources"""
         raise NotImplementedError
 
@@ -82,12 +82,12 @@ class DataSourceSemanticsAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_identifier_references(self) -> List[IdentifierReference]:
+    def get_identifier_references(self) -> Sequence[IdentifierReference]:
         """Retrieve all identifier references from the collection of data sources"""
         raise NotImplementedError
 
     @abstractmethod
-    def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> List[DataSource]:
+    def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> Sequence[DataSource]:
         """Retrieve a list of all data source model objects associated with the measure reference"""
         raise NotImplementedError
 
@@ -136,21 +136,21 @@ class MetricSemanticsAccessor(ABC):
     @abstractmethod
     def element_specs_for_metrics(
         self,
-        metric_references: List[MetricReference],
+        metric_references: Sequence[MetricReference],
         with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
         without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
-    ) -> List[LinkableInstanceSpec]:
+    ) -> Sequence[LinkableInstanceSpec]:
         """Retrieve the matching set of linkable elements common to all metrics requested (intersection)"""
         raise NotImplementedError
 
     @abstractmethod
-    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:
+    def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:
         """Retrieve the Metric model objects associated with the provided metric specs"""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def metric_references(self) -> List[MetricReference]:
+    def metric_references(self) -> Sequence[MetricReference]:
         """Return the metric references"""
         raise NotImplementedError
 
@@ -159,7 +159,7 @@ class MetricSemanticsAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
+    def measures_for_metric(self, metric_reference: MetricReference) -> Sequence[MetricInputMeasureSpec]:
         """Return the measure specs required to compute the metric."""
         raise NotImplementedError
 
@@ -169,6 +169,6 @@ class MetricSemanticsAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def metric_input_specs_for_metric(self, metric_spec: MetricReference) -> Tuple[MetricSpec, ...]:
+    def metric_input_specs_for_metric(self, metric_spec: MetricReference) -> Sequence[MetricSpec]:
         """Returns the metric input specs required to compute the metric."""
         raise NotImplementedError

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -8,15 +8,15 @@ than the interface specifications.
 
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Dict, FrozenSet, List, Optional, Protocol, Sequence, Set, Tuple
+from abc import abstractmethod, ABC
+from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple
 
-from metricflow.instances import DataSourceElementReference, DataSourceReference
 from dbt_semantic_interfaces.objects.data_source import DataSource, DataSourceOrigin
 from dbt_semantic_interfaces.objects.elements.dimension import Dimension
 from dbt_semantic_interfaces.objects.elements.identifier import Identifier
 from dbt_semantic_interfaces.objects.elements.measure import Measure
 from dbt_semantic_interfaces.objects.metric import Metric
+from metricflow.instances import DataSourceElementReference, DataSourceReference
 from metricflow.model.semantics.element_group import ElementGrouper
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.references import (
@@ -26,7 +26,6 @@ from metricflow.references import (
     TimeDimensionReference,
     MetricReference,
 )
-
 from metricflow.specs import (
     LinkableInstanceSpec,
     MeasureSpec,
@@ -36,8 +35,8 @@ from metricflow.specs import (
 )
 
 
-class DataSourceSemanticsAccessor(Protocol):
-    """Protocol defining core interface for accessing semantic information about a set of data source objects
+class DataSourceSemanticsAccessor(ABC):
+    """Interface for accessing semantic information about a set of data source objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want
     them to use. For example, the DataSourceSemantics class might implement this protocol but also include some
@@ -130,8 +129,8 @@ class DataSourceSemanticsAccessor(Protocol):
         raise NotImplementedError
 
 
-class MetricSemanticsAccessor(Protocol):
-    """Protocol defining core interface for accessing semantic information about a set of metric objects
+class MetricSemanticsAccessor(ABC):
+    """Interface for accessing semantic information about a set of metric objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want
     them to use. For example, the MetricSemantics class might implement this protocol but also include some

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -101,11 +101,6 @@ class DataSourceSemanticsAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get(self, data_source_name: str) -> Optional[DataSource]:
-        """Retrieve the data source model object matching the given name, if any"""
-        raise NotImplementedError
-
-    @abstractmethod
     def get_by_reference(self, data_source_reference: DataSourceReference) -> Optional[DataSource]:
         """Retrieve the data source model object matching the input data source reference, if any"""
         raise NotImplementedError

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -164,12 +164,6 @@ class MetricSemanticsAccessor(Protocol):
     def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
         raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def valid_hashes(self) -> Set[str]:
-        """Return all of the hashes of the metric definitions."""
-        raise NotImplementedError
-
     @abstractmethod
     def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
         """Return the measure specs required to compute the metric."""

--- a/metricflow/test/model/semantics/test_data_source_join_evaluator.py
+++ b/metricflow/test/model/semantics/test_data_source_join_evaluator.py
@@ -1,7 +1,7 @@
 from typing import Dict, Sequence
 
-from metricflow.instances import DataSourceReference
 from dbt_semantic_interfaces.objects.elements.identifier import IdentifierType
+from metricflow.instances import DataSourceReference
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.semantics.data_source_join_evaluator import (
     DataSourceIdentifierJoinType,
@@ -57,9 +57,13 @@ def __get_simple_model_user_data_source_references_by_type(
     semantic_model: SemanticModel,
 ) -> Dict[IdentifierType, DataSourceReference]:
     """Helper to get a set of data sources with the `user` identifier organized by identifier type"""
-    foreign_user_data_source = semantic_model.data_source_semantics.get("listings_latest")
-    primary_user_data_source = semantic_model.data_source_semantics.get("users_latest")
-    unique_user_data_source = semantic_model.data_source_semantics.get("companies")
+    foreign_user_data_source = semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("listings_latest")
+    )
+    primary_user_data_source = semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("users_latest")
+    )
+    unique_user_data_source = semantic_model.data_source_semantics.get_by_reference(DataSourceReference("companies"))
 
     assert foreign_user_data_source, "Could not find `listings_latest` data source in simple model!"
     assert primary_user_data_source, "Could not find `users_latest` data source in simple model!"
@@ -165,9 +169,13 @@ def test_foreign_target_data_source_join_validation(simple_semantic_model: Seman
 
 def test_data_source_join_validation_on_missing_identifier(simple_semantic_model: SemanticModel) -> None:
     """Tests data source join validation where the identifier is missing from one or both data sources"""
-    primary_listing_data_source = simple_semantic_model.data_source_semantics.get("listings_latest")
+    primary_listing_data_source = simple_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("listings_latest")
+    )
     assert primary_listing_data_source, "Could not find data source `listings_latest` in the simple model!"
-    no_listing_data_source = simple_semantic_model.data_source_semantics.get("id_verifications")
+    no_listing_data_source = simple_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("id_verifications")
+    )
     assert no_listing_data_source, "Could not find data source `id_verifications` in the simple model!"
     listing_identifier_reference = IdentifierReference(element_name="listing")
     join_evaluator = DataSourceJoinEvaluator(data_source_semantics=simple_semantic_model.data_source_semantics)
@@ -361,10 +369,18 @@ def test_natural_identifier_data_source_validation(scd_semantic_model: SemanticM
 
     These tests rely on the scd_semantic_model, which makes extensive use of NATURAL key types.
     """
-    natural_user_data_source = scd_semantic_model.data_source_semantics.get("primary_accounts")
-    primary_user_data_source = scd_semantic_model.data_source_semantics.get("users_latest")
-    foreign_user_data_source = scd_semantic_model.data_source_semantics.get("bookings_source")
-    unique_user_data_source = scd_semantic_model.data_source_semantics.get("companies")
+    natural_user_data_source = scd_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("primary_accounts")
+    )
+    primary_user_data_source = scd_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("users_latest")
+    )
+    foreign_user_data_source = scd_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("bookings_source")
+    )
+    unique_user_data_source = scd_semantic_model.data_source_semantics.get_by_reference(
+        DataSourceReference("companies")
+    )
     user_identifier_reference = IdentifierReference(element_name="user")
     join_evaluator = DataSourceJoinEvaluator(data_source_semantics=scd_semantic_model.data_source_semantics)
     # Type refinement

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -13,23 +13,23 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def new_data_source_semantics(simple_user_configured_model: UserConfiguredModel) -> DataSourceSemantics:  # Noqa: D
+def data_source_semantics(simple_user_configured_model: UserConfiguredModel) -> DataSourceSemantics:  # Noqa: D
     return DataSourceSemantics(
         model=simple_user_configured_model,
     )
 
 
 @pytest.fixture
-def new_metric_semantics(  # Noqa: D
-    simple_user_configured_model: UserConfiguredModel, new_data_source_semantics: DataSourceSemantics
+def metric_semantics(  # Noqa: D
+    simple_user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
 ) -> MetricSemantics:
     return MetricSemantics(
         user_configured_model=simple_user_configured_model,
-        data_source_semantics=new_data_source_semantics,
+        data_source_semantics=data_source_semantics,
     )
 
 
-def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
+def test_get_names(data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
     expected = [
         "account_type",
         "booking_paid_at",
@@ -45,7 +45,7 @@ def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # n
         "is_lux_latest",
         "verification_type",
     ]
-    assert sorted([d.element_name for d in new_data_source_semantics.get_dimension_references()]) == expected
+    assert sorted([d.element_name for d in data_source_semantics.get_dimension_references()]) == expected
 
     expected = [
         "account_balance",
@@ -72,7 +72,7 @@ def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # n
         "txn_revenue",
         "views",
     ]
-    assert sorted([m.element_name for m in new_data_source_semantics.measure_references]) == expected
+    assert sorted([m.element_name for m in data_source_semantics.measure_references]) == expected
 
     expected = [
         "company",
@@ -84,39 +84,39 @@ def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # n
         "user",
         "verification",
     ]
-    assert sorted([i.element_name for i in new_data_source_semantics.get_identifier_references()]) == expected
+    assert sorted([i.element_name for i in data_source_semantics.get_identifier_references()]) == expected
 
 
-def test_get_elements(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
-    for dimension_reference in new_data_source_semantics.get_dimension_references():
+def test_get_elements(data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
+    for dimension_reference in data_source_semantics.get_dimension_references():
         assert (
-            new_data_source_semantics.get_dimension(dimension_reference=dimension_reference).reference
+            data_source_semantics.get_dimension(dimension_reference=dimension_reference).reference
             == dimension_reference
         )
-    for measure_reference in new_data_source_semantics.measure_references:
+    for measure_reference in data_source_semantics.measure_references:
         measure_reference = MeasureReference(element_name=measure_reference.element_name)
-        assert new_data_source_semantics.get_measure(measure_reference=measure_reference).reference == measure_reference
+        assert data_source_semantics.get_measure(measure_reference=measure_reference).reference == measure_reference
 
 
-def test_get_data_sources_for_measure(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
-    bookings_sources = new_data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="bookings"))
+def test_get_data_sources_for_measure(data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
+    bookings_sources = data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="bookings"))
     assert len(bookings_sources) == 1
     assert bookings_sources[0].name == "bookings_source"
 
-    views_sources = new_data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="views"))
+    views_sources = data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="views"))
     assert len(views_sources) == 1
     assert views_sources[0].name == "views_source"
 
-    listings_sources = new_data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="listings"))
+    listings_sources = data_source_semantics.get_data_sources_for_measure(MeasureReference(element_name="listings"))
     assert len(listings_sources) == 1
     assert listings_sources[0].name == "listings_latest"
 
 
-def test_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # noqa: D
+def test_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa: D
     assert set(
         [
             x.qualified_name
-            for x in new_metric_semantics.element_specs_for_metrics(
+            for x in metric_semantics.element_specs_for_metrics(
                 [MetricReference(element_name="views")],
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
             )
@@ -160,7 +160,7 @@ def test_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # 
         "user__home_state_latest",
     }
 
-    local_specs = new_metric_semantics.element_specs_for_metrics(
+    local_specs = metric_semantics.element_specs_for_metrics(
         metric_references=[MetricReference(element_name="views")],
         with_any_property=frozenset({LinkableElementProperties.LOCAL}),
         without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
@@ -174,11 +174,11 @@ def test_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # 
     }
 
 
-def test_local_linked_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # noqa: D
+def test_local_linked_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa: D
     result = set(
         [
             x.qualified_name
-            for x in new_metric_semantics.element_specs_for_metrics(
+            for x in metric_semantics.element_specs_for_metrics(
                 [MetricReference(element_name="listings")],
                 with_any_property=frozenset({LinkableElementProperties.LOCAL_LINKED}),
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
@@ -195,9 +195,9 @@ def test_local_linked_elements_for_metric(new_metric_semantics: MetricSemantics)
     }
 
 
-def test_get_data_sources_for_identifier(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
+def test_get_data_sources_for_identifier(data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
     identifier_reference = IdentifierReference(element_name="user")
-    linked_data_sources = new_data_source_semantics.get_data_sources_for_identifier(
+    linked_data_sources = data_source_semantics.get_data_sources_for_identifier(
         identifier_reference=identifier_reference
     )
     assert len(linked_data_sources) == 9

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -3,9 +3,8 @@ import logging
 import pytest
 
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.references import IdentifierReference, MeasureReference
 from metricflow.references import MetricReference
@@ -17,7 +16,6 @@ logger = logging.getLogger(__name__)
 def new_data_source_semantics(simple_user_configured_model: UserConfiguredModel) -> DataSourceSemantics:  # Noqa: D
     return DataSourceSemantics(
         model=simple_user_configured_model,
-        configured_data_source_container=PydanticDataSourceContainer(simple_user_configured_model.data_sources),
     )
 
 


### PR DESCRIPTION
This PR cleans up `DataSourceSemantics` and `MetricSemantics` to

* Remove functionality that is no longer used. 
* Move from using strings to look up data sources to using `DataSourceReference`.
* Change signatures to use `Sequence` instead of `List` or `Tuple` to follow principle of using the most general interfaces in the signatures. `Iterable` or something else may be more apt, however.

Cleanup of some of the internal data structures will be handled in another PR.