### PR TITLE
Renaming MEASURE_PROXY to SIMPLE

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230517-105747.yaml
+++ b/.changes/unreleased/Breaking Changes-20230517-105747.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Renaming measure proxy metrics to simple metrics
+time: 2023-05-17T10:57:47.654235-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "0"

--- a/config-templates/salesforce/opportunities.yaml
+++ b/config-templates/salesforce/opportunities.yaml
@@ -63,7 +63,7 @@ metric:
   name: closed_won_opps
   owners:
     - support@transformdata.io
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - opps
@@ -75,7 +75,7 @@ metric:
   name: closed_won_amount
   owners:
     - support@transformdata.io
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - amount

--- a/metricflow/cli/sample_models/transactions.yaml
+++ b/metricflow/cli/sample_models/transactions.yaml
@@ -76,7 +76,7 @@ semantic_model:
 ---
 metric: 
   name: cancellations
-  type: measure_proxy 
+  type: simple 
   type_params:
     measure: cancellations_usd
 ---
@@ -99,7 +99,7 @@ metric:
 ---
 metric:
   name: cancellations_mx
-  type: measure_proxy 
+  type: simple 
   type_params:
     measure: cancellations_usd
   filter: |
@@ -107,7 +107,7 @@ metric:
 ---
 metric:
   name: transaction_usd_na
-  type: measure_proxy 
+  type: simple 
   type_params:
     measure: transaction_amount_usd
   filter: |

--- a/metricflow/model/dbt_mapping_rules/dbt_mapping_rule.py
+++ b/metricflow/model/dbt_mapping_rules/dbt_mapping_rule.py
@@ -63,12 +63,12 @@ def assert_essential_metric_properties(metric: MetricNode) -> None:
 
 
 CALC_METHOD_TO_METRIC_TYPE: Dict[str, MetricType] = {
-    "count": MetricType.MEASURE_PROXY,
-    "count_distinct": MetricType.MEASURE_PROXY,
-    "sum": MetricType.MEASURE_PROXY,
-    "average": MetricType.MEASURE_PROXY,
-    "min": MetricType.MEASURE_PROXY,
-    "max": MetricType.MEASURE_PROXY,
+    "count": MetricType.SIMPLE,
+    "count_distinct": MetricType.SIMPLE,
+    "sum": MetricType.SIMPLE,
+    "average": MetricType.SIMPLE,
+    "min": MetricType.SIMPLE,
+    "max": MetricType.SIMPLE,
     "derived": MetricType.DERIVED,
 }
 

--- a/metricflow/model/dbt_mapping_rules/dbt_metric_to_metrics_rules.py
+++ b/metricflow/model/dbt_mapping_rules/dbt_metric_to_metrics_rules.py
@@ -88,9 +88,9 @@ class DbtToMeasureProxyMetricTypeParams(DbtMappingRule):
         for metric in dbt_metrics:
             try:
                 assert_essential_metric_properties(metric=metric)
-                # We only do this for MEASURE_PROXY metrics
+                # We only do this for SIMPLE metrics
                 metric_type = get_and_assert_calc_method_mapping(dbt_metric=metric)
-                if metric_type == MetricType.MEASURE_PROXY:
+                if metric_type == MetricType.SIMPLE:
                     objects.metrics[metric.name]["type_params"] = MetricTypeParams(
                         measure=MetricInputMeasure(name=metric.name)
                     ).dict()

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -251,7 +251,7 @@ class DbtManifestTransformer:
         return Metric(
             name=dbt_metric.name,
             description=dbt_metric.description,
-            type=MetricType.MEASURE_PROXY,
+            type=MetricType.SIMPLE,
             type_params=MetricTypeParams(
                 measure=MetricInputMeasure(name=dbt_metric.name),
             ),

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -671,7 +671,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                         )
                     ),
                 )
