### PR TITLE
Move dataclass_serialization.py to dbt_semantic_interfaces

### DIFF
--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/dataclass_serialization.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/dataclass_serialization.py
@@ -6,7 +6,18 @@ import logging
 from builtins import NameError
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Type, TypeVar, Tuple, Union, get_args, get_origin, get_type_hints
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Type,
+    TypeVar,
+    Tuple,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 from typing_extensions import TypeAlias
 
 import pydantic
@@ -35,7 +46,9 @@ class DataclassDeserializationError(Exception):
     pass
 
 
-def _get_dataclass_field_definitions(dataclass_type: Type) -> Dict[str, FieldDefinition]:
+def _get_dataclass_field_definitions(
+    dataclass_type: Type,
+) -> Dict[str, FieldDefinition]:
     """Returns the types of fields in a dataclass. Returns a dict from the name of the field to the type."""
     assert dataclasses.is_dataclass(dataclass_type)
     try:
@@ -200,7 +213,8 @@ class DataclassSerializer:
             field_values: Dict[str, AnyValueType] = {}
             for field_name, field_definition in field_dict.items():
                 field_values[field_name] = self._convert_dataclass_instance_to_pydantic_model(
-                    object_type=field_definition.annotated_field_type, obj=getattr(obj, field_name)
+                    object_type=field_definition.annotated_field_type,
+                    obj=getattr(obj, field_name),
                 )
             return PydanticModel(**field_values)
 
@@ -303,7 +317,9 @@ class DataClassTypeToPydanticTypeConverter:  # noqa: D
         return self._dataclass_type_to_pydantic_type[dataclass_type]
 
     @staticmethod
-    def _convert_dataclass_type_to_pydantic_type(dataclass_type: Type) -> Type[BaseModel]:  # noqa: D
+    def _convert_dataclass_type_to_pydantic_type(
+        dataclass_type: Type,
+    ) -> Type[BaseModel]:  # noqa: D
         logger.debug(f"Converting {dataclass_type.__name__} to a pydantic class")
         assert issubclass(dataclass_type, SerializableDataclass)
         assert dataclasses.is_dataclass(dataclass_type)
@@ -344,7 +360,8 @@ class DataClassTypeToPydanticTypeConverter:  # noqa: D
                 FieldDefinition(field_type=optional_field_type_parameter)
             )
             return FieldDefinition(  # type: ignore[arg-type]
-                Union[converted_field_definition.field_type, type(None)], field_definition.default_value
+                Union[converted_field_definition.field_type, type(None)],
+                field_definition.default_value,
             )
         elif _is_sequence_like_tuple_type(field_definition.annotated_field_type):
             tuple_field_type_parameter = _get_type_parameter_for_sequence_like_tuple_type(
@@ -353,7 +370,10 @@ class DataClassTypeToPydanticTypeConverter:  # noqa: D
             converted_field_definition = DataClassTypeToPydanticTypeConverter._convert_nested_fields(
                 FieldDefinition(field_type=tuple_field_type_parameter)
             )
-            return FieldDefinition(Tuple[converted_field_definition.field_type, ...], field_definition.default_value)
+            return FieldDefinition(
+                Tuple[converted_field_definition.field_type, ...],
+                field_definition.default_value,
+            )
         elif issubclass(field_definition.annotated_field_type, SerializableDataclass):
             return FieldDefinition(
                 field_type=DataClassTypeToPydanticTypeConverter._convert_dataclass_type_to_pydantic_type(

--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/references.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/references.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 
 
 @dataclass(frozen=True)

--- a/metricflow/column_assoc.py
+++ b/metricflow/column_assoc.py
@@ -2,7 +2,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Optional, Any
 
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from metricflow.assert_one_arg import assert_exactly_one_arg_set
 
 

--- a/metricflow/constraints/time_constraint.py
+++ b/metricflow/constraints/time_constraint.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import pandas as pd
 
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from metricflow.time.time_granularity import offset_period
 from dbt_semantic_interfaces.objects.time_granularity import TimeGranularity
 

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -9,7 +9,7 @@ from typing import List, TypeVar, Generic, Tuple
 from dbt_semantic_interfaces.references import DataSourceElementReference, MetricModelReference
 from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import ColumnAssociation
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from metricflow.specs import (
     MetadataSpec,
     MeasureSpec,

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -27,7 +27,7 @@ from metricflow.aggregation_properties import AggregationType
 from metricflow.assert_one_arg import assert_exactly_one_arg_set
 from metricflow.column_assoc import ColumnAssociation
 from metricflow.constraints.time_constraint import TimeRangeConstraint
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import hash_items
 from metricflow.sql.sql_bind_parameters import SqlBindParameters

--- a/metricflow/sql/sql_bind_parameters.py
+++ b/metricflow/sql/sql_bind_parameters.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple, Mapping
 
-from metricflow.dataclass_serialization import SerializableDataclass
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from metricflow.sql.sql_column_type import SqlColumnType
 from metricflow.assert_one_arg import assert_exactly_one_arg_set
 

--- a/metricflow/test/sql/test_bind_parameter_serialization.py
+++ b/metricflow/test/sql/test_bind_parameter_serialization.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metricflow.dataclass_serialization import DataclassSerializer, DataClassDeserializer
+from dbt_semantic_interfaces.dataclass_serialization import DataclassSerializer, DataClassDeserializer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters, SqlBindParameter, SqlBindParameterValue
 
 

--- a/metricflow/test/test_dataclass_serialization.py
+++ b/metricflow/test/test_dataclass_serialization.py
@@ -4,7 +4,11 @@ from typing import Optional, Tuple, Protocol
 
 import pytest
 
-from metricflow.dataclass_serialization import SerializableDataclass, DataClassDeserializer, DataclassSerializer
+from dbt_semantic_interfaces.dataclass_serialization import (
+    SerializableDataclass,
+    DataClassDeserializer,
+    DataclassSerializer,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/test_instance_serialization.py
+++ b/metricflow/test/test_instance_serialization.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metricflow.dataclass_serialization import DataclassSerializer, DataClassDeserializer
+from dbt_semantic_interfaces.dataclass_serialization import DataclassSerializer, DataClassDeserializer
 from metricflow.instances import InstanceSet
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 


### PR DESCRIPTION
### Description

We're not sure if this serialization is actually still necessary, it
may be vestigial. However, until we figure that out, dbt-semantic-interfaces
will need to know about SerializableDataclass. This is because one of the
main things that can be serialized are instances sets. Although instance
sets aren't in dbt-semantic-interfaces, references are, and instance have
a lot of references. Thus the references must be built with
SerializableDataclass, and thus it must be in dbt-semantic-interfaces.
If SerializableDataclass does turn out to be vestigial, then we'll remove
it from things at that point.