### PR TITLE
BUG: Input Metric's original constraint is not being propogated

### DIFF
--- a/.changes/unreleased/Fixes-20230428-123628.yaml
+++ b/.changes/unreleased/Fixes-20230428-123628.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Derived metrics were not respecting the constraint defined in the original input
+  metric's definition.
+time: 2023-04-28T12:36:28.092934-04:00
+custom:
+  Author: WilliamDee
+  Issue: None

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.objects.base import (
     PydanticParseableValueType,
 )
 from metricflow.object_utils import ExtendedEnum, hash_items
-from metricflow.references import MeasureReference
+from metricflow.references import MeasureReference, MetricReference
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_granularity import string_to_time_granularity
 
@@ -128,6 +128,10 @@ class MetricInput(HashableBaseModel):
     alias: Optional[str]
     offset_window: Optional[MetricTimeWindow]
     offset_to_grain: Optional[TimeGranularity]
+
+    @property
+    def as_reference(self) -> MetricReference:  # noqa: D
+        return MetricReference(element_name=self.name)
 
 
 class MetricTypeParams(HashableBaseModel):

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -375,6 +375,25 @@ metric:
       - name: bookings
 ---
 metric:
+  name: "booking_value_sub_instant"
+  description: "booking_value - instant_booking_value"
+  type: derived
+  type_params:
+    expr: booking_value - instant_booking_value
+    metrics:
+      - name: instant_booking_value
+      - name: booking_value
+---
+metric:
+  name: "booking_value_sub_instant_add_10"
+  description: "Add 10 to booking_value - instant_booking_value"
+  type: derived
+  type_params:
+    expr: booking_value_sub_instant + 10
+    metrics:
+      - name: booking_value_sub_instant
+---
+metric:
   name: bookings_per_lux_listing_derived
   description: Bookings divided by listings - using derived metric type
   type: derived

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -804,3 +804,69 @@ integration_test:
         metric_time
     ) b
     ON {{ render_date_sub("a", "ds", 5, TimeGranularity.DAY) }} = b.metric_time
+---
+integration_test:
+  name: derived_metric_with_input_metric_with_constraint
+  description: |
+    Tests a derived metric where the input metric has a metric constraint
+  model: SIMPLE_MODEL
+  metrics: ["booking_value_sub_instant"]
+  group_bys: ["metric_time"]
+  check_query: |
+    SELECT
+      booking_value - instant_booking_value AS booking_value_sub_instant
+      , a.metric_time
+    FROM (
+      SELECT
+        SUM(booking_value) AS instant_booking_value
+        , ds AS metric_time
+      FROM {{ source_schema }}.fct_bookings
+      WHERE is_instant
+      GROUP BY
+        ds
+    ) a
+    INNER JOIN (
+      SELECT
+        SUM(booking_value) AS booking_value
+        , ds AS metric_time
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        ds
+    ) b
+    ON a.metric_time = b.metric_time
+---
+integration_test:
+  name: nested_derived_metric_with_input_metric_with_constraint
+  description: |
+    Tests a nested derived metric where the input metric is a derived metric 
+    where the input_metric has a metric constraint
+  model: SIMPLE_MODEL
+  metrics: ["booking_value_sub_instant_add_10"]
+  group_bys: ["metric_time"]
+  check_query: |
+    SELECT 
+      c.booking_value_sub_instant + 10 AS booking_value_sub_instant_add_10
+      , c.metric_time
+    FROM (
+      SELECT
+        booking_value - instant_booking_value AS booking_value_sub_instant
+        , a.metric_time AS metric_time
+      FROM (
+        SELECT
+          SUM(booking_value) AS instant_booking_value
+          , ds AS metric_time
+        FROM {{ source_schema }}.fct_bookings
+        WHERE is_instant
+        GROUP BY
+          ds
+      ) a
+      INNER JOIN (
+        SELECT
+          SUM(booking_value) AS booking_value
+          , ds AS metric_time
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          ds
+      ) b
+      ON a.metric_time = b.metric_time
+    ) c


### PR DESCRIPTION
## Context
In derived metric, there are multiple layers of constraints.
1. The constraint in the metric used as an input metric
2. The input_metric constraint defined in the derived metric definition

`(1)` is not being respected so if one were to define a derived metric as so,
```yaml
metric:
  name: "instant_bookings"
  description: "bookings metric"
  type: measure_proxy
  type_params:
    measures:
      - bookings
  constraint: is_instant
---
metric:
  name: "double_instant_bookings"
  description: "2x bookings metric"
  type: derived
  type_params:
    expr: instant_bookings * 2
    metrics:
      - name: instant_bookings
```
The `constraint: is_instant` clause would be missing in the metric `double_instant_bookings`. This PR fixes this bug.
    