### PR TITLE
Reduce time to run tests by using a persistent source schema

### DIFF
--- a/.changes/unreleased/Under the Hood-20230503-174526.yaml
+++ b/.changes/unreleased/Under the Hood-20230503-174526.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add pytest flag to use a persistent source schema for faster repeat testing.
+time: 2023-05-03T17:45:26.930661-07:00
+custom:
+  Author: plypaul
+  Issue: "482"

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Snowflake configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_SNOWFLAKE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_SNOWFLAKE_PWD }}
@@ -69,7 +69,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Redshift configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_REDSHIFT_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_REDSHIFT_PWD }}
@@ -102,7 +102,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with BigQuery configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
@@ -135,7 +135,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Databricks configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_CLUSTER_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
@@ -168,7 +168,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Databricks configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_SQL_WAREHOUSE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
@@ -216,7 +216,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install -E dbt-cloud
 
       - name: Run MetricFlow Unit tests suites
-        run: poetry run pytest metricflow/test
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/
         env:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   metricflow-unit-tests-postgres:
@@ -82,7 +82,7 @@ jobs:
         run: cd metricflow && poetry install -E dbt-cloud
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: poetry run pytest metricflow/test/
+        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres

--- a/metricflow/test/fixtures/sql_client_fixtures.py
+++ b/metricflow/test/fixtures/sql_client_fixtures.py
@@ -28,7 +28,10 @@ def async_sql_client(mf_test_session_state: MetricFlowTestSessionState) -> Gener
 
     logger.info(f"Dropping schema '{mf_test_session_state.mf_system_schema}'")
     sql_client.drop_schema(mf_test_session_state.mf_system_schema, cascade=True)
-    if mf_test_session_state.mf_system_schema != mf_test_session_state.mf_source_schema:
+    if (
+        mf_test_session_state.mf_system_schema != mf_test_session_state.mf_source_schema
+        and not mf_test_session_state.use_persistent_source_schema
+    ):
         logger.info(f"Dropping schema '{mf_test_session_state.mf_source_schema}'")
         sql_client.drop_schema(mf_test_session_state.mf_source_schema, cascade=True)
 

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -90,7 +90,7 @@ def test_failed_query_with_execution_params(sql_client: SqlClient) -> None:  # n
 
 
 def test_create_table(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    sql_table = SqlTable(schema_name=mf_test_session_state.mf_source_schema, table_name=_random_table())
+    sql_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
     sql_client.create_table_as_select(sql_table, _select_x_as_y())
     df = sql_client.query(f"SELECT * FROM {sql_table.sql}")
     _check_1col(df)
@@ -111,7 +111,7 @@ def test_create_table_from_dataframe(  # noqa: D
             (3, None, 1.2, None, "2020-01-04"),  # Test None types for NA conversions
         ],
     )
-    sql_table = SqlTable(schema_name=mf_test_session_state.mf_source_schema, table_name=_random_table())
+    sql_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
     sql_client.create_table_from_dataframe(sql_table=sql_table, df=expected_df)
 
     actual_df = sql_client.query(f"SELECT * FROM {sql_table.sql}")
@@ -119,7 +119,7 @@ def test_create_table_from_dataframe(  # noqa: D
 
 
 def test_table_exists(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    sql_table = SqlTable(schema_name=mf_test_session_state.mf_source_schema, table_name=_random_table())
+    sql_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
     sql_client.create_table_as_select(sql_table, _select_x_as_y())
     assert sql_client.table_exists(sql_table)
 
@@ -145,11 +145,11 @@ def example_df() -> pd.DataFrame:
 
 
 def test_health_checks(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    sql_client.health_checks(schema_name=mf_test_session_state.mf_source_schema)
+    sql_client.health_checks(schema_name=mf_test_session_state.mf_system_schema)
 
 
 def test_dry_run(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    test_table = SqlTable(schema_name=mf_test_session_state.mf_source_schema, table_name=_random_table())
+    test_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
 
     stmt = f"CREATE TABLE {test_table.sql} AS SELECT 1 AS foo"
     sql_client.dry_run(stmt)
@@ -241,11 +241,11 @@ def test_update_params_with_same_key_different_values() -> None:  # noqa: D
 
 
 def test_list_tables(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    source_schema = mf_test_session_state.mf_source_schema
-    sql_table = SqlTable(schema_name=source_schema, table_name=_random_table())
-    table_count_before_create = len(sql_client.list_tables(source_schema))
+    schema = mf_test_session_state.mf_system_schema
+    sql_table = SqlTable(schema_name=schema, table_name=_random_table())
+    table_count_before_create = len(sql_client.list_tables(schema))
     sql_client.create_table_as_select(sql_table, _select_x_as_y())
-    table_list = sql_client.list_tables(source_schema)
+    table_list = sql_client.list_tables(schema)
     table_count_after_create = len(table_list)
     assert table_count_after_create == table_count_before_create + 1
     assert len([x for x in table_list if x == sql_table.table_name]) == 1


### PR DESCRIPTION
This PR implements the issue https://github.com/dbt-labs/metricflow/issues/482 and allows the user to run `pytest --use-persistent-source-schema ...`.