### PR TITLE
Remove MYSQL from `SqlEngine` & `SqlDialect` enums

### DIFF
--- a/.changes/unreleased/Fixes-20230426-104954.yaml
+++ b/.changes/unreleased/Fixes-20230426-104954.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Removes MySQL from SqlEngine and SqlDialect options since it is not supported.
+time: 2023-04-26T10:49:54.213848-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "0"

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -21,9 +21,6 @@ class SqlEngine(Enum):
     SNOWFLAKE = "Snowflake"
     DATABRICKS = "Databricks"
 
-    # Not yet supported.
-    MYSQL = "MySQL"
-
 
 class SqlIsolationLevel(Enum):
     """Describes the isolation levels used to execute SQL queries. Values are passed as options to SQLAlchemy."""

--- a/metricflow/sql_clients/common_client.py
+++ b/metricflow/sql_clients/common_client.py
@@ -10,7 +10,6 @@ class SqlDialect(ExtendedEnum):
     DUCKDB = "duckdb"
     REDSHIFT = "redshift"
     POSTGRESQL = "postgresql"
-    MYSQL = "mysql"
     SNOWFLAKE = "snowflake"
     BIGQUERY = "bigquery"
     DATABRICKS = "databricks"

--- a/metricflow/test/sql_clients/test_async.py
+++ b/metricflow/test/sql_clients/test_async.py
@@ -192,7 +192,6 @@ def test_request_tags(
         or engine_type is SqlEngine.REDSHIFT
         or engine_type is SqlEngine.DATABRICKS
         or engine_type is SqlEngine.POSTGRES
-        or engine_type is SqlEngine.MYSQL
     ):
         pytest.skip(f"Testing tags not supported in {engine_type}")
     else:

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -175,7 +175,6 @@ def _issue_sleep_query(sql_client: SqlClient, sleep_time: int) -> None:
         or engine_type is SqlEngine.REDSHIFT
         or engine_type is SqlEngine.DATABRICKS
         or engine_type is SqlEngine.POSTGRES
-        or engine_type is SqlEngine.MYSQL
     ):
         raise RuntimeError(f"Sleep yet not supported with {engine_type}")
     else:
@@ -193,7 +192,6 @@ def _supports_sleep_query(sql_client: SqlClient) -> bool:
         or engine_type is SqlEngine.REDSHIFT
         or engine_type is SqlEngine.DATABRICKS
         or engine_type is SqlEngine.POSTGRES
-        or engine_type is SqlEngine.MYSQL
     ):
         return False
     else:


### PR DESCRIPTION
This was an artifact of Transform and is no longer needed.