### PR TITLE
Update pydantic validator for SemanticModel.relation_name

### DIFF
--- a/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/semantic_model.py
+++ b/dbt_semantic_interfaces/dbt_semantic_interfaces/objects/semantic_model.py
@@ -21,11 +21,18 @@ class NodeRelation(HashableBaseModel):
 
     @validator("relation_name", always=True)
     @classmethod
-    def create_default_relation_name(cls, value: Any, values: Any) -> str:  # type: ignore[misc]
+    def __create_default_relation_name(cls, value: Any, values: Any) -> str:  # type: ignore[misc]
         """Dynamically build the dot path for `relation_name`, if not specified"""
         if value:
+            # Only build the relation_name if it was not present in config.
             return value
+
         alias, schema, database = values.get("alias"), values.get("schema_name"), values.get("database")
+        if alias is None or schema is None:
+            raise ValueError(
+                f"Failed to build relation_name because alias and/or schema was None. schema: {schema}, alias: {alias}"
+            )
+
         if database is not None:
             value = f"{database}.{schema}.{alias}"
         else:


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Set the `relation_name` pydantic validator to private as it shouldn't be accessed outside of pydantic and added additional errors to avoid `None` string formatting.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)