### PR TITLE
Cutover errors specific to parsing/transformation/validation to dbt_semantic_interfaces

### DIFF
--- a/.changes/unreleased/Under the Hood-20230425-112809.yaml
+++ b/.changes/unreleased/Under the Hood-20230425-112809.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Moving errors relevant to dbt_semantic_interfaces to dbt_semantic_interfaces
+time: 2023-04-25T11:28:09.018345-07:00
+custom:
+  Author: QMalcolm
+  Issue: None

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/errors.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/errors.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from dbt_semantic_interfaces.parsing.yaml_loader import ParsingContext
+
+
+class ConstraintParseException(Exception):  # noqa: D
+    pass
+
+
+class ParsingException(Exception):  # noqa: D
+    def __init__(  # noqa: D
+        self, message: str, ctx: Optional[ParsingContext] = None, config_filepath: Optional[str] = None
+    ) -> None:
+        if config_filepath:
+            message = f"Failed to parse YAML file '{config_filepath}' - {message}"
+        if ctx:
+            message = f"{message}\nContext: {str(ctx)}"
+        super().__init__(message)
+
+
+class ModelTransformError(Exception):
+    """Exception to represent errors related to model transformations."""
+
+    pass

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/base.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/base.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Generic, Iterator, TypeVar
 
 from pydantic import BaseModel, root_validator
 
-from metricflow.errors.errors import ParsingException
+from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.parsing.yaml_loader import ParsingContext, PARSING_CONTEXT_KEY
 
 # Type alias for the implicit "Any" type used as input and output for Pydantic's parsing API

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/common.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/common.py
@@ -4,7 +4,7 @@ import re
 
 from typing import Optional
 
-from metricflow.errors.errors import ParsingException
+from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.objects.base import HashableBaseModel
 
 

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/constraints/where.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/constraints/where.py
@@ -5,7 +5,7 @@ import re
 from typing import List, Optional, Dict, Any
 
 from mo_sql_parsing import parse as mo_parse
-from metricflow.errors.errors import ConstraintParseException
+from dbt_semantic_interfaces.errors import ConstraintParseException
 from dbt_semantic_interfaces.objects.base import (
     HashableBaseModel,
     PydanticCustomInputParser,

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from metricflow.errors.errors import ParsingException
+from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.objects.common import Metadata
 from dbt_semantic_interfaces.objects.constraints.where import WhereClauseConstraint
 from dbt_semantic_interfaces.objects.base import (

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict, List, Union, Type
 
 from jsonschema import exceptions
 
-from metricflow.errors.errors import ParsingException
+from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
 from dbt_semantic_interfaces.objects.common import Version, YamlConfigFile
 from dbt_semantic_interfaces.objects.data_source import DataSource

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -1,6 +1,6 @@
 from typing import Set
 
-from metricflow.errors.errors import ModelTransformError
+from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.objects.metric import MetricType, MetricInputMeasure
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/convert_count.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/convert_count.py
@@ -1,5 +1,5 @@
 from dbt_semantic_interfaces.objects.aggregation_type import AggregationType
-from metricflow.errors.errors import ModelTransformError
+from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/convert_median.py
@@ -1,5 +1,5 @@
 from dbt_semantic_interfaces.objects.aggregation_type import AggregationType
-from metricflow.errors.errors import ModelTransformError
+from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.objects.elements.measure import MeasureAggregationParameters
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -1,6 +1,6 @@
 import logging
 
-from metricflow.errors.errors import ModelTransformError
+from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.objects.metric import Metric, MetricInputMeasure, MetricType, MetricTypeParams
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -1,7 +1,5 @@
 import textwrap
-from typing import Dict, Optional
-
-from dbt_semantic_interfaces.parsing.yaml_loader import ParsingContext
+from typing import Dict
 
 
 class CustomerFacingSemanticException(Exception):
@@ -45,21 +43,6 @@ class InvalidDataSourceError(SemanticException):  # noqa:D
     pass
 
 
-class ConstraintParseException(Exception):  # noqa: D
-    pass
-
-
-class ParsingException(Exception):  # noqa: D
-    def __init__(  # noqa: D
-        self, message: str, ctx: Optional[ParsingContext] = None, config_filepath: Optional[str] = None
-    ) -> None:
-        if config_filepath:
-            message = f"Failed to parse YAML file '{config_filepath}' - {message}"
-        if ctx:
-            message = f"{message}\nContext: {str(ctx)}"
-        super().__init__(message)
-
-
 class ExecutionException(Exception):
     """Raised if there are any errors while executing the execution plan"""
 
@@ -95,9 +78,3 @@ class ModelCreationException(Exception):
 
 class InferenceError(Exception):
     """Exception to represent errors related to inference."""
-
-
-class ModelTransformError(Exception):
-    """Exception to represent errors related to model transformations."""
-
-    pass

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -1,7 +1,7 @@
 import traceback
 from typing import List
 
-from metricflow.errors.errors import ParsingException
+from dbt_semantic_interfaces.errors import ParsingException
 from metricflow.instances import MetricModelReference
 from dbt_semantic_interfaces.objects.metric import Metric, MetricType, MetricTimeWindow
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel


### PR DESCRIPTION
The parsing/transformation/validation related MetricFlow errors are only related to those processes. Those processes are moving to dbt_semantic_interfaces. Thus, it behooves us to move these to dbt_semantic_interfaces as well.