### PR TITLE
Remove References to Definition Haash

### DIFF
--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/common.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/common.py
@@ -62,10 +62,6 @@ class YamlConfigFile(HashableBaseModel):
     url: Optional[str]
 
 
-class SourceContext(HashableBaseModel):  # noqa: D
-    definition_hash: str
-
-
 class Metadata(HashableBaseModel):  # noqa: D
     repo_file_path: str
     file_slice: FileSlice

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/metric.py
@@ -13,7 +13,6 @@ from dbt_semantic_interfaces.objects.common import Metadata
 from dbt_semantic_interfaces.objects.constraints.where import WhereClauseConstraint
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from metricflow.enum_extension import ExtendedEnum
-from metricflow.object_utils import hash_items
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_granularity import string_to_time_granularity
 
@@ -191,13 +190,3 @@ class Metric(HashableBaseModel, ModelWithMetadataParsing):
     def input_metrics(self) -> List[MetricInput]:
         """Return the associated input metrics for this metric"""
         return self.type_params.metrics or []
-
-    @property
-    def definition_hash(self) -> str:  # noqa: D
-        values: List[str] = [self.name, self.type_params.expr or ""]
-        if self.constraint:
-            values.append(self.constraint.where)
-            if self.constraint.linkable_names:
-                values.extend(self.constraint.linkable_names)
-        values.extend([m.element_name for m in self.measure_references])
-        return hash_items(values)


### PR DESCRIPTION
### Description

This PR removes functions and classes that make references to `definition_hash`, which is not used in the open source project. This was originally a part of https://github.com/dbt-labs/metricflow/pull/444, but got left out by accident.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)