### PR TITLE
Add ObjectToReference converter

### DIFF
--- a/.changes/unreleased/Under the Hood-20230501-155001.yaml
+++ b/.changes/unreleased/Under the Hood-20230501-155001.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add ObjectToReference class in preparation of removing the .reference calls
+time: 2023-05-01T15:50:01.751773-04:00
+custom:
+  Author: WilliamDee
+  Issue: '#463, #464'

--- a/metricflow/model/object_to_reference.py
+++ b/metricflow/model/object_to_reference.py
@@ -1,0 +1,44 @@
+from dbt_semantic_interfaces.objects.data_source import DataSource
+from dbt_semantic_interfaces.objects.elements.dimension import Dimension
+from dbt_semantic_interfaces.objects.elements.identifier import Identifier
+from dbt_semantic_interfaces.objects.elements.measure import Measure
+from dbt_semantic_interfaces.objects.metric import Metric
+
+from metricflow.instances import DataSourceReference
+from metricflow.references import (
+    DimensionReference,
+    MeasureReference,
+    MetricReference,
+    IdentifierReference,
+)
+
+
+class ObjectToReference:
+    """Converting model objects to a model reference.
+
+    With moving all the model objects to dbt-semantic-interfaces and having *Reference objects
+    remain in MetricFlow, all the `Object.reference` properties should be removed from the model
+    objects. This means, we would need to replace all usages of `Object.reference` to
+    instantiating the *Reference object directly. This class organizes and keeps note of
+    where those use cases were.
+    """
+
+    @staticmethod
+    def from_data_source(data_source: DataSource) -> DataSourceReference:  # noqa: D
+        return DataSourceReference(data_source_name=data_source.name)
+
+    @staticmethod
+    def from_measure(measure: Measure) -> MeasureReference:  # noqa: D
+        return MeasureReference(element_name=measure.name)
+
+    @staticmethod
+    def from_identifier(identifier: Identifier) -> IdentifierReference:  # noqa: D
+        return IdentifierReference(element_name=identifier.name)
+
+    @staticmethod
+    def from_metric(metric: Metric) -> MetricReference:  # noqa: D
+        return MetricReference(element_name=metric.name)
+
+    @staticmethod
+    def from_dimension(dimension: Dimension) -> DimensionReference:  # noqa: D
+        return DimensionReference(element_name=dimension.name)


### PR DESCRIPTION


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
With moving all the model objects to dbt-semantic-interfaces and having *Reference objects remain in MetricFlow, all the `Object.reference` properties should be removed from the model objects. This means, we would need to replace all usages of `Object.reference` to instantiating the *Reference object directly. This class organizes and keeps note of where those use cases were.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)