### PR TITLE
Remove use of `SqlTable` in `reserved_keywords.py` validation rule

### DIFF
--- a/metricflow/model/validations/reserved_keywords.py
+++ b/metricflow/model/validations/reserved_keywords.py
@@ -1,5 +1,4 @@
 from typing import List
-from metricflow.dataflow.sql_table import SqlTable
 from dbt_semantic_interfaces.references import DataSourceElementReference
 
 
@@ -133,9 +132,7 @@ class ReservedKeywordsRule(ModelValidationRule):
 
         for data_source in model.data_sources:
             if data_source.sql_table is not None:
-                set_sql_table_path_parts = set(
-                    [part.upper() for part in SqlTable.from_string(data_source.sql_table).parts_tuple]
-                )
+                set_sql_table_path_parts = set([part.upper() for part in data_source.sql_table.split(".")])
                 keyword_intersection = set_keywords.intersection(set_sql_table_path_parts)
 
                 if len(keyword_intersection) > 0:


### PR DESCRIPTION
### Description

Validations are going to be moved over to dbt_semantic_interfaces. As such they can't be importing metricflow. The change here is small. We're unfortunately duplicating code that is in `SqlTable`, but this will likely be changing again in the near future as dbt_semantic_interfaces plans on using a more structured object directly on the data source in place of sql_table.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)