### PR TITLE
Making AggregationType use ExtendedEnum again

### DIFF
--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/aggregation_type.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/aggregation_type.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from dbt_semantic_interfaces.enum_extension import ExtendedEnum
 
 
-class AggregationType(Enum):
+class AggregationType(ExtendedEnum):
     """Aggregation methods for measures"""
 
     SUM = "sum"


### PR DESCRIPTION
### Description

When we moved `AggregationType` over, we changed it from an `ExtendedEnum` to an `Enum`. We thought this wouldn't be problematic. However, it turns out that the `_missing_` function of `ExtendedEnum` is actually very important. This is because the custom `_missing_` implementation ensures that using upper-cased or lower-cased values in a config file both work. That is to say that with `ExtendedEnum`, `sum` and `SUM` are both valid, but with `Enum` only `sum` is.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)