### PR TITLE
Remove Output Column Overrides

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generic, Tuple, Optional, Union
+from typing import Generic, Optional, Union
 
 from metricflow.dag.id_generation import IdGeneratorRegistry, SQL_QUERY_PLAN_PREFIX, EXEC_PLAN_PREFIX
 from metricflow.dataflow.dataflow_plan import (
@@ -21,9 +21,8 @@ from metricflow.execution.execution_plan import (
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter, SqlDataSetT
 from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_request import SqlJsonTag
-from metricflow.specs import OutputColumnNameOverride
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
-from metricflow.sql.sql_plan import SqlSelectStatementNode, SqlSelectColumn, SqlQueryPlan
+from metricflow.sql.sql_plan import SqlQueryPlan
 from metricflow.sql.sql_plan_to_text import sql_query_plan_as_text
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,6 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
         sql_plan_renderer: SqlQueryPlanRenderer,
         sql_client: AsyncSqlClient,
         extra_sql_tags: SqlJsonTag = SqlJsonTag(),
-        output_column_name_overrides: Tuple[OutputColumnNameOverride, ...] = (),
     ) -> None:
         """Constructor.
 
@@ -47,54 +45,11 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
             sql_plan_renderer: Converts a SQL query plan to SQL text
             sql_client: The client to use for running queries.
             extra_sql_tags: Tags to supply to the SQL client when running statements.
-            output_column_name_overrides: In the output dataframe / table, name output columns in a specific way.
         """
         self._sql_plan_converter = sql_plan_converter
         self._sql_plan_renderer = sql_plan_renderer
         self._sql_client = sql_client
         self._sql_tags = extra_sql_tags
-        self._output_column_name_overrides = output_column_name_overrides
-
-    @staticmethod
-    def override_output_column_names(
-        sql_plan_converter: DataflowToSqlQueryPlanConverter[SqlDataSetT],
-        output_column_name_overrides: Tuple[OutputColumnNameOverride, ...],
-        select_node: SqlSelectStatementNode,
-    ) -> SqlSelectStatementNode:
-        """Change the output column names in the select_node according ot output_column_name_overrides."""
-        column_name_mapping = {}
-        for column_name_override in output_column_name_overrides:
-            expected_column_name = sql_plan_converter.column_association_resolver.resolve_time_dimension_spec(
-                column_name_override.time_dimension_spec
-            ).column_name
-            assert expected_column_name in [
-                x.column_alias for x in select_node.select_columns
-            ], f"Column {expected_column_name} not in {[x.column_alias for x in select_node.select_columns]}"
-            new_column_name = column_name_override.output_column_name
-            column_name_mapping[expected_column_name] = new_column_name
-
-        new_select_columns = []
-        for select_column in select_node.select_columns:
-            if select_column.column_alias in column_name_mapping:
-                new_select_columns.append(
-                    SqlSelectColumn(
-                        expr=select_column.expr, column_alias=column_name_mapping[select_column.column_alias]
-                    )
-                )
-            else:
-                new_select_columns.append(select_column)
-
-        return SqlSelectStatementNode(
-            description=select_node.description,
-            select_columns=tuple(new_select_columns),
-            from_source=select_node.from_source,
-            from_source_alias=select_node.from_source_alias,
-            joins_descs=select_node.join_descs,
-            group_bys=select_node.group_bys,
-            order_bys=select_node.order_bys,
-            where=select_node.where,
-            limit=select_node.limit,
-        )
 
     def _build_execution_plan(  # noqa: D
         self,
@@ -107,19 +62,6 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
             sql_query_plan_id=IdGeneratorRegistry.for_class(SqlQueryPlan).create_id(SQL_QUERY_PLAN_PREFIX),
             dataflow_plan_node=node,
         )
-
-        if self._output_column_name_overrides:
-            select_node = sql_plan.render_node.as_select_node
-            assert select_node
-
-            sql_plan = SqlQueryPlan(
-                plan_id=IdGeneratorRegistry.for_class(SqlQueryPlan).create_id(SQL_QUERY_PLAN_PREFIX),
-                render_node=DataflowToExecutionPlanConverter.override_output_column_names(
-                    sql_plan_converter=self._sql_plan_converter,
-                    output_column_name_overrides=self._output_column_name_overrides,
-                    select_node=select_node,
-                ),
-            )
 
         logger.debug(f"Generated SQL query plan is:\n{sql_query_plan_as_text(sql_plan)}")
 

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -613,7 +613,6 @@ class MetricFlowQuerySpec(SerializableDataclass):
     entity_specs: Tuple[EntitySpec, ...] = ()
     time_dimension_specs: Tuple[TimeDimensionSpec, ...] = ()
     order_by_specs: Tuple[OrderBySpec, ...] = ()
-    output_column_name_overrides: Tuple[OutputColumnNameOverride, ...] = ()
     time_range_constraint: Optional[TimeRangeConstraint] = None
     where_constraint: Optional[SpecWhereClauseConstraint] = None
     limit: Optional[int] = None


### PR DESCRIPTION
### Description

This PR removes the output column override feature that renamed the output columns in specific cases. This feature is no longer needed as it was for migration.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)