### PR TITLE
Move TimeGranularity to dbt_semantic_interfaces

### DIFF
--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/elements/dimension.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/elements/dimension.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.objects.base import HashableBaseModel, ModelWithMet
 from dbt_semantic_interfaces.objects.common import Metadata
 from dbt_semantic_interfaces.references import DimensionReference, TimeDimensionReference
 from metricflow.enum_extension import ExtendedEnum
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 ISO8601_FMT = "YYYY-MM-DD"
 

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
@@ -13,8 +13,7 @@ from dbt_semantic_interfaces.objects.common import Metadata
 from dbt_semantic_interfaces.objects.constraints.where import WhereClauseConstraint
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from metricflow.enum_extension import ExtendedEnum
-from metricflow.time.time_granularity import TimeGranularity
-from metricflow.time.time_granularity import string_to_time_granularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity, string_to_time_granularity
 
 
 class MetricType(ExtendedEnum):

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/time_granularity.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/time_granularity.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+from metricflow.enum_extension import assert_values_exhausted, ExtendedEnum
+
+
+class TimeGranularity(ExtendedEnum):
+    """For time dimensions, the smallest possible difference between two time values.
+
+    Needed for calculating adjacency when merging 2 different time ranges.
+    """
+
+    # Names are used in parameters to DATE_TRUNC, so don't change them.
+    # Values are used to convert user supplied strings to enums.
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    QUARTER = "quarter"
+    YEAR = "year"
+
+    def to_int(self) -> int:
+        """Convert to an int so that the size of the granularity can be easily compared."""
+        if self is TimeGranularity.DAY:
+            return 10
+        elif self is TimeGranularity.WEEK:
+            return 11
+        elif self is TimeGranularity.MONTH:
+            return 12
+        elif self is TimeGranularity.QUARTER:
+            return 13
+        elif self is TimeGranularity.YEAR:
+            return 14
+        else:
+            assert_values_exhausted(self)
+
+    def is_smaller_than(self, other: TimeGranularity) -> bool:  # noqa: D
+        return self.to_int() < other.to_int()
+
+    def is_smaller_than_or_equal(self, other: TimeGranularity) -> bool:  # noqa: D
+        return self.to_int() <= other.to_int()
+
+    def __lt__(self, other: Any) -> bool:  # type: ignore [misc] # noqa: D
+        if not isinstance(other, TimeGranularity):
+            return NotImplemented
+        return self.to_int() < other.to_int()
+
+    def __hash__(self) -> int:  # noqa: D
+        return self.to_int()
+
+    def __repr__(self) -> str:  # noqa: D
+        return f"{self.__class__.__name__}.{self.name}"
+
+
+def string_to_time_granularity(s: str) -> TimeGranularity:  # noqa: D
+    values = {item.value: item for item in TimeGranularity}
+    return values[s]

--- a/metricflow/constraints/time_constraint.py
+++ b/metricflow/constraints/time_constraint.py
@@ -8,7 +8,7 @@ from typing import Optional
 import pandas as pd
 
 from metricflow.dataclass_serialization import SerializableDataclass
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/constraints/time_constraint.py
+++ b/metricflow/constraints/time_constraint.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pandas as pd
 
 from metricflow.dataclass_serialization import SerializableDataclass
