### PR TITLE
Disable using --use-persistent-schema in CI tests

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Snowflake configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_SNOWFLAKE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_SNOWFLAKE_PWD }}
@@ -69,7 +69,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Redshift configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_REDSHIFT_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_REDSHIFT_PWD }}
@@ -102,7 +102,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with BigQuery configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
@@ -135,7 +135,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Databricks configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_CLUSTER_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
@@ -168,7 +168,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Databricks configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_SQL_WAREHOUSE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
@@ -216,7 +216,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        run: poetry run pytest -v metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install -E dbt-cloud
 
       - name: Run MetricFlow Unit tests suites
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/
+        run: poetry run pytest -v metricflow/test/
         env:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   metricflow-unit-tests-postgres:
@@ -82,7 +82,7 @@ jobs:
         run: cd metricflow && poetry install -E dbt-cloud
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: poetry run pytest -v --use-persistent-source-schema metricflow/test/
+        run: poetry run pytest -v metricflow/test/
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres


### PR DESCRIPTION
### Description
There is a known race condition when creating the persistent source schema for the first time that was thought to be rare to hit. But with the current Databricks setup in CI, it is actually likely, so removing this speedup for now.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)