-            elif metric.type is MetricType.MEASURE_PROXY:
+            elif metric.type is MetricType.SIMPLE:
                 if len(metric.input_measures) > 0:
                     assert (
                         len(metric.input_measures) == 1

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_metrics.yaml
@@ -2,7 +2,7 @@
 metric:
   name: bookings
   description: raw booking count
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - bookings
@@ -10,7 +10,7 @@ metric:
 metric:
   name: family_bookings
   description: Bookings of units with capacity for more than 2 people.
-  type: measure_proxy
+  type: simple
   filter:
     "{{ dimension('capacity', entity_path=['listing']) }} > 2"
   type_params:
@@ -20,7 +20,7 @@ metric:
 metric:
   name: potentially_lux_bookings
   description: raw booking count for listings that are lux, or unknown
-  type: measure_proxy
+  type: simple
   filter:
     "{{ dimension('is_lux', entity_path=['listing']) }} OR {{ dimension('is_lux', entity_path=['listing']) }} IS NULL"
   type_params:

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -2,7 +2,7 @@
 metric:
   name: "bookings"
   description: "bookings metric"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - bookings
@@ -10,7 +10,7 @@ metric:
 metric:
   name: "average_booking_value"
   description: "average booking value metric"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - average_booking_value
@@ -18,7 +18,7 @@ metric:
 metric:
   name: "instant_bookings"
   description: "instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - instant_bookings
@@ -26,7 +26,7 @@ metric:
 metric:
   name: "booking_value"
   description: "booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -34,7 +34,7 @@ metric:
 metric:
   name: "max_booking_value"
   description: "max booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - max_booking_value
@@ -42,7 +42,7 @@ metric:
 metric:
   name: "min_booking_value"
   description: "min booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - min_booking_value
@@ -50,7 +50,7 @@ metric:
 metric:
   name: "instant_booking_value"
   description: "booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -59,7 +59,7 @@ metric:
 metric:
   name: "average_instant_booking_value"
   description: "average booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - average_booking_value
@@ -68,7 +68,7 @@ metric:
 metric:
   name: "booking_value_for_non_null_listing_id"
   description: "booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -77,7 +77,7 @@ metric:
 metric:
   name: "bookers"
   description: "bookers"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - bookers
@@ -85,7 +85,7 @@ metric:
 metric:
   name: "booking_payments"
   description: "Booking payments."
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_payments
@@ -93,7 +93,7 @@ metric:
 metric:
   name: "views"
   description: "views"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - views
@@ -101,7 +101,7 @@ metric:
 metric:
   name: "listings"
   description: "listings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - listings
@@ -109,7 +109,7 @@ metric:
 metric:
   name: "lux_listings"
   description: "lux_listings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - listings
@@ -118,7 +118,7 @@ metric:
 metric:
   name: "smallest_listing"
   description: "smallest listing"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - smallest_listing
@@ -126,7 +126,7 @@ metric:
 metric:
   name: "largest_listing"
   description: "largest listing"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - largest_listing
@@ -134,7 +134,7 @@ metric:
 metric:
   name: "identity_verifications"
   description: "identity_verifications"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - identity_verifications
@@ -142,7 +142,7 @@ metric:
 metric:
   name: "revenue"
   description: "revenue"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - txn_revenue
@@ -246,7 +246,7 @@ metric:
 metric:
   name: "total_account_balance_first_day"
   description: "total_account_balance_first_day"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - total_account_balance_first_day
@@ -254,7 +254,7 @@ metric:
 metric:
   name: "current_account_balance_by_user"
   description: "current_account_balance_by_user"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - current_account_balance_by_user
@@ -345,7 +345,7 @@ metric:
 metric:
   name: "referred_bookings"
   description: "bookings made through a referral"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - referred_bookings
@@ -431,7 +431,7 @@ metric:
 metric:
   name: "median_booking_value"
   description: "median booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - median_booking_value
@@ -439,7 +439,7 @@ metric:
 metric:
   name: "booking_value_p99"
   description: "p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value_p99
@@ -447,7 +447,7 @@ metric:
 metric:
   name: "discrete_booking_value_p99"
   description: "discrete p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - discrete_booking_value_p99
@@ -455,7 +455,7 @@ metric:
 metric:
   name: "approximate_continuous_booking_value_p99"
   description: "approximate continuous p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - approximate_continuous_booking_value_p99
@@ -463,7 +463,7 @@ metric:
 metric:
   name: "approximate_discrete_booking_value_p99"
   description: "approximate discrete p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - approximate_discrete_booking_value_p99

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -203,8 +203,8 @@ integration_test:
     ON a.ds = b.ds
 ---
 integration_test:
-  name: min_measure_proxy
-  description: Test measure_proxy metric with a min.
+  name: min_simple
+  description: Test simple metric with a min.
   model: SIMPLE_MODEL
   metrics: ["min_booking_value"]
   group_bys: []
@@ -214,8 +214,8 @@ integration_test:
     FROM {{ source_schema }}.fct_bookings
 ---
 integration_test:
-  name: max_measure_proxy
-  description: Test measure_proxy metric with a max.
+  name: max_simple
+  description: Test simple metric with a max.
   model: SIMPLE_MODEL
   metrics: ["max_booking_value"]
   group_bys: []

--- a/metricflow/test/model/dbt_cloud_parsing/test_dbt_converter.py
+++ b/metricflow/test/model/dbt_cloud_parsing/test_dbt_converter.py
@@ -39,9 +39,9 @@ def test_for_breaking_model_changes(dbt_metrics: Tuple[MetricNode, ...]) -> None
             mf_metric.type is not None
         ), f"Metric `{mf_metric.name}` created from dbt metric `{dbt_metric.name}` is missing a `type`"
         assert mf_metric.type in [
-            MetricType.MEASURE_PROXY,
+            MetricType.SIMPLE,
             MetricType.DERIVED,
-        ], f"Metric `{mf_metric.name}` created from dbt metric `{dbt_metric.name}` is a type other than `MEASURE_PROXY` or `DERIVED`"
+        ], f"Metric `{mf_metric.name}` created from dbt metric `{dbt_metric.name}` is a type other than `SIMPLE` or `DERIVED`"
         assert (
             mf_metric.type_params is not None
         ), f"Metric `{mf_metric.name}` created from dbt metric `{dbt_metric.name}` is missing `type_params`"

