### PR TITLE
Removing boolean aggregation type

### DIFF
--- a/metricflow/aggregation_properties.py
+++ b/metricflow/aggregation_properties.py
@@ -15,7 +15,6 @@ def is_expansive(agg_type: AggregationType) -> bool:
         AggregationType.SUM,
         AggregationType.MIN,
         AggregationType.MAX,
-        AggregationType.BOOLEAN,
         AggregationType.COUNT,
     )
 
@@ -28,7 +27,6 @@ def is_additive(agg_type: AggregationType) -> bool:
         agg_type is AggregationType.MIN
         or agg_type is AggregationType.MAX
         or agg_type is AggregationType.COUNT_DISTINCT
-        or agg_type is AggregationType.BOOLEAN
         or agg_type is AggregationType.AVERAGE
         or agg_type is AggregationType.PERCENTILE
         or agg_type is AggregationType.MEDIAN

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -705,11 +705,7 @@ class SqlFunction(Enum):
                 f"Unhandled aggregation type {aggregation_type} - this should have been transformed to PERCENTILE "
                 "during model parsing."
             )
-        elif (
-            aggregation_type is AggregationType.SUM_BOOLEAN
-            or aggregation_type is AggregationType.BOOLEAN
-            or aggregation_type is AggregationType.COUNT
-        ):
+        elif aggregation_type is AggregationType.SUM_BOOLEAN or aggregation_type is AggregationType.COUNT:
             raise RuntimeError(
                 f"Unhandled aggregation type {aggregation_type} - this should have been transformed to SUM "
                 "during model parsing."


### PR DESCRIPTION
resolves non-created issue

### Description

In dbt-semantic-interfaces, we removed `boolean` as an aggregation type because it was deprecated. 