### PR TITLE
Update the naming of SemanticManifestLookup objects

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -112,7 +112,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         node_output_resolver: Optional[DataflowPlanNodeOutputDataSetResolver[SqlDataSetT]] = None,
         column_association_resolver: Optional[ColumnAssociationResolver] = None,
     ) -> None:
-        self._semantic_model_semantics = semantic_manifest_lookup.semantic_model_semantics
+        self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._metric_semantics = semantic_manifest_lookup.metric_semantics
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
         self._cost_function = cost_function
@@ -367,10 +367,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         semantic_model_names: Set[str] = set()
         for measure_name in measure_names:
             semantic_model_names = semantic_model_names.union(
-                {
-                    d.name
-                    for d in self._semantic_model_semantics.get_semantic_models_for_measure(measure_name.as_reference)
-                }
+                {d.name for d in self._semantic_model_lookup.get_semantic_models_for_measure(measure_name.as_reference)}
             )
         return semantic_model_names
 
@@ -433,14 +430,14 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                 f"semantic models: {semantic_models}. This suggests the measure_specs were not correctly filtered."
             )
 
-        agg_time_dimension = agg_time_dimension = self._semantic_model_semantics.get_agg_time_dimension_for_measure(
+        agg_time_dimension = agg_time_dimension = self._semantic_model_lookup.get_agg_time_dimension_for_measure(
             measure_specs[0].as_reference
         )
         non_additive_dimension_spec = measure_specs[0].non_additive_dimension_spec
         for measure_spec in measure_specs:
             if non_additive_dimension_spec != measure_spec.non_additive_dimension_spec:
                 raise ValueError(f"measure_specs {measure_specs} do not have the same non_additive_dimension_spec.")
-            measure_agg_time_dimension = self._semantic_model_semantics.get_agg_time_dimension_for_measure(
+            measure_agg_time_dimension = self._semantic_model_lookup.get_agg_time_dimension_for_measure(
                 measure_spec.as_reference
             )
             if measure_agg_time_dimension != agg_time_dimension:
@@ -465,7 +462,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         """
         measure_specs = measure_spec_properties.measure_specs
         node_processor = PreDimensionJoinNodeProcessor(
-            semantic_model_semantics=self._semantic_model_semantics,
+            semantic_model_lookup=self._semantic_model_lookup,
             node_data_set_resolver=self._node_data_set_resolver,
         )
 
@@ -507,7 +504,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         logger.info(f"Processing nodes took: {time.time()-start_time:.2f}s")
 
         node_evaluator = NodeEvaluatorForLinkableInstances(
-            semantic_model_semantics=self._semantic_model_semantics,
+            semantic_model_lookup=self._semantic_model_lookup,
             nodes_available_for_joins=self._sort_by_suitability(nodes_available_for_joins),
             node_data_set_resolver=self._node_data_set_resolver,
         )
@@ -636,7 +633,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         for input_spec in metric_input_measure_specs:
             semantic_model_names = [
                 dsource.name
-                for dsource in self._semantic_model_semantics.get_semantic_models_for_measure(
+                for dsource in self._semantic_model_lookup.get_semantic_models_for_measure(
                     measure_reference=input_spec.measure_spec.as_reference
                 )
             ]

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -113,7 +113,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         column_association_resolver: Optional[ColumnAssociationResolver] = None,
     ) -> None:
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
-        self._metric_semantics = semantic_manifest_lookup.metric_semantics
+        self._metric_lookup = semantic_manifest_lookup.metric_lookup
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
         self._cost_function = cost_function
         self._source_nodes = source_nodes
@@ -190,10 +190,10 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         for metric_spec in metric_specs:
             logger.info(f"Generating compute metrics node for {metric_spec}")
             metric_reference = metric_spec.as_reference
-            metric = self._metric_semantics.get_metric(metric_reference)
+            metric = self._metric_lookup.get_metric(metric_reference)
 
             if metric.type == MetricType.DERIVED:
-                metric_input_specs = self._metric_semantics.metric_input_specs_for_metric(
+                metric_input_specs = self._metric_lookup.metric_input_specs_for_metric(
                     metric_reference=metric_reference,
                     column_association_resolver=self._column_association_resolver,
                 )
@@ -213,7 +213,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                     metric_specs=[metric_spec],
                 )
             else:
-                metric_input_measure_specs = self._metric_semantics.measures_for_metric(
+                metric_input_measure_specs = self._metric_lookup.measures_for_metric(
                     metric_reference=metric_reference,
                     column_association_resolver=self._column_association_resolver,
                 )

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -112,23 +112,23 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
 
     def __init__(
         self,
-        semantic_model_semantics: SemanticModelAccessor,
+        semantic_model_lookup: SemanticModelAccessor,
         nodes_available_for_joins: Sequence[BaseOutput[SourceDataSetT]],
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SourceDataSetT],
     ) -> None:
         """Constructor
 
         Args:
-            semantic_model_semantics: Needed to resolve partition dimensions.
+            semantic_model_lookup: Needed to resolve partition dimensions.
             nodes_available_for_joins: Nodes that contain linkable instances and may be joined with the "start_node"
             (e.g. the node containing a desired measure) to retrieve the needed linkable instances.
             node_data_set_resolver: Figures out what data set is output by a node.
         """
-        self._semantic_model_semantics = semantic_model_semantics
+        self._semantic_model_lookup = semantic_model_lookup
         self._nodes_available_for_joins = nodes_available_for_joins
         self._node_data_set_resolver = node_data_set_resolver
-        self._partition_resolver = PartitionJoinResolver(self._semantic_model_semantics)
-        self._join_evaluator = SemanticModelJoinEvaluator(self._semantic_model_semantics)
+        self._partition_resolver = PartitionJoinResolver(self._semantic_model_lookup)
+        self._join_evaluator = SemanticModelJoinEvaluator(self._semantic_model_lookup)
 
     def _find_joinable_candidate_nodes_that_can_satisfy_linkable_specs(
         self,
@@ -170,7 +170,7 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
                     len(entity_instance_in_right_node.defined_from) == 1
                 ), f"Did not get exactly 1 defined_from in {entity_instance_in_right_node}"
 
-                entity_in_right_node = self._semantic_model_semantics.get_entity_in_semantic_model(
+                entity_in_right_node = self._semantic_model_lookup.get_entity_in_semantic_model(
                     entity_instance_in_right_node.defined_from[0]
                 )
                 if entity_in_right_node is None:
@@ -247,7 +247,7 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
                         node_to_join_spec_set=data_set_in_right_node.instance_set.spec_set,
                     )
                     validity_window_join_description = CreateValidityWindowJoinDescription(
-                        self._semantic_model_semantics
+                        self._semantic_model_lookup
                     ).transform(instance_set=data_set_in_right_node.instance_set)
 
                     candidates_for_join.append(

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -34,7 +34,7 @@ from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.plan_conversion.instance_converters import CreateValidityWindowJoinDescription
 
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs import (
     LinkableInstanceSpec,
     LinklessEntitySpec,
@@ -112,7 +112,7 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
 
     def __init__(
         self,
-        semantic_model_semantics: SemanticModelSemanticsAccessor,
+        semantic_model_semantics: SemanticModelAccessor,
         nodes_available_for_joins: Sequence[BaseOutput[SourceDataSetT]],
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SourceDataSetT],
     ) -> None:

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -33,21 +33,21 @@ class PartitionTimeDimensionJoinDescription:
 class PartitionJoinResolver:
     """When joining data sets, this class helps to figure out the necessary partition specs to join on."""
 
-    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:  # noqa: D
-        self._semantic_model_semantics = semantic_model_semantics
+    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D
+        self._semantic_model_lookup = semantic_model_lookup
 
     def _get_partitions(self, spec_set: InstanceSpecSet) -> PartitionSpecSet:
         """Returns the specs from the instance set that correspond to partition specs."""
         partition_dimension_specs = tuple(
             x
             for x in spec_set.dimension_specs
-            if self._semantic_model_semantics.get_dimension(dimension_reference=x.reference).is_partition
+            if self._semantic_model_lookup.get_dimension(dimension_reference=x.reference).is_partition
         )
         partition_time_dimension_specs = tuple(
             x
             for x in spec_set.time_dimension_specs
             if x.reference != DataSet.metric_time_dimension_reference()
-            and self._semantic_model_semantics.get_time_dimension(time_dimension_reference=x.reference).is_partition
+            and self._semantic_model_lookup.get_time_dimension(time_dimension_reference=x.reference).is_partition
         )
 
         return PartitionSpecSet(

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Tuple, Sequence, List
 
 from metricflow.dataset.dataset import DataSet
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs import (
     DimensionSpec,
     TimeDimensionSpec,
@@ -33,7 +33,7 @@ class PartitionTimeDimensionJoinDescription:
 class PartitionJoinResolver:
     """When joining data sets, this class helps to figure out the necessary partition specs to join on."""
 
-    def __init__(self, semantic_model_semantics: SemanticModelSemanticsAccessor) -> None:  # noqa: D
+    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:  # noqa: D
         self._semantic_model_semantics = semantic_model_semantics
 
     def _get_partitions(self, spec_set: InstanceSpecSet) -> PartitionSpecSet:

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -27,7 +27,7 @@ class SourceNodeBuilder:
         for data_set in data_sets:
             read_node = ReadSqlSourceNode[SemanticModelDataSet](data_set)
             agg_time_dim_to_measures_grouper = (
-                self._semantic_manifest_lookup.semantic_model_semantics.get_aggregation_time_dimensions_with_measures(
+                self._semantic_manifest_lookup.semantic_model_lookup.get_aggregation_time_dimensions_with_measures(
                     data_set.semantic_model_reference
                 )
             )

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -388,7 +388,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
         logger.info(f"Query spec is:\n{pformat_big_objects(query_spec)}")
 
-        if self._semantic_manifest_lookup.metric_semantics.contains_cumulative_or_time_offset_metric(
+        if self._semantic_manifest_lookup.metric_lookup.contains_cumulative_or_time_offset_metric(
             tuple(m.as_reference for m in query_spec.metric_specs)
         ):
             self._time_spine_table_builder.create_if_necessary()
@@ -451,7 +451,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def simple_dimensions_for_metrics(self, metric_names: List[str]) -> List[Dimension]:  # noqa: D
         return [
             Dimension(name=dim.qualified_name)
-            for dim in self._semantic_manifest_lookup.metric_semantics.element_specs_for_metrics(
+            for dim in self._semantic_manifest_lookup.metric_lookup.element_specs_for_metrics(
                 metric_references=[MetricReference(element_name=mname) for mname in metric_names],
                 without_any_property=frozenset(
                     {
@@ -465,8 +465,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def list_metrics(self) -> List[Metric]:  # noqa: D
-        metric_references = self._semantic_manifest_lookup.metric_semantics.metric_references
-        metrics = self._semantic_manifest_lookup.metric_semantics.get_metrics(metric_references)
+        metric_references = self._semantic_manifest_lookup.metric_lookup.metric_references
+        metrics = self._semantic_manifest_lookup.metric_lookup.get_metrics(metric_references)
         return [
             Metric(
                 name=metric.name,

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -108,13 +108,13 @@ class DataWarehouseTaskBuilder:
         render_tools: QueryRenderingTools, semantic_model: SemanticModel
     ) -> Sequence[BaseOutput[SemanticModelDataSet]]:
         """Builds and returns the SemanticModelDataSet node for the given semantic model"""
-        semantic_model_semantics = render_tools.semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+        semantic_model_lookup = render_tools.semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
             SemanticModelReference(semantic_model_name=semantic_model.name)
         )
-        assert semantic_model_semantics
+        assert semantic_model_lookup
 
         source_nodes = render_tools.source_node_builder.create_from_data_sets(
-            (render_tools.converter.create_sql_source_data_set(semantic_model_semantics),)
+            (render_tools.converter.create_sql_source_data_set(semantic_model_lookup),)
         )
 
         assert len(source_nodes) >= 1

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -1,7 +1,7 @@
 from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from metricflow.model.semantics.semantic_model_semantics import SemanticModelSemantics
 from metricflow.model.semantics.metric_semantics import MetricSemantics
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor, MetricSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor, MetricSemanticsAccessor
 
 
 class SemanticManifestLookup:
@@ -17,7 +17,7 @@ class SemanticManifestLookup:
         return self._semantic_manifest
 
     @property
-    def semantic_model_semantics(self) -> SemanticModelSemanticsAccessor:  # noqa: D
+    def semantic_model_semantics(self) -> SemanticModelAccessor:  # noqa: D
         return self._semantic_model_semantics
 
     @property

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -1,6 +1,6 @@
 from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
-from metricflow.model.semantics.metric_semantics import MetricSemantics
+from metricflow.model.semantics.metric_lookup import MetricLookup
 from metricflow.protocols.semantics import SemanticModelAccessor, MetricAccessor
 
 
@@ -10,7 +10,8 @@ class SemanticManifestLookup:
     def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
         self._semantic_manifest = semantic_manifest
         self._semantic_model_lookup = SemanticModelLookup(user_configured_model)
-        self._metric_semantics = MetricSemantics(self._semantic_manifest, self._semantic_model_lookup)
+        self._metric_lookup = MetricLookup(self._semantic_manifest, self._semantic_model_lookup)
+
 
     @property
     def semantic_manifest(self) -> SemanticManifest:  # noqa: D
@@ -21,5 +22,5 @@ class SemanticManifestLookup:
         return self._semantic_model_lookup
 
     @property
-    def metric_semantics(self) -> MetricAccessor:  # noqa: D
-        return self._metric_semantics
+    def metric_lookup(self) -> MetricAccessor:  # noqa: D
+        return self._metric_lookup

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -9,9 +9,8 @@ class SemanticManifestLookup:
 
     def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
         self._semantic_manifest = semantic_manifest
-        self._semantic_model_lookup = SemanticModelLookup(user_configured_model)
+        self._semantic_model_lookup = SemanticModelLookup(semantic_manifest)
         self._metric_lookup = MetricLookup(self._semantic_manifest, self._semantic_model_lookup)
-
 
     @property
     def semantic_manifest(self) -> SemanticManifest:  # noqa: D

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -1,5 +1,5 @@
 from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
-from metricflow.model.semantics.semantic_model_semantics import SemanticModelSemantics
+from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.protocols.semantics import SemanticModelAccessor, MetricSemanticsAccessor
 
@@ -9,16 +9,16 @@ class SemanticManifestLookup:
 
     def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
         self._semantic_manifest = semantic_manifest
-        self._semantic_model_semantics = SemanticModelSemantics(semantic_manifest)
-        self._metric_semantics = MetricSemantics(self._semantic_manifest, self._semantic_model_semantics)
+        self._semantic_model_lookup = SemanticModelLookup(user_configured_model)
+        self._metric_semantics = MetricSemantics(self._semantic_manifest, self._semantic_model_lookup)
 
     @property
     def semantic_manifest(self) -> SemanticManifest:  # noqa: D
         return self._semantic_manifest
 
     @property
-    def semantic_model_semantics(self) -> SemanticModelAccessor:  # noqa: D
-        return self._semantic_model_semantics
+    def semantic_model_lookup(self) -> SemanticModelAccessor:  # noqa: D
+        return self._semantic_model_lookup
 
     @property
     def metric_semantics(self) -> MetricSemanticsAccessor:  # noqa: D

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -1,7 +1,7 @@
 from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.model.semantics.metric_semantics import MetricSemantics
-from metricflow.protocols.semantics import SemanticModelAccessor, MetricSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor, MetricAccessor
 
 
 class SemanticManifestLookup:
@@ -21,5 +21,5 @@ class SemanticManifestLookup:
         return self._semantic_model_lookup
 
     @property
-    def metric_semantics(self) -> MetricSemanticsAccessor:  # noqa: D
+    def metric_semantics(self) -> MetricAccessor:  # noqa: D
         return self._metric_semantics

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -376,20 +376,20 @@ class ValidLinkableSpecResolver:
     def __init__(
         self,
         semantic_manifest: SemanticManifest,
-        semantic_model_semantics: SemanticModelAccessor,
+        semantic_model_lookup: SemanticModelAccessor,
         max_entity_links: int,
     ) -> None:
         """Constructor.
 
         Args:
             semantic_manifest: the model to use.
-            semantic_model_semantics: used to look up entities for a semantic model.
+            semantic_model_lookup: used to look up entities for a semantic model.
             max_entity_links: the maximum number of joins to do when computing valid elements.
         """
         self._semantic_manifest = semantic_manifest
         # Sort semantic models by name for consistency in building derived objects.
         self._semantic_models = sorted(self._semantic_manifest.semantic_models, key=lambda x: x.name)
-        self._join_evaluator = SemanticModelJoinEvaluator(semantic_model_semantics)
+        self._join_evaluator = SemanticModelJoinEvaluator(semantic_model_lookup)
 
         assert max_entity_links >= 0
         self._max_entity_links = max_entity_links

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -15,7 +15,7 @@ from dbt_semantic_interfaces.references import SemanticModelReference, MeasureRe
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs import (
     DEFAULT_TIME_GRANULARITY,
     LinkableSpecSet,
@@ -376,7 +376,7 @@ class ValidLinkableSpecResolver:
     def __init__(
         self,
         semantic_manifest: SemanticManifest,
-        semantic_model_semantics: SemanticModelSemanticsAccessor,
+        semantic_model_semantics: SemanticModelAccessor,
         max_entity_links: int,
     ) -> None:
         """Constructor.

--- a/metricflow/model/semantics/metric_lookup.py
+++ b/metricflow/model/semantics/metric_lookup.py
@@ -22,7 +22,7 @@ from metricflow.specs import (
 logger = logging.getLogger(__name__)
 
 
-class MetricSemantics(MetricAccessor):  # noqa: D
+class MetricLookup(MetricAccessor):  # noqa: D
     def __init__(  # noqa: D
         self, semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
     ) -> None:

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -9,7 +9,7 @@ from metricflow.model.semantics.linkable_element_properties import LinkableEleme
 from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
 from metricflow.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HOPS
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
-from metricflow.protocols.semantics import MetricSemanticsAccessor
+from metricflow.protocols.semantics import MetricAccessor
 from metricflow.specs import (
     MetricSpec,
     LinkableInstanceSpec,
@@ -22,7 +22,7 @@ from metricflow.specs import (
 logger = logging.getLogger(__name__)
 
 
-class MetricSemantics(MetricSemanticsAccessor):  # noqa: D
+class MetricSemantics(MetricAccessor):  # noqa: D
     def __init__(  # noqa: D
         self, semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
     ) -> None:

--- a/metricflow/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow/model/semantics/semantic_model_join_evaluator.py
@@ -11,7 +11,7 @@ from dbt_semantic_interfaces.references import (
 )
 from metricflow.instances import EntityInstance, InstanceSet
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 
 MAX_JOIN_HOPS = 2
 
@@ -69,7 +69,7 @@ class SemanticModelJoinEvaluator:
         SemanticModelEntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.NATURAL),
     )
 
-    def __init__(self, semantic_model_semantics: SemanticModelSemanticsAccessor) -> None:  # noqa: D
+    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:  # noqa: D
         self._semantic_model_semantics = semantic_model_semantics
 
     def get_joinable_semantic_models(

--- a/metricflow/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow/model/semantics/semantic_model_join_evaluator.py
@@ -69,8 +69,8 @@ class SemanticModelJoinEvaluator:
         SemanticModelEntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.NATURAL),
     )
 
-    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:  # noqa: D
-        self._semantic_model_semantics = semantic_model_semantics
+    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D
+        self._semantic_model_lookup = semantic_model_lookup
 
     def get_joinable_semantic_models(
         self, left_semantic_model_reference: SemanticModelReference, include_multi_hop: bool = False
@@ -94,7 +94,7 @@ class SemanticModelJoinEvaluator:
     ) -> None:
         assert join_hops_remaining > 0, "No join hops remaining. This is unexpected with proper use of this method."
         for parent_semantic_model_reference, parent_join_path in parent_semantic_model_to_join_paths.items():
-            parent_semantic_model = self._semantic_model_semantics.get_by_reference(
+            parent_semantic_model = self._semantic_model_lookup.get_by_reference(
                 semantic_model_reference=parent_semantic_model_reference
             )
             assert parent_semantic_model is not None
@@ -104,7 +104,7 @@ class SemanticModelJoinEvaluator:
             join_paths_to_visit_next: List[List[SemanticModelEntityJoin]] = []
             for entity in parent_semantic_model.entities:
                 entity_reference = EntityReference(element_name=entity.name)
-                entity_semantic_models = self._semantic_model_semantics.get_semantic_models_for_entity(
+                entity_semantic_models = self._semantic_model_lookup.get_semantic_models_for_entity(
                     entity_reference=entity_reference
                 )
 
@@ -164,18 +164,18 @@ class SemanticModelJoinEvaluator:
         on_entity_reference: EntityReference,
     ) -> Optional[SemanticModelEntityJoinType]:
         """Get valid join type used to join semantic models on given entity, if exists."""
-        left_entity = self._semantic_model_semantics.get_entity_in_semantic_model(
+        left_entity = self._semantic_model_lookup.get_entity_in_semantic_model(
             SemanticModelElementReference.create_from_references(left_semantic_model_reference, on_entity_reference)
         )
 
-        right_entity = self._semantic_model_semantics.get_entity_in_semantic_model(
+        right_entity = self._semantic_model_lookup.get_entity_in_semantic_model(
             SemanticModelElementReference.create_from_references(right_semantic_model_reference, on_entity_reference)
         )
         if left_entity is None or right_entity is None:
             return None
 
-        left_semantic_model = self._semantic_model_semantics.get_by_reference(left_semantic_model_reference)
-        right_semantic_model = self._semantic_model_semantics.get_by_reference(right_semantic_model_reference)
+        left_semantic_model = self._semantic_model_lookup.get_by_reference(left_semantic_model_reference)
+        right_semantic_model = self._semantic_model_lookup.get_by_reference(right_semantic_model_reference)
         assert left_semantic_model, "Type refinement. If you see this error something has refactored wrongly"
         assert right_semantic_model, "Type refinement. If you see this error something has refactored wrongly"
 

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -27,7 +27,7 @@ from metricflow.specs import NonAdditiveDimensionSpec, MeasureSpec
 logger = logging.getLogger(__name__)
 
 
-class SemanticModelSemantics(SemanticModelAccessor):
+class SemanticModelLookup(SemanticModelAccessor):
     """Tracks semantic information for semantic model held in a set of SemanticModelContainers
 
     This implements both the SemanticModelAccessors protocol, the interface type we use throughout the codebase.

--- a/metricflow/model/semantics/semantic_model_semantics.py
+++ b/metricflow/model/semantics/semantic_model_semantics.py
@@ -21,16 +21,16 @@ from dbt_semantic_interfaces.references import (
 from metricflow.errors.errors import InvalidSemanticModelError
 from metricflow.model.semantics.element_group import ElementGrouper
 from metricflow.model.spec_converters import MeasureConverter
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs import NonAdditiveDimensionSpec, MeasureSpec
 
 logger = logging.getLogger(__name__)
 
 
-class SemanticModelSemantics(SemanticModelSemanticsAccessor):
+class SemanticModelSemantics(SemanticModelAccessor):
     """Tracks semantic information for semantic model held in a set of SemanticModelContainers
 
-    This implements both the SemanticModelSemanticsAccessors protocol, the interface type we use throughout the codebase.
+    This implements both the SemanticModelAccessors protocol, the interface type we use throughout the codebase.
     That interface prevents unwanted calls to methods for adding semantic models to the container.
     """
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -155,7 +155,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
             time_spine_source: Allows getting dates for use in cumulative joins
         """
         self._column_association_resolver = column_association_resolver
-        self._metric_semantics = semantic_manifest_lookup.metric_semantics
+        self._metric_lookup = semantic_manifest_lookup.metric_lookup
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._time_spine_source = time_spine_source
 
@@ -641,7 +641,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         metric_select_columns = []
         metric_instances = []
         for metric_spec in node.metric_specs:
-            metric = self._metric_semantics.get_metric(metric_spec.as_reference)
+            metric = self._metric_lookup.get_metric(metric_spec.as_reference)
 
             metric_expr: Optional[SqlExpressionNode] = None
             if metric.type is MetricType.RATIO:

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -156,7 +156,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         """
         self._column_association_resolver = column_association_resolver
         self._metric_semantics = semantic_manifest_lookup.metric_semantics
-        self._semantic_model_semantics = semantic_manifest_lookup.semantic_model_semantics
+        self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._time_spine_source = time_spine_source
 
     @property
@@ -584,7 +584,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
             CreateSelectColumnsWithMeasuresAggregated(
                 table_alias=from_data_set_alias,
                 column_resolver=self._column_association_resolver,
-                semantic_model_semantics=self._semantic_model_semantics,
+                semantic_model_lookup=self._semantic_model_lookup,
                 metric_input_measure_specs=node.metric_input_measure_specs,
             )
         )
@@ -1104,7 +1104,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         # Only these measures will be in the output data set.
         output_measure_instances = []
         for measure_instance in input_data_set.instance_set.measure_instances:
-            measure = self._semantic_model_semantics.get_measure(measure_instance.spec.as_reference)
+            measure = self._semantic_model_lookup.get_measure(measure_instance.spec.as_reference)
             if measure.checked_agg_time_dimension == node.aggregation_time_dimension_reference:
                 output_measure_instances.append(measure_instance)
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -23,7 +23,7 @@ from metricflow.instances import (
     InstanceSetTransform,
     TimeDimensionInstance,
 )
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.assert_one_arg import assert_exactly_one_arg_set
 from metricflow.plan_conversion.select_column_gen import SelectColumnSet
 from metricflow.specs import (
@@ -167,7 +167,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
         self,
         table_alias: str,
         column_resolver: ColumnAssociationResolver,
-        semantic_model_semantics: SemanticModelSemanticsAccessor,
+        semantic_model_semantics: SemanticModelAccessor,
         metric_input_measure_specs: Sequence[MetricInputMeasureSpec],
     ) -> None:
         self._semantic_model_semantics = semantic_model_semantics
@@ -273,8 +273,8 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
     an SCD source, and extracting validity window information accordingly.
     """
 
-    def __init__(self, semantic_model_semantics: SemanticModelSemanticsAccessor) -> None:
-        """Initializer. The SemanticModelSemanticsAccessor is needed for getting the original model definition."""
+    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:
+        """Initializer. The SemanticModelAccessor is needed for getting the original model definition."""
         self._semantic_model_semantics = semantic_model_semantics
 
     def _get_validity_window_dimensions_for_semantic_model(

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -167,10 +167,10 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
         self,
         table_alias: str,
         column_resolver: ColumnAssociationResolver,
-        semantic_model_semantics: SemanticModelAccessor,
+        semantic_model_lookup: SemanticModelAccessor,
         metric_input_measure_specs: Sequence[MetricInputMeasureSpec],
     ) -> None:
-        self._semantic_model_semantics = semantic_model_semantics
+        self._semantic_model_lookup = semantic_model_lookup
         self.metric_input_measure_specs = metric_input_measure_specs
         super().__init__(table_alias=table_alias, column_resolver=column_resolver)
 
@@ -205,7 +205,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
 
         # Create an expression that will aggregate the given measure.
         # Figure out the aggregation function for the measure.
-        measure = self._semantic_model_semantics.get_measure(measure_instance.spec.as_reference)
+        measure = self._semantic_model_lookup.get_measure(measure_instance.spec.as_reference)
         aggregation_type = measure.agg
 
         expression_to_get_measure = SqlColumnReferenceExpression(
@@ -273,15 +273,15 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
     an SCD source, and extracting validity window information accordingly.
     """
 
-    def __init__(self, semantic_model_semantics: SemanticModelAccessor) -> None:
+    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:
         """Initializer. The SemanticModelAccessor is needed for getting the original model definition."""
-        self._semantic_model_semantics = semantic_model_semantics
+        self._semantic_model_lookup = semantic_model_lookup
 
     def _get_validity_window_dimensions_for_semantic_model(
         self, semantic_model_reference: SemanticModelReference
     ) -> Optional[Tuple[_DimensionValidityParams, _DimensionValidityParams]]:
         """Returns a 2-tuple (start, end) of validity window dimensions info, if any exist in the semantic model"""
-        semantic_model = self._semantic_model_semantics.get_by_reference(semantic_model_reference)
+        semantic_model = self._semantic_model_lookup.get_by_reference(semantic_model_reference)
         assert semantic_model, f"Could not find semantic model {semantic_model_reference} after data set conversion!"
 
         start_dim = semantic_model.validity_start_dimension

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -79,13 +79,13 @@ class PreDimensionJoinNodeProcessor(Generic[SqlDataSetT]):
 
     def __init__(  # noqa: D
         self,
-        semantic_model_semantics: SemanticModelAccessor,
+        semantic_model_lookup: SemanticModelAccessor,
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SqlDataSetT],
     ):
         self._node_data_set_resolver = node_data_set_resolver
-        self._partition_resolver = PartitionJoinResolver(semantic_model_semantics)
-        self._semantic_model_semantics = semantic_model_semantics
-        self._join_evaluator = SemanticModelJoinEvaluator(semantic_model_semantics)
+        self._partition_resolver = PartitionJoinResolver(semantic_model_lookup)
+        self._semantic_model_lookup = semantic_model_lookup
+        self._join_evaluator = SemanticModelJoinEvaluator(semantic_model_lookup)
 
     def add_time_range_constraint(
         self,
@@ -139,7 +139,7 @@ class PreDimensionJoinNodeProcessor(Generic[SqlDataSetT]):
                 len(entity_instance_in_first_node.defined_from) == 1
             ), "Multiple items in defined_from not yet supported"
 
-            entity = self._semantic_model_semantics.get_entity_in_semantic_model(
+            entity = self._semantic_model_lookup.get_entity_in_semantic_model(
                 entity_instance_in_first_node.defined_from[0]
             )
             if entity is None:

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -17,7 +17,7 @@ from metricflow.dataflow.dataflow_plan import (
 from metricflow.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator, MAX_JOIN_HOPS
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
-from metricflow.protocols.semantics import SemanticModelSemanticsAccessor
+from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.spec_set_transforms import ToElementNameSet
 from metricflow.specs import LinkableInstanceSpec, LinklessEntitySpec, InstanceSpecSet
 
@@ -79,7 +79,7 @@ class PreDimensionJoinNodeProcessor(Generic[SqlDataSetT]):
 
     def __init__(  # noqa: D
         self,
-        semantic_model_semantics: SemanticModelSemanticsAccessor,
+        semantic_model_semantics: SemanticModelAccessor,
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SqlDataSetT],
     ):
         self._node_data_set_resolver = node_data_set_resolver

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -124,7 +124,7 @@ class SemanticModelAccessor(ABC):
         raise NotImplementedError
 
 
-class MetricSemanticsAccessor(ABC):
+class MetricAccessor(ABC):
     """Interface for accessing semantic information about a set of metric objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -37,7 +37,7 @@ from metricflow.specs import (
 )
 
 
-class SemanticModelSemanticsAccessor(ABC):
+class SemanticModelAccessor(ABC):
     """Interface for accessing semantic information about a set of semantic model objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -41,7 +41,7 @@ class SemanticModelAccessor(ABC):
     """Interface for accessing semantic information about a set of semantic model objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want
-    them to use. For example, the SemanticModelSemantics class might implement this protocol but also include some
+    them to use. For example, the SemanticModelLookup class might implement this protocol but also include some
     public methods for adding or removing semantic models from the container, while this protocol only allows the
     caller to invoke the accessor methods which retrieve semantic information about the collected semantic models.
     """

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -128,7 +128,7 @@ class MetricAccessor(ABC):
     """Interface for accessing semantic information about a set of metric objects
 
     This is primarily useful for restricting caller access to the subset of container methods and imports we want
-    them to use. For example, the MetricSemantics class might implement this protocol but also include some
+    them to use. For example, the MetricLookup class might implement this protocol but also include some
     public methods for adding or removing metrics from the container, while this protocol only allows the
     caller to invoke the accessor methods which retrieve semantic information about the collected metrics.
     """

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -113,15 +113,15 @@ class MetricFlowQueryParser:
         self._column_association_resolver = column_association_resolver
         self._model = model
         self._metric_semantics = model.metric_semantics
-        self._semantic_model_semantics = model.semantic_model_semantics
+        self._semantic_model_lookup = model.semantic_model_lookup
 
         # Set up containers for known element names
-        self._known_entity_element_references = self._semantic_model_semantics.get_entity_references()
+        self._known_entity_element_references = self._semantic_model_lookup.get_entity_references()
 
         self._known_time_dimension_element_references = [DataSet.metric_time_dimension_reference()]
         self._known_dimension_element_references = []
-        for dimension_reference in self._semantic_model_semantics.get_dimension_references():
-            dimension = self._semantic_model_semantics.get_dimension(dimension_reference)
+        for dimension_reference in self._semantic_model_lookup.get_dimension_references():
+            dimension = self._semantic_model_lookup.get_dimension(dimension_reference)
             if dimension.type == DimensionType.CATEGORICAL:
                 self._known_dimension_element_references.append(dimension_reference)
             elif dimension.type == DimensionType.TIME:

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -112,7 +112,7 @@ class MetricFlowQueryParser:
     ) -> None:
         self._column_association_resolver = column_association_resolver
         self._model = model
-        self._metric_semantics = model.metric_semantics
+        self._metric_lookup = model.metric_lookup
         self._semantic_model_lookup = model.semantic_model_lookup
 
         # Set up containers for known element names
@@ -129,7 +129,7 @@ class MetricFlowQueryParser:
             else:
                 raise RuntimeError(f"Unhandled linkable type: {dimension.type}")
 
-        self._known_metric_names = set(self._metric_semantics.metric_references)
+        self._known_metric_names = set(self._metric_lookup.metric_references)
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
         self._time_granularity_solver = TimeGranularitySolver(
             semantic_manifest_lookup=self._model,
@@ -198,7 +198,7 @@ class MetricFlowQueryParser:
     def _validate_no_time_dimension_query(self, metric_references: Sequence[MetricReference]) -> None:
         """Validate if all requested metrics are queryable without a time dimension."""
         for metric_reference in metric_references:
-            metric = self._metric_semantics.get_metric(metric_reference)
+            metric = self._metric_lookup.get_metric(metric_reference)
             if metric.type == MetricType.CUMULATIVE:
                 # Cumulative metrics configured with a window/grain_to_date cannot be queried without a dimension.
                 if metric.type_params.window or metric.type_params.grain_to_date:
@@ -230,7 +230,7 @@ class MetricFlowQueryParser:
         if len(invalid_group_bys) > 0:
             valid_group_by_names_for_metrics = sorted(
                 x.qualified_name
-                for x in self._metric_semantics.element_specs_for_metrics(metric_references=list(metric_references))
+                for x in self._metric_lookup.element_specs_for_metrics(metric_references=list(metric_references))
             )
             # Create suggestions for invalid dimensions in case the user made a typo.
             suggestion_sections = {}
@@ -262,7 +262,7 @@ class MetricFlowQueryParser:
         """
         metric_specs = []
         for metric_reference in metric_references:
-            metric = self._metric_semantics.get_metric(metric_reference)
+            metric = self._metric_lookup.get_metric(metric_reference)
             metric_where_constraint: Optional[WhereFilterSpec] = None
             if metric.filter:
                 # add constraint to MetricSpec
@@ -388,7 +388,7 @@ class MetricFlowQueryParser:
         # by the filters.
         # TODO: Consider moving this logic into _validate_linkable_specs().
         for metric_reference in metric_references:
-            metric = self._metric_semantics.get_metric(metric_reference)
+            metric = self._metric_lookup.get_metric(metric_reference)
             if metric.filter is not None:
                 group_by_specs_for_one_metric = self._parse_linkable_element_names(
                     qualified_linkable_names=group_by_names,
@@ -568,7 +568,7 @@ class MetricFlowQueryParser:
         # The config must be lower-case, so we lower case for case-insensitivity against query inputs from the user.
         metric_names = [x.lower() for x in metric_names]
 
-        known_metric_names = set(self._metric_semantics.metric_references)
+        known_metric_names = set(self._metric_lookup.metric_references)
         metric_references: List[MetricReference] = []
         for metric_name in metric_names:
             metric_reference = MetricReference(element_name=metric_name)
@@ -577,7 +577,7 @@ class MetricFlowQueryParser:
                     f"Suggestions for '{metric_name}'": pformat_big_objects(
                         MetricFlowQueryParser._top_fuzzy_matches(
                             item=metric_name,
-                            candidate_items=[x.element_name for x in self._metric_semantics.metric_references],
+                            candidate_items=[x.element_name for x in self._metric_lookup.metric_references],
                         )
                     )
                 }
@@ -587,7 +587,7 @@ class MetricFlowQueryParser:
                 )
             metric_references.append(metric_reference)
             if traverse_metric_inputs:
-                metric = self._metric_semantics.get_metric(metric_reference)
+                metric = self._metric_lookup.get_metric(metric_reference)
                 if metric.type == MetricType.DERIVED:
                     input_metrics = self._parse_metric_names([metric.name for metric in metric.input_metrics])
                     metric_references.extend(list(input_metrics))
@@ -632,7 +632,7 @@ class MetricFlowQueryParser:
                 entity_specs.append(EntitySpec(element_name=element_name, entity_links=entity_links))
             else:
                 valid_group_by_names_for_metrics = sorted(
-                    x.qualified_name for x in self._metric_semantics.element_specs_for_metrics(list(metric_references))
+                    x.qualified_name for x in self._metric_lookup.element_specs_for_metrics(list(metric_references))
                 )
 
                 suggestions = {
@@ -665,9 +665,7 @@ class MetricFlowQueryParser:
         """Checks that each requested linkable instance can be retrieved for the given metric"""
         invalid_linkable_specs: List[LinkableInstanceSpec] = []
         # TODO: distinguish between dimensions that invalid via typo vs ambiguous join path
-        valid_linkable_specs = self._metric_semantics.element_specs_for_metrics(
-            metric_references=list(metric_references)
-        )
+        valid_linkable_specs = self._metric_lookup.element_specs_for_metrics(metric_references=list(metric_references))
 
         for dimension_spec in dimension_specs:
             if dimension_spec not in valid_linkable_specs:

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -49,7 +49,7 @@ def node_evaluator(
     source_nodes = tuple(consistent_id_object_repository.simple_model_read_nodes.values())
 
     return NodeEvaluatorForLinkableInstances(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics,
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
         # Use all nodes in the simple model as candidates for joins.
         nodes_available_for_joins=source_nodes,
         node_data_set_resolver=node_data_set_resolver,
@@ -70,7 +70,7 @@ def make_multihop_node_evaluator(
     )
 
     node_processor = PreDimensionJoinNodeProcessor(
-        semantic_model_semantics=semantic_manifest_lookup_with_multihop_links.semantic_model_semantics,
+        semantic_model_lookup=semantic_manifest_lookup_with_multihop_links.semantic_model_lookup,
         node_data_set_resolver=node_data_set_resolver,
     )
 
@@ -85,7 +85,7 @@ def make_multihop_node_evaluator(
     )
 
     return NodeEvaluatorForLinkableInstances(
-        semantic_model_semantics=semantic_manifest_lookup_with_multihop_links.semantic_model_semantics,
+        semantic_model_lookup=semantic_manifest_lookup_with_multihop_links.semantic_model_lookup,
         nodes_available_for_joins=nodes_available_for_joins,
         node_data_set_resolver=node_data_set_resolver,
     )
@@ -475,7 +475,7 @@ def test_node_evaluator_with_scd_target(
     source_nodes = tuple(consistent_id_object_repository.scd_model_read_nodes.values())
 
     node_evaluator = NodeEvaluatorForLinkableInstances(
-        semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics,
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup,
         # Use all nodes in the simple model as candidates for joins.
         nodes_available_for_joins=source_nodes,
         node_data_set_resolver=node_data_set_resolver,

--- a/metricflow/test/examples/test_node_sql.py
+++ b/metricflow/test/examples/test_node_sql.py
@@ -29,7 +29,7 @@ def test_view_sql_generated_at_a_node(
     time_spine_source: TimeSpineSource,
 ) -> None:
     """Example that shows how to view generated SQL for nodes in a dataflow plan."""
-    bookings_semantic_model = simple_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    bookings_semantic_model = simple_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference(semantic_model_name="bookings_source")
     )
     assert bookings_semantic_model

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -21,7 +21,7 @@ def simple_model_spec_resolver(  # noqa: D
 ) -> ValidLinkableSpecResolver:
     return ValidLinkableSpecResolver(
         semantic_manifest=simple_semantic_manifest_lookup.semantic_manifest,
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics,
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
         max_entity_links=MAX_JOIN_HOPS,
     )
 
@@ -173,7 +173,7 @@ def test_joined_property(simple_model_spec_resolver: ValidLinkableSpecResolver) 
 def test_multi_hop_property(multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
     multi_hop_spec_resolver = ValidLinkableSpecResolver(
         semantic_manifest=multi_hop_join_semantic_manifest_lookup.semantic_manifest,
-        semantic_model_semantics=multi_hop_join_semantic_manifest_lookup.semantic_model_semantics,
+        semantic_model_lookup=multi_hop_join_semantic_manifest_lookup.semantic_model_lookup,
         max_entity_links=MAX_JOIN_HOPS,
     )
     property_check_helper(

--- a/metricflow/test/model/semantics/test_semantic_model_join_evaluator.py
+++ b/metricflow/test/model/semantics/test_semantic_model_join_evaluator.py
@@ -56,13 +56,13 @@ def __get_simple_model_user_semantic_model_references_by_type(
     semantic_manifest_lookup: SemanticManifestLookup,
 ) -> Dict[EntityType, SemanticModelReference]:
     """Helper to get a set of semantic models with the `user` identifier organized by identifier type"""
-    foreign_user_semantic_model = semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    foreign_user_semantic_model = semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("listings_latest")
     )
-    primary_user_semantic_model = semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    primary_user_semantic_model = semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("users_latest")
     )
-    unique_user_semantic_model = semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    unique_user_semantic_model = semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("companies")
     )
 
@@ -90,7 +90,7 @@ def test_distinct_target_semantic_model_join_validation(
     )
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup
     )
 
     foreign_primary = join_evaluator.is_valid_semantic_model_join(
@@ -148,7 +148,7 @@ def test_foreign_target_semantic_model_join_validation(simple_semantic_manifest_
     )
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup
     )
 
     foreign_foreign = join_evaluator.is_valid_semantic_model_join(
@@ -182,17 +182,17 @@ def test_semantic_model_join_validation_on_missing_entity(
     simple_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
     """Tests semantic model join validation where the entity is missing from one or both semantic models"""
-    primary_listing_semantic_model = simple_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    primary_listing_semantic_model = simple_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("listings_latest")
     )
     assert primary_listing_semantic_model, "Could not find semantic model `listings_latest` in the simple model!"
-    no_listing_semantic_model = simple_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    no_listing_semantic_model = simple_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("id_verifications")
     )
     assert no_listing_semantic_model, "Could not find semantic model `id_verifications` in the simple model!"
     listing_entity_reference = EntityReference(element_name="listing")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup
     )
 
     assert not join_evaluator.is_valid_semantic_model_join(
@@ -215,7 +215,7 @@ def test_distinct_target_instance_set_join_validation(
     unique_user_instance_set = consistent_id_object_repository.simple_model_data_sets["companies"].instance_set
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup
     )
 
     foreign_primary = join_evaluator.is_valid_instance_set_join(
@@ -273,7 +273,7 @@ def test_foreign_target_instance_set_join_validation(
     unique_user_instance_set = consistent_id_object_repository.simple_model_data_sets["companies"].instance_set
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=simple_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup
     )
 
     foreign_foreign = join_evaluator.is_valid_instance_set_join(
@@ -308,7 +308,7 @@ def test_get_joinable_semantic_models_single_hop(  # noqa: D
 ) -> None:
     semantic_model_reference = SemanticModelReference(semantic_model_name="account_month_txns")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=multi_hop_join_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=multi_hop_join_semantic_manifest_lookup.semantic_model_lookup
     )
 
     # Single-hop
@@ -335,7 +335,7 @@ def test_get_joinable_semantic_models_multi_hop(  # noqa: D
 ) -> None:
     semantic_model_reference = SemanticModelReference(semantic_model_name="account_month_txns")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=multi_hop_join_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=multi_hop_join_semantic_manifest_lookup.semantic_model_lookup
     )
 
     # 2-hop
@@ -400,21 +400,21 @@ def test_natural_entity_semantic_model_validation(scd_semantic_manifest_lookup: 
 
     These tests rely on the scd_semantic_manifest_lookup, which makes extensive use of NATURAL key types.
     """
-    natural_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    natural_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("primary_accounts")
     )
-    primary_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    primary_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("users_latest")
     )
-    foreign_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    foreign_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("bookings_source")
     )
-    unique_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_semantics.get_by_reference(
+    unique_user_semantic_model = scd_semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
         SemanticModelReference("companies")
     )
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     )
     # Type refinement
     assert natural_user_semantic_model, "Could not find `primary_accounts` semantic model in scd model!"
@@ -491,7 +491,7 @@ def test_natural_entity_instance_set_validation(
     unique_user_instance_set = consistent_id_object_repository.scd_model_data_sets["companies"].instance_set
     user_entity_reference = EntityReference(element_name="user")
     join_evaluator = SemanticModelJoinEvaluator(
-        semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     )
 
     # Valid cases

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference, MeasureReference, MetricReference
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
-from metricflow.model.semantics.metric_semantics import MetricSemantics
+from metricflow.model.semantics.metric_lookup import MetricLookup
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +19,11 @@ def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> Semanti
 
 
 @pytest.fixture
-def metric_semantics(  # Noqa: D
+def metric_lookup(  # Noqa: D
     simple_semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
 ) -> MetricSemantics:
-    return MetricSemantics(
+    return MetricLookup(
         semantic_manifest=simple_semantic_manifest,
-        semantic_model_lookup=semantic_model_lookup,
     )
 
 
@@ -111,11 +110,11 @@ def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLoo
     assert listings_sources[0].name == "listings_latest"
 
 
-def test_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa: D
+def test_elements_for_metric(metric_lookup: MetricLookup) -> None:  # noqa: D
     assert set(
         [
             x.qualified_name
-            for x in metric_semantics.element_specs_for_metrics(
+            for x in metric_lookup.element_specs_for_metrics(
                 [MetricReference(element_name="views")],
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
             )
@@ -159,7 +158,7 @@ def test_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa
         "user__home_state_latest",
     }
 
-    local_specs = metric_semantics.element_specs_for_metrics(
+    local_specs = metric_lookup.element_specs_for_metrics(
         metric_references=[MetricReference(element_name="views")],
         with_any_property=frozenset({LinkableElementProperties.LOCAL}),
         without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
@@ -173,11 +172,11 @@ def test_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa
     }
 
 
-def test_local_linked_elements_for_metric(metric_semantics: MetricSemantics) -> None:  # noqa: D
+def test_local_linked_elements_for_metric(metric_lookup: MetricLookup) -> None:  # noqa: D
     result = set(
         [
             x.qualified_name
-            for x in metric_semantics.element_specs_for_metrics(
+            for x in metric_lookup.element_specs_for_metrics(
                 [MetricReference(element_name="listings")],
                 with_any_property=frozenset({LinkableElementProperties.LOCAL_LINKED}),
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -21,10 +21,8 @@ def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> Semanti
 @pytest.fixture
 def metric_lookup(  # Noqa: D
     simple_semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
-) -> MetricSemantics:
-    return MetricLookup(
-        semantic_manifest=simple_semantic_manifest,
-    )
+) -> MetricLookup:
+    return MetricLookup(semantic_manifest=simple_semantic_manifest, semantic_model_lookup=semantic_model_lookup)
 
 
 def test_get_names(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -4,7 +4,7 @@ import pytest
 
 from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference, MeasureReference, MetricReference
-from metricflow.model.semantics.semantic_model_semantics import SemanticModelSemantics
+from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.metric_semantics import MetricSemantics
 
@@ -12,23 +12,23 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def semantic_model_semantics(simple_semantic_manifest: SemanticManifest) -> SemanticModelSemantics:  # Noqa: D
-    return SemanticModelSemantics(
+def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> SemanticModelLookup:  # Noqa: D
+    return SemanticModelLookup(
         model=simple_semantic_manifest,
     )
 
 
 @pytest.fixture
 def metric_semantics(  # Noqa: D
-    simple_semantic_manifest: SemanticManifest, semantic_model_semantics: SemanticModelSemantics
+    simple_semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
 ) -> MetricSemantics:
     return MetricSemantics(
         semantic_manifest=simple_semantic_manifest,
-        semantic_model_semantics=semantic_model_semantics,
+        semantic_model_lookup=semantic_model_lookup,
     )
 
 
-def test_get_names(semantic_model_semantics: SemanticModelSemantics) -> None:  # noqa: D
+def test_get_names(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
     expected = [
         "account_type",
         "booking_paid_at",
@@ -44,7 +44,7 @@ def test_get_names(semantic_model_semantics: SemanticModelSemantics) -> None:  #
         "is_lux_latest",
         "verification_type",
     ]
-    assert sorted([d.element_name for d in semantic_model_semantics.get_dimension_references()]) == expected
+    assert sorted([d.element_name for d in semantic_model_lookup.get_dimension_references()]) == expected
 
     expected = [
         "account_balance",
@@ -71,7 +71,7 @@ def test_get_names(semantic_model_semantics: SemanticModelSemantics) -> None:  #
         "txn_revenue",
         "views",
     ]
-    assert sorted([m.element_name for m in semantic_model_semantics.measure_references]) == expected
+    assert sorted([m.element_name for m in semantic_model_lookup.measure_references]) == expected
 
     expected = [
         "company",
@@ -83,34 +83,30 @@ def test_get_names(semantic_model_semantics: SemanticModelSemantics) -> None:  #
         "user",
         "verification",
     ]
-    assert sorted([i.element_name for i in semantic_model_semantics.get_entity_references()]) == expected
+    assert sorted([i.element_name for i in semantic_model_lookup.get_entity_references()]) == expected
 
 
-def test_get_elements(semantic_model_semantics: SemanticModelSemantics) -> None:  # noqa: D
-    for dimension_reference in semantic_model_semantics.get_dimension_references():
+def test_get_elements(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+    for dimension_reference in semantic_model_lookup.get_dimension_references():
         assert (
-            semantic_model_semantics.get_dimension(dimension_reference=dimension_reference).reference
+            semantic_model_lookup.get_dimension(dimension_reference=dimension_reference).reference
             == dimension_reference
         )
-    for measure_reference in semantic_model_semantics.measure_references:
+    for measure_reference in semantic_model_lookup.measure_references:
         measure_reference = MeasureReference(element_name=measure_reference.element_name)
-        assert semantic_model_semantics.get_measure(measure_reference=measure_reference).reference == measure_reference
+        assert semantic_model_lookup.get_measure(measure_reference=measure_reference).reference == measure_reference
 
 
-def test_get_semantic_models_for_measure(semantic_model_semantics: SemanticModelSemantics) -> None:  # noqa: D
-    bookings_sources = semantic_model_semantics.get_semantic_models_for_measure(
-        MeasureReference(element_name="bookings")
-    )
+def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+    bookings_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="bookings"))
     assert len(bookings_sources) == 1
     assert bookings_sources[0].name == "bookings_source"
 
-    views_sources = semantic_model_semantics.get_semantic_models_for_measure(MeasureReference(element_name="views"))
+    views_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="views"))
     assert len(views_sources) == 1
     assert views_sources[0].name == "views_source"
 
-    listings_sources = semantic_model_semantics.get_semantic_models_for_measure(
-        MeasureReference(element_name="listings")
-    )
+    listings_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="listings"))
     assert len(listings_sources) == 1
     assert listings_sources[0].name == "listings_latest"
 
@@ -198,7 +194,7 @@ def test_local_linked_elements_for_metric(metric_semantics: MetricSemantics) -> 
     }
 
 
-def test_get_semantic_models_for_entity(semantic_model_semantics: SemanticModelSemantics) -> None:  # noqa: D
+def test_get_semantic_models_for_entity(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
     entity_reference = EntityReference(element_name="user")
-    linked_semantic_models = semantic_model_semantics.get_semantic_models_for_entity(entity_reference=entity_reference)
+    linked_semantic_models = semantic_model_lookup.get_semantic_models_for_entity(entity_reference=entity_reference)
     assert len(linked_semantic_models) == 8

--- a/metricflow/test/plan_conversion/instance_converters/test_create_select_columns_with_measures_aggregated.py
+++ b/metricflow/test/plan_conversion/instance_converters/test_create_select_columns_with_measures_aggregated.py
@@ -40,7 +40,7 @@ def test_sum_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="booking_value")),),
     ).transform(instance_set=instance_set)
 
@@ -62,7 +62,7 @@ def test_sum_boolean_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="instant_bookings")),),
     ).transform(instance_set=instance_set)
 
@@ -85,7 +85,7 @@ def test_avg_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="average_booking_value")),),
     ).transform(instance_set=instance_set)
 
@@ -107,7 +107,7 @@ def test_count_distinct_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="bookers")),),
     ).transform(instance_set=instance_set)
 
@@ -129,7 +129,7 @@ def test_max_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="largest_listing")),),
     ).transform(instance_set=instance_set)
 
@@ -151,7 +151,7 @@ def test_min_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="smallest_listing")),),
     ).transform(instance_set=instance_set)
 
@@ -173,7 +173,7 @@ def test_aliased_sum(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="booking_value"), alias="bvalue"),),
     ).transform(instance_set=instance_set)
 
@@ -196,7 +196,7 @@ def test_percentile_aggregation(
     select_column_set: SelectColumnSet = CreateSelectColumnsWithMeasuresAggregated(
         __SOURCE_TABLE_ALIAS,
         DefaultColumnAssociationResolver(simple_semantic_manifest_lookup),
-        simple_semantic_manifest_lookup.semantic_model_semantics,
+        simple_semantic_manifest_lookup.semantic_model_lookup,
         (MetricInputMeasureSpec(measure_spec=MeasureSpec(element_name="booking_value_p99")),),
     ).transform(instance_set=instance_set)
 

--- a/metricflow/test/plan_conversion/instance_converters/test_create_validity_window_join_description.py
+++ b/metricflow/test/plan_conversion/instance_converters/test_create_validity_window_join_description.py
@@ -17,7 +17,7 @@ def test_no_validity_dims(
     dataset = consistent_id_object_repository.scd_model_data_sets["bookings_source"]
 
     validity_window_join_description = CreateValidityWindowJoinDescription(
-        semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     ).transform(instance_set=dataset.instance_set)
 
     assert validity_window_join_description is None, (
@@ -44,7 +44,7 @@ def test_validity_window_conversion(
     )
 
     validity_window_join_description = CreateValidityWindowJoinDescription(
-        semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     ).transform(instance_set=dataset.instance_set)
 
     assert (
@@ -64,5 +64,5 @@ def test_multiple_validity_windows(
     merged_instance_set = InstanceSet.merge([first_dataset.instance_set, second_dataset.instance_set])
     with pytest.raises(AssertionError, match="Found more than 1 set of validity window specs"):
         CreateValidityWindowJoinDescription(
-            semantic_model_semantics=scd_semantic_manifest_lookup.semantic_model_semantics
+            semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
         ).transform(merged_instance_set)

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -167,7 +167,7 @@ class TimeGranularitySolver:
                 # If there is a cumulative metric, granularity changes aren't supported. We need to check the granularity
                 # specified in the configs for the cumulative metric alone, since `min_granularity_for_querying` may not be supported.
                 for metric_reference in metric_references:
-                    metric = self._semantic_manifest_lookup.metric_semantics.get_metric(metric_reference)
+                    metric = self._semantic_manifest_lookup.metric_lookup.get_metric(metric_reference)
                     if metric.type == MetricType.CUMULATIVE:
                         _, only_queryable_granularity = self.local_dimension_granularity_range(
                             metric_references=[metric_reference],


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
As a followup of renaming `DataSource` -> `SemanticModel`, `SemanticModelSemantics` is not a desirable name. So will be renaming

- `SemanticModelSemantics` -> `SemanticModelAccessor`
- `MetricSemantics` -> `MetricAccessor`
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)