--- a/metricflow/test/model/dbt_cloud_parsing/test_dbt_metric_to_metrics_rules.py
+++ b/metricflow/test/model/dbt_cloud_parsing/test_dbt_metric_to_metrics_rules.py
@@ -165,7 +165,7 @@ def test_dbt_to_derived_metric_type_params_requires_depends_on(dbt_metrics: Tupl
     ), f"DbtToDerivedMetricTypeParams didn't raise blocking issues when it should have: {issues.to_pretty_json()}"
 
 
-def test_dbt_to_measure_proxy_metric_type_params(dbt_metrics: Tuple[MetricNode, ...]) -> None:  # noqa: D
+def test_dbt_to_simple_metric_type_params(dbt_metrics: Tuple[MetricNode, ...]) -> None:  # noqa: D
     objects = MappedObjects()
     issues = DbtToMeasureProxyMetricTypeParams().run(dbt_metrics=dbt_metrics, objects=objects)
     assert (
@@ -187,7 +187,7 @@ def test_dbt_to_measure_proxy_metric_type_params(dbt_metrics: Tuple[MetricNode, 
             ), f"DbtToMeasureProxyMetricTypeParams created a metric type params for the non derived metirc `{dbt_metric.name}`"
 
 
-def test_dbt_to_measure_proxy_metric_type_params_requires_name(dbt_metrics: Tuple[MetricNode, ...]) -> None:  # noqa: D
+def test_dbt_to_simple_metric_type_params_requires_name(dbt_metrics: Tuple[MetricNode, ...]) -> None:  # noqa: D
     objects = MappedObjects()
     for dbt_metric in dbt_metrics:
         metric_type = get_and_assert_calc_method_mapping(dbt_metric=dbt_metric)


### PR DESCRIPTION
resolves Issue 7 in dbt_semantic_interfaces

### Description

This PR is not meant to be merged until Metricflow has cutover to relying on dbt-semantic-interfaces and the Simple metrics PR is merged there.