+from metricflow.time.time_granularity import offset_period
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class TimeRangeConstraint(SerializableDataclass):
         if the metric is weekly-active-users (ie window = 1 week) it moves time_constraint.start one week earlier
         """
         start_ts = pd.Timestamp(self.start_time)
-        offset = time_granularity.offset_period * time_unit_count
+        offset = offset_period(time_granularity) * time_unit_count
         adjusted_start = (start_ts - offset).to_pydatetime()
         return TimeRangeConstraint(
             start_time=adjusted_start,

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -68,7 +68,7 @@ from metricflow.specs import (
     InstanceSpecSet,
 )
 from metricflow.sql.sql_plan import SqlJoinType
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -49,7 +49,7 @@ from metricflow.specs import (
     InstanceSpecSet,
 )
 from metricflow.sql.sql_plan import SqlJoinType
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.visitor import Visitable, VisitorOutputT
 
 logger = logging.getLogger(__name__)

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -42,7 +42,7 @@ from metricflow.sql.sql_plan import (
     SqlQueryPlanNode,
     SqlSelectQueryFromClauseNode,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.references import TimeDimensionReference
 from metricflow.instances import InstanceSet, TimeDimensionInstance
 from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords
 from metricflow.specs import TimeDimensionSpec
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 logger = logging.getLogger(__name__)

--- a/metricflow/model/dbt_mapping_rules/dbt_metric_to_dimensions_rules.py
+++ b/metricflow/model/dbt_mapping_rules/dbt_metric_to_dimensions_rules.py
@@ -8,7 +8,7 @@ from metricflow.model.dbt_mapping_rules.dbt_mapping_rule import (
     assert_metric_model_name,
 )
 from dbt_semantic_interfaces.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.model.validations.validator_helpers import ModelValidationResults, ValidationIssue, ValidationError
 from dbt_semantic_interfaces.objects.constraints.where import WhereClauseConstraint
 

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -24,7 +24,7 @@ from metricflow.specs import (
     IdentifierSpec,
     IdentifierReference,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.objects.metric import Metric, MetricInputMeasure, M
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.parsing.dir_to_model import ModelBuildResult
 from metricflow.model.validations.validator_helpers import ModelValidationResults, ValidationError, ValidationIssue
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 @dataclass

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -14,7 +14,7 @@ from metricflow.model.validations.validator_helpers import (
 )
 from dbt_semantic_interfaces.objects.user_configured_model import UserConfiguredModel
 from dbt_semantic_interfaces.references import DataSourceElementReference, DimensionReference
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class DimensionConsistencyRule(ModelValidationRule):

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -25,7 +25,7 @@ from metricflow.model.validations.validator_helpers import (
     ValidationIssue,
     validate_safely,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 @enum.unique

--- a/metricflow/naming/linkable_spec_name.py
+++ b/metricflow/naming/linkable_spec_name.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 DUNDER = "__"
 

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -18,7 +18,7 @@ from metricflow.specs import (
     ColumnAssociationResolver,
 )
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -45,7 +45,7 @@ from metricflow.sql.sql_exprs import (
     SqlFunctionExpression,
 )
 from metricflow.sql.sql_plan import SqlSelectColumn
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/plan_conversion/time_spine.py
+++ b/metricflow/plan_conversion/time_spine.py
@@ -12,7 +12,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.time.time_constants import ISO8601_PYTHON_FORMAT
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -38,7 +38,7 @@ from metricflow.specs import (
     SpecWhereClauseConstraint,
     LinkableSpecSet,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.time.time_granularity_solver import (
     TimeGranularitySolver,
     PartialTimeDimensionSpec,

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -31,7 +31,7 @@ from metricflow.dataclass_serialization import SerializableDataclass
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import hash_items
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class ColumnAssociationResolver(ABC):

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -16,7 +16,7 @@ from metricflow.sql.sql_exprs import (
     SqlTimeDeltaExpression,
 )
 from metricflow.sql.sql_plan import SqlSelectColumn
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_exprs import (
     SqlPercentileFunctionType,
     SqlTimeDeltaExpression,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):

--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -33,7 +33,7 @@ from metricflow.sql.sql_exprs import (
     SqlWindowFunctionExpression,
 )
 from metricflow.sql.sql_plan import SqlSelectColumn
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_exprs import (
     SqlPercentileFunctionType,
     SqlTimeDeltaExpression,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -31,7 +31,7 @@ from dbt_semantic_interfaces.objects.elements.measure import MeasureAggregationP
 from metricflow.enum_extension import assert_values_exhausted
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.visitor import Visitable, VisitorOutputT
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 class SqlExpressionNode(DagNode, Generic[VisitorOutputT], Visitable, ABC):

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -24,7 +24,7 @@ from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_utils import assert_plan_snapshot_text_equal
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD, MTD_SPEC_MONTH
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -25,7 +25,7 @@ from metricflow.specs import (
 )
 from metricflow.sql.sql_exprs import SqlColumnReferenceExpression, SqlColumnReference
 from metricflow.sql.sql_plan import SqlSelectStatementNode, SqlSelectColumn, SqlTableFromClauseNode
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 
 logger = logging.getLogger(__name__)

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -26,7 +26,7 @@ from metricflow.specs import (
     LinkableInstanceSpec,
     IdentifierReference,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 
 logger = logging.getLogger(__name__)

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -44,7 +44,7 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_utils import assert_plan_snapshot_text_equal
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/dataset/test_convert_data_source.py
+++ b/metricflow/test/dataset/test_convert_data_source.py
@@ -16,7 +16,7 @@ from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/examples/test_node_sql.py
+++ b/metricflow/test/examples/test_node_sql.py
@@ -17,7 +17,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs import TimeDimensionSpec, TimeDimensionReference, InstanceSpecSet
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -16,7 +16,7 @@ from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotRestorer,
 )
 from metricflow.time.time_constants import ISO8601_PYTHON_FORMAT
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -16,6 +16,7 @@ from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotRestorer,
 )
 from metricflow.time.time_constants import ISO8601_PYTHON_FORMAT
+from metricflow.time.time_granularity import period_begin_offset
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -337,7 +338,7 @@ def create_extended_date_model_tables(mf_test_session_state: MetricFlowTestSessi
         fct_bookings_extended_monthly_data.append((10, True, current_date.strftime(ISO8601_PYTHON_FORMAT)))
         fct_bookings_extended_monthly_data.append((5, False, current_date.strftime(ISO8601_PYTHON_FORMAT)))
 
-        current_date += TimeGranularity.MONTH.period_begin_offset
+        current_date += period_begin_offset(TimeGranularity.MONTH)
 
     sql_table = SqlTable(schema_name=schema, table_name="fct_bookings_extended_monthly")
     sql_client.drop_table(sql_table=sql_table)

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -26,7 +26,7 @@ from metricflow.sql.sql_exprs import (
     SqlCastToTimestampExpression,
     SqlStringExpression,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.integration.configured_test_case import (

--- a/metricflow/test/model/parsing/test_data_source_parsing.py
+++ b/metricflow/test/model/parsing/test_data_source_parsing.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.objects.data_source import DataSourceOrigin, Mutabi
 from dbt_semantic_interfaces.objects.elements.identifier import IdentifierType
 from dbt_semantic_interfaces.objects.elements.dimension import DimensionType
 from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_model
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_base_data_source_attribute_parsing() -> None:

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.objects.metric import MetricTimeWindow, MetricInput
 from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_model
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_legacy_measure_metric_parsing() -> None:

--- a/metricflow/test/model/validations/test_data_sources.py
+++ b/metricflow/test/model/validations/test_data_sources.py
@@ -4,7 +4,7 @@ from dbt_semantic_interfaces.objects.data_source import MutabilityType, Mutabili
 from dbt_semantic_interfaces.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 @pytest.mark.skip("TODO: Will convert to validation rule")

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -12,7 +12,7 @@ from metricflow.model.validations.data_sources import DataSourceTimeDimensionWar
 from metricflow.model.validations.dimension_const import DimensionConsistencyRule
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_incompatible_dimension_type() -> None:  # noqa:D

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -29,7 +29,7 @@ from metricflow.test.model.validations.helpers import (
     base_model_file,
 )
 from metricflow.test.test_utils import find_data_source_with
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_data_source_cant_have_more_than_one_primary_identifier(

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -13,7 +13,7 @@ from metricflow.model.validations.metrics import DerivedMetricRule
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.test.fixtures.table_fixtures import DEFAULT_DS
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D

--- a/metricflow/test/plan_conversion/instance_converters/test_create_validity_window_join_description.py
+++ b/metricflow/test/plan_conversion/instance_converters/test_create_validity_window_join_description.py
@@ -6,7 +6,7 @@ from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.instance_converters import CreateValidityWindowJoinDescription
 from metricflow.specs import TimeDimensionSpec
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 def test_no_validity_dims(

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -56,7 +56,7 @@ from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_from_plan_e
 from metricflow.test.sql.compare_sql_plan import assert_sql_plan_text_equal
 from metricflow.test.test_utils import as_datetime
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.objects.metric import MetricTimeWindow
 
 

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -17,7 +17,7 @@ from metricflow.specs import (
 )
 from metricflow.test.test_utils import as_datetime
 from metricflow.test.time.metric_time_dimension import MTD
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.time.time_granularity_solver import RequestTimeGranularityException
 from metricflow.test.fixtures.model_fixtures import query_parser_from_yaml
 

--- a/metricflow/test/sql/test_sql_expr_render.py
+++ b/metricflow/test/sql/test_sql_expr_render.py
@@ -26,7 +26,7 @@ from metricflow.sql.sql_exprs import (
     SqlWindowFunction,
     SqlWindowOrderByArgument,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/test_specs.py
+++ b/metricflow/test/test_specs.py
@@ -14,7 +14,7 @@ from metricflow.specs import (
     LinklessIdentifierSpec,
     IdentifierReference,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
 @pytest.fixture

--- a/metricflow/test/time/metric_time_dimension.py
+++ b/metricflow/test/time/metric_time_dimension.py
@@ -1,5 +1,5 @@
 from metricflow.dataset.dataset import DataSet
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 # Shortcuts for referring to the metric time dimension.
 MTD = DataSet.metric_time_dimension_name()

--- a/metricflow/test/time/test_time_granularity_solver.py
+++ b/metricflow/test/time/test_time_granularity_solver.py
@@ -13,7 +13,7 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.time_spine import TimeSpineSource
 from dbt_semantic_interfaces.references import MetricReference
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_YEAR, MTD_REFERENCE
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 from metricflow.time.time_granularity_solver import (
     TimeGranularitySolver,
     PartialTimeDimensionSpec,

--- a/metricflow/time/time_constants.py
+++ b/metricflow/time/time_constants.py
@@ -1,4 +1,4 @@
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 # Python formatting string to use for converting datetime to ISO8601
 ISO8601_PYTHON_FORMAT = "%Y-%m-%d"

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -82,28 +82,28 @@ def period_begin_offset(  # noqa: D
         assert_values_exhausted(time_granularity)
 
 
+def period_end_offset(  # noqa: D
+    time_granularity: TimeGranularity,
+) -> Union[pd.offsets.MonthEnd, pd.offsets.QuarterEnd, pd.offsets.Week, pd.offsets.YearEnd]:
+    if time_granularity is TimeGranularity.DAY:
+        raise ValueError(f"Can't get period end offset for TimeGranularity.{time_granularity.name}.")
+    elif time_granularity == TimeGranularity.WEEK:
+        return pd.offsets.Week(weekday=ISOWeekDay.SUNDAY.pandas_value)
+    elif time_granularity is TimeGranularity.MONTH:
+        return pd.offsets.MonthEnd()
+    elif time_granularity is TimeGranularity.QUARTER:
+        return pd.offsets.QuarterEnd(startingMonth=3)
+    elif time_granularity is TimeGranularity.YEAR:
+        return pd.offsets.YearEnd()
+    else:
+        assert_values_exhausted(time_granularity)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    @property
-    def period_end_offset(  # noqa: D
-        self,
-    ) -> Union[pd.offsets.MonthEnd, pd.offsets.QuarterEnd, pd.offsets.Week, pd.offsets.YearEnd]:
-        if self is TimeGranularity.DAY:
-            raise ValueError(f"Can't get period end offset for TimeGranularity.{self.name}.")
-        elif self == TimeGranularity.WEEK:
-            return pd.offsets.Week(weekday=ISOWeekDay.SUNDAY.pandas_value)
-        elif self is TimeGranularity.MONTH:
-            return pd.offsets.MonthEnd()
-        elif self is TimeGranularity.QUARTER:
-            return pd.offsets.QuarterEnd(startingMonth=3)
-        elif self is TimeGranularity.YEAR:
-            return pd.offsets.YearEnd()
-        else:
-            assert_values_exhausted(self)
 
     def adjust_to_start_of_period(self, date_to_adjust: pd.Timestamp, rollback: bool = True) -> pd.Timestamp:
         """Adjust to start of period if not at start already."""
@@ -115,9 +115,9 @@ class ExtendedTimeGranularity(TimeGranularity):
     def adjust_to_end_of_period(self, date_to_adjust: pd.Timestamp, rollforward: bool = True) -> pd.Timestamp:
         """Adjust to end of period if not at end already."""
         if rollforward:
-            return self.period_end_offset.rollforward(date_to_adjust)
+            return period_end_offset(self).rollforward(date_to_adjust)
         else:
-            return self.period_end_offset.rollback(date_to_adjust)
+            return period_end_offset(self).rollback(date_to_adjust)
 
     def match_start_or_end_of_period(self, date_to_match: pd.Timestamp, date_to_adjust: pd.Timestamp) -> pd.Timestamp:
         """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -65,28 +65,28 @@ def is_period_end(time_granularity: TimeGranularity, date: Union[pd.Timestamp, d
         assert_values_exhausted(time_granularity)
 
 
+def period_begin_offset(  # noqa: D
+    time_granularity: TimeGranularity,
+) -> Union[pd.offsets.MonthBegin, pd.offsets.QuarterBegin, pd.offsets.Week, pd.offsets.YearBegin]:
+    if time_granularity is TimeGranularity.DAY:
+        raise ValueError(f"Can't get period start offset for TimeGranularity.{time_granularity.name}.")
+    elif time_granularity is TimeGranularity.WEEK:
+        return pd.offsets.Week(weekday=ISOWeekDay.MONDAY.pandas_value)
+    elif time_granularity is TimeGranularity.MONTH:
+        return pd.offsets.MonthBegin()
+    elif time_granularity is TimeGranularity.QUARTER:
+        return pd.offsets.QuarterBegin(startingMonth=1)
+    elif time_granularity is TimeGranularity.YEAR:
+        return pd.offsets.YearBegin()
+    else:
+        assert_values_exhausted(time_granularity)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    @property
-    def period_begin_offset(  # noqa: D
-        self,
-    ) -> Union[pd.offsets.MonthBegin, pd.offsets.QuarterBegin, pd.offsets.Week, pd.offsets.YearBegin]:
-        if self is TimeGranularity.DAY:
-            raise ValueError(f"Can't get period start offset for TimeGranularity.{self.name}.")
-        elif self is TimeGranularity.WEEK:
-            return pd.offsets.Week(weekday=ISOWeekDay.MONDAY.pandas_value)
-        elif self is TimeGranularity.MONTH:
-            return pd.offsets.MonthBegin()
-        elif self is TimeGranularity.QUARTER:
-            return pd.offsets.QuarterBegin(startingMonth=1)
-        elif self is TimeGranularity.YEAR:
-            return pd.offsets.YearBegin()
-        else:
-            assert_values_exhausted(self)
 
     @property
     def period_end_offset(  # noqa: D
@@ -108,9 +108,9 @@ class ExtendedTimeGranularity(TimeGranularity):
     def adjust_to_start_of_period(self, date_to_adjust: pd.Timestamp, rollback: bool = True) -> pd.Timestamp:
         """Adjust to start of period if not at start already."""
         if rollback:
-            return self.period_begin_offset.rollback(date_to_adjust)
+            return period_begin_offset(self).rollback(date_to_adjust)
         else:
-            return self.period_begin_offset.rollforward(date_to_adjust)
+            return period_begin_offset(self).rollforward(date_to_adjust)
 
     def adjust_to_end_of_period(self, date_to_adjust: pd.Timestamp, rollforward: bool = True) -> pd.Timestamp:
         """Adjust to end of period if not at end already."""

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -119,22 +119,18 @@ def adjust_to_end_of_period(
         return period_end_offset(time_granularity).rollback(date_to_adjust)
 
 
-class ExtendedTimeGranularity(TimeGranularity):
-    """For time dimensions, the smallest possible difference between two time values.
-
-    Needed for calculating adjacency when merging 2 different time ranges.
-    """
-
-    def match_start_or_end_of_period(self, date_to_match: pd.Timestamp, date_to_adjust: pd.Timestamp) -> pd.Timestamp:
-        """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""
-        if is_period_start(self, date_to_match):
-            return adjust_to_start_of_period(self, date_to_adjust)
-        elif is_period_end(self, date_to_match):
-            return adjust_to_end_of_period(self, date_to_adjust)
-        else:
-            raise ValueError(
-                f"Expected `date_to_match` to fall at the start or end of the granularity period. Got '{date_to_match}' for granularity {self}."
-            )
+def match_start_or_end_of_period(
+    time_granularity: TimeGranularity, date_to_match: pd.Timestamp, date_to_adjust: pd.Timestamp
+) -> pd.Timestamp:
+    """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""
+    if is_period_start(time_granularity, date_to_match):
+        return adjust_to_start_of_period(time_granularity, date_to_adjust)
+    elif is_period_end(time_granularity, date_to_match):
+        return adjust_to_end_of_period(time_granularity, date_to_adjust)
+    else:
+        raise ValueError(
+            f"Expected `date_to_match` to fall at the start or end of the granularity period. Got '{date_to_match}' for granularity {time_granularity}."
+        )
 
 
 class ISOWeekDay(ExtendedEnum):

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -48,27 +48,28 @@ def is_period_start(time_granularity: TimeGranularity, date: Union[pd.Timestamp,
         assert_values_exhausted(time_granularity)
 
 
+def is_period_end(time_granularity: TimeGranularity, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D
+    pd_date = pd.Timestamp(date)
+
+    if time_granularity is TimeGranularity.DAY:
+        return True
+    elif time_granularity is TimeGranularity.WEEK:
+        return ISOWeekDay.from_pandas_timestamp(pd_date).is_week_end
+    elif time_granularity is TimeGranularity.MONTH:
+        return pd_date.is_month_end
+    elif time_granularity is TimeGranularity.QUARTER:
+        return pd_date.is_quarter_end
+    elif time_granularity is TimeGranularity.YEAR:
+        return pd_date.is_year_end
+    else:
+        assert_values_exhausted(time_granularity)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    def is_period_end(self, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D
-        pd_date = pd.Timestamp(date)
-
-        if self is TimeGranularity.DAY:
-            return True
-        elif self is TimeGranularity.WEEK:
-            return ISOWeekDay.from_pandas_timestamp(pd_date).is_week_end
-        elif self is TimeGranularity.MONTH:
-            return pd_date.is_month_end
-        elif self is TimeGranularity.QUARTER:
-            return pd_date.is_quarter_end
-        elif self is TimeGranularity.YEAR:
-            return pd_date.is_year_end
-        else:
-            assert_values_exhausted(self)
 
     @property
     def period_begin_offset(  # noqa: D
@@ -122,7 +123,7 @@ class ExtendedTimeGranularity(TimeGranularity):
         """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""
         if is_period_start(self, date_to_match):
             return self.adjust_to_start_of_period(date_to_adjust)
-        elif self.is_period_end(date_to_match):
+        elif is_period_end(self, date_to_match):
             return self.adjust_to_end_of_period(date_to_adjust)
         else:
             raise ValueError(

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -26,16 +26,16 @@ def offset_period(time_granularity: TimeGranularity) -> pd.offsets.DateOffset:
         assert_values_exhausted(time_granularity)
 
 
+def format_with_first_or_last(time_granularity: TimeGranularity) -> bool:
+    """Indicates that this can only be calculated if query results display the first or last date of the period."""
+    return time_granularity in [TimeGranularity.MONTH, TimeGranularity.QUARTER, TimeGranularity.YEAR]
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    @property
-    def format_with_first_or_last(self) -> bool:
-        """Indicates that this can only be calculated if query results display the first or last date of the period."""
-        return self in [TimeGranularity.MONTH, TimeGranularity.QUARTER, TimeGranularity.YEAR]
 
     def is_period_start(self, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D
         pd_date = pd.Timestamp(date)

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -99,18 +99,21 @@ def period_end_offset(  # noqa: D
         assert_values_exhausted(time_granularity)
 
 
+def adjust_to_start_of_period(
+    time_granularity: TimeGranularity, date_to_adjust: pd.Timestamp, rollback: bool = True
+) -> pd.Timestamp:
+    """Adjust to start of period if not at start already."""
+    if rollback:
+        return period_begin_offset(time_granularity).rollback(date_to_adjust)
+    else:
+        return period_begin_offset(time_granularity).rollforward(date_to_adjust)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    def adjust_to_start_of_period(self, date_to_adjust: pd.Timestamp, rollback: bool = True) -> pd.Timestamp:
-        """Adjust to start of period if not at start already."""
-        if rollback:
-            return period_begin_offset(self).rollback(date_to_adjust)
-        else:
-            return period_begin_offset(self).rollforward(date_to_adjust)
 
     def adjust_to_end_of_period(self, date_to_adjust: pd.Timestamp, rollforward: bool = True) -> pd.Timestamp:
         """Adjust to end of period if not at end already."""
@@ -122,7 +125,7 @@ class ExtendedTimeGranularity(TimeGranularity):
     def match_start_or_end_of_period(self, date_to_match: pd.Timestamp, date_to_adjust: pd.Timestamp) -> pd.Timestamp:
         """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""
         if is_period_start(self, date_to_match):
-            return self.adjust_to_start_of_period(date_to_adjust)
+            return adjust_to_start_of_period(self, date_to_adjust)
         elif is_period_end(self, date_to_match):
             return self.adjust_to_end_of_period(date_to_adjust)
         else:

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -1,47 +1,19 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Union, Any
+from typing import Union
 
 import pandas as pd
 
 from metricflow.enum_extension import assert_values_exhausted, ExtendedEnum
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
-class TimeGranularity(ExtendedEnum):
+class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    # Names are used in parameters to DATE_TRUNC, so don't change them.
-    # Values are used to convert user supplied strings to enums.
-    DAY = "day"
-    WEEK = "week"
-    MONTH = "month"
-    QUARTER = "quarter"
-    YEAR = "year"
-
-    def to_int(self) -> int:
-        """Convert to an int so that the size of the granularity can be easily compared."""
-        if self is TimeGranularity.DAY:
-            return 10
-        elif self is TimeGranularity.WEEK:
-            return 11
-        elif self is TimeGranularity.MONTH:
-            return 12
-        elif self is TimeGranularity.QUARTER:
-            return 13
-        elif self is TimeGranularity.YEAR:
-            return 14
-        else:
-            assert_values_exhausted(self)
-
-    def is_smaller_than(self, other: "TimeGranularity") -> bool:  # noqa: D
-        return self.to_int() < other.to_int()
-
-    def is_smaller_than_or_equal(self, other: "TimeGranularity") -> bool:  # noqa: D
-        return self.to_int() <= other.to_int()
 
     @property
     def offset_period(self) -> pd.offsets.DateOffset:
@@ -155,17 +127,6 @@ class TimeGranularity(ExtendedEnum):
             raise ValueError(
                 f"Expected `date_to_match` to fall at the start or end of the granularity period. Got '{date_to_match}' for granularity {self}."
             )
-
-    def __lt__(self, other: Any) -> bool:  # type: ignore [misc] # noqa: D
-        if not isinstance(other, TimeGranularity):
-            return NotImplemented
-        return self.to_int() < other.to_int()
-
-    def __hash__(self) -> int:  # noqa: D
-        return self.to_int()
-
-    def __repr__(self) -> str:  # noqa: D
-        return f"{self.__class__.__name__}.{self.name}"
 
 
 class ISOWeekDay(ExtendedEnum):

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -109,25 +109,28 @@ def adjust_to_start_of_period(
         return period_begin_offset(time_granularity).rollforward(date_to_adjust)
 
 
+def adjust_to_end_of_period(
+    time_granularity: TimeGranularity, date_to_adjust: pd.Timestamp, rollforward: bool = True
+) -> pd.Timestamp:
+    """Adjust to end of period if not at end already."""
+    if rollforward:
+        return period_end_offset(time_granularity).rollforward(date_to_adjust)
+    else:
+        return period_end_offset(time_granularity).rollback(date_to_adjust)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
 
-    def adjust_to_end_of_period(self, date_to_adjust: pd.Timestamp, rollforward: bool = True) -> pd.Timestamp:
-        """Adjust to end of period if not at end already."""
-        if rollforward:
-            return period_end_offset(self).rollforward(date_to_adjust)
-        else:
-            return period_end_offset(self).rollback(date_to_adjust)
-
     def match_start_or_end_of_period(self, date_to_match: pd.Timestamp, date_to_adjust: pd.Timestamp) -> pd.Timestamp:
         """Adjust date_to_adjust to be start or end of period based on if date_to_match is at start or end of period."""
         if is_period_start(self, date_to_match):
             return adjust_to_start_of_period(self, date_to_adjust)
         elif is_period_end(self, date_to_match):
-            return self.adjust_to_end_of_period(date_to_adjust)
+            return adjust_to_end_of_period(self, date_to_adjust)
         else:
             raise ValueError(
                 f"Expected `date_to_match` to fall at the start or end of the granularity period. Got '{date_to_match}' for granularity {self}."

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -9,28 +9,28 @@ from metricflow.enum_extension import assert_values_exhausted, ExtendedEnum
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 
+def offset_period(time_granularity: TimeGranularity) -> pd.offsets.DateOffset:
+    """Offset object to use for adjusting by one granularity period."""
+    # The type checker is throwing errors for some of those arguments, but they are valid.
+    if time_granularity is TimeGranularity.DAY:
+        return pd.offsets.DateOffset(days=1)  # type: ignore
+    elif time_granularity is TimeGranularity.WEEK:
+        return pd.offsets.DateOffset(weeks=1)  # type: ignore
+    elif time_granularity is TimeGranularity.MONTH:
+        return pd.offsets.DateOffset(months=1)
+    elif time_granularity is TimeGranularity.QUARTER:
+        return pd.offsets.DateOffset(months=3)
+    elif time_granularity is TimeGranularity.YEAR:
+        return pd.offsets.DateOffset(years=1)  # type: ignore
+    else:
+        assert_values_exhausted(time_granularity)
+
+
 class ExtendedTimeGranularity(TimeGranularity):
     """For time dimensions, the smallest possible difference between two time values.
 
     Needed for calculating adjacency when merging 2 different time ranges.
     """
-
-    @property
-    def offset_period(self) -> pd.offsets.DateOffset:
-        """Offset object to use for adjusting by one granularity period."""
-        # The type checker is throwing errors for some of those arguments, but they are valid.
-        if self is TimeGranularity.DAY:
-            return pd.offsets.DateOffset(days=1)  # type: ignore
-        elif self is TimeGranularity.WEEK:
-            return pd.offsets.DateOffset(weeks=1)  # type: ignore
-        elif self is TimeGranularity.MONTH:
-            return pd.offsets.DateOffset(months=1)
-        elif self is TimeGranularity.QUARTER:
-            return pd.offsets.DateOffset(months=3)
-        elif self is TimeGranularity.YEAR:
-            return pd.offsets.DateOffset(years=1)  # type: ignore
-        else:
-            assert_values_exhausted(self)
 
     @property
     def format_with_first_or_last(self) -> bool:

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -26,6 +26,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     DEFAULT_TIME_GRANULARITY,
 )
+from metricflow.time.time_granularity import is_period_start
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -238,7 +239,7 @@ class TimeGranularitySolver:
         constraint_end = time_range_constraint.end_time
 
         start_ts = pd.Timestamp(time_range_constraint.start_time)
-        if not time_granularity.is_period_start(start_ts):
+        if not is_period_start(time_granularity, start_ts):
             constraint_start = time_granularity.adjust_to_start_of_period(start_ts).to_pydatetime()
 
         end_ts = pd.Timestamp(time_range_constraint.end_time)

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -26,7 +26,12 @@ from metricflow.specs import (
     TimeDimensionSpec,
     DEFAULT_TIME_GRANULARITY,
 )
-from metricflow.time.time_granularity import is_period_start, is_period_end, adjust_to_start_of_period
+from metricflow.time.time_granularity import (
+    is_period_start,
+    is_period_end,
+    adjust_to_start_of_period,
+    adjust_to_end_of_period,
+)
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -244,7 +249,7 @@ class TimeGranularitySolver:
 
         end_ts = pd.Timestamp(time_range_constraint.end_time)
         if not is_period_end(time_granularity, end_ts):
-            constraint_end = time_granularity.adjust_to_end_of_period(end_ts).to_pydatetime()
+            constraint_end = adjust_to_end_of_period(time_granularity, end_ts).to_pydatetime()
 
         if constraint_start < TimeRangeConstraint.ALL_TIME_BEGIN():
             constraint_start = TimeRangeConstraint.ALL_TIME_BEGIN()

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -26,7 +26,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     DEFAULT_TIME_GRANULARITY,
 )
-from metricflow.time.time_granularity import TimeGranularity
+from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -26,7 +26,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     DEFAULT_TIME_GRANULARITY,
 )
-from metricflow.time.time_granularity import is_period_start
+from metricflow.time.time_granularity import is_period_start, is_period_end
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ class TimeGranularitySolver:
             constraint_start = time_granularity.adjust_to_start_of_period(start_ts).to_pydatetime()
 
         end_ts = pd.Timestamp(time_range_constraint.end_time)
-        if not time_granularity.is_period_end(end_ts):
+        if not is_period_end(time_granularity, end_ts):
             constraint_end = time_granularity.adjust_to_end_of_period(end_ts).to_pydatetime()
 
         if constraint_start < TimeRangeConstraint.ALL_TIME_BEGIN():

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -26,7 +26,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     DEFAULT_TIME_GRANULARITY,
 )
-from metricflow.time.time_granularity import is_period_start, is_period_end
+from metricflow.time.time_granularity import is_period_start, is_period_end, adjust_to_start_of_period
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -240,7 +240,7 @@ class TimeGranularitySolver:
 
         start_ts = pd.Timestamp(time_range_constraint.start_time)
         if not is_period_start(time_granularity, start_ts):
-            constraint_start = time_granularity.adjust_to_start_of_period(start_ts).to_pydatetime()
+            constraint_start = adjust_to_start_of_period(time_granularity, start_ts).to_pydatetime()
 
         end_ts = pd.Timestamp(time_range_constraint.end_time)
         if not is_period_end(time_granularity, end_ts):


### PR DESCRIPTION
## Resolves #466

### Description

This moves TimeGranularity to dbt_semantic_interfaces. However the whole class was not moved. Specifically we had to leave functions of TimeGranularity which utlized pandas in MetricFlow. Hopefully we find a better solution long term of extending dbt_semantic_interfaces objects with functions in MetricFlow (probably something dealing with class composition), but this will work for now.