### PR TITLE
Include the Source Semantic Model for Available Dimensions

### DIFF
--- a/metricflow/model/semantics/linkable_element_properties.py
+++ b/metricflow/model/semantics/linkable_element_properties.py
@@ -23,8 +23,6 @@ class LinkableElementProperties(Enum):
     DERIVED_TIME_GRANULARITY = "derived_time_granularity"
     # Refers to an entity, not a dimension.
     ENTITY = "entity"
-    # After an intersection operation.
-    INTERSECTED = "intersected"
 
     @staticmethod
     def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class JoinPathKey:
+class ElementPathKey:
     """A key that can uniquely identify an element and the joins used to realize the element."""
 
     element_name: str
@@ -50,8 +50,8 @@ class LinkableDimension:
     time_granularity: Optional[TimeGranularity] = None
 
     @property
-    def path_key(self) -> JoinPathKey:  # noqa: D
-        return JoinPathKey(
+    def path_key(self) -> ElementPathKey:  # noqa: D
+        return ElementPathKey(
             element_name=self.element_name,
             entity_links=self.entity_links,
             time_granularity=self.time_granularity,
@@ -68,8 +68,8 @@ class LinkableEntity:
     join_path: Tuple[SemanticModelJoinPathElement, ...]
 
     @property
-    def path_key(self) -> JoinPathKey:  # noqa: D
-        return JoinPathKey(element_name=self.element_name, entity_links=self.entity_links, time_granularity=None)
+    def path_key(self) -> ElementPathKey:  # noqa: D
+        return ElementPathKey(element_name=self.element_name, entity_links=self.entity_links, time_granularity=None)
 
 
 @dataclass(frozen=True)
@@ -90,8 +90,8 @@ class LinkableElementSet:
     #       semantic_model_origin="listings_latest_source",
     #   )
     # }
-    path_key_to_linkable_dimensions: Dict[JoinPathKey, Tuple[LinkableDimension, ...]]
-    path_key_to_linkable_entities: Dict[JoinPathKey, Tuple[LinkableEntity, ...]]
+    path_key_to_linkable_dimensions: Dict[ElementPathKey, Tuple[LinkableDimension, ...]]
+    path_key_to_linkable_entities: Dict[ElementPathKey, Tuple[LinkableEntity, ...]]
 
     @staticmethod
     def merge_by_path_key(linkable_element_sets: Sequence[LinkableElementSet]) -> LinkableElementSet:
@@ -99,8 +99,8 @@ class LinkableElementSet:
 
         If there are elements with the same join key, those elements will be categorized as ambiguous.
         """
-        key_to_linkable_dimensions: Dict[JoinPathKey, List[LinkableDimension]] = defaultdict(list)
-        key_to_linkable_entities: Dict[JoinPathKey, List[LinkableEntity]] = defaultdict(list)
+        key_to_linkable_dimensions: Dict[ElementPathKey, List[LinkableDimension]] = defaultdict(list)
+        key_to_linkable_entities: Dict[ElementPathKey, List[LinkableEntity]] = defaultdict(list)
 
         for linkable_element_set in linkable_element_sets:
             for path_key, linkable_dimensions in linkable_element_set.path_key_to_linkable_dimensions.items():
@@ -132,14 +132,14 @@ class LinkableElementSet:
             )
 
         # Find path keys that are common to all LinkableElementSets.
-        common_linkable_dimension_path_keys: Set[JoinPathKey] = set.intersection(
+        common_linkable_dimension_path_keys: Set[ElementPathKey] = set.intersection(
             *[
                 set(linkable_element_set.path_key_to_linkable_dimensions.keys())
                 for linkable_element_set in linkable_element_sets
             ]
         )
 
-        common_linkable_entity_path_keys: Set[JoinPathKey] = set.intersection(
+        common_linkable_entity_path_keys: Set[ElementPathKey] = set.intersection(
             *[
                 set(linkable_element_set.path_key_to_linkable_entities.keys())
                 for linkable_element_set in linkable_element_sets
@@ -147,8 +147,8 @@ class LinkableElementSet:
         )
 
         # Create a new LinkableElementSet that only includes items where the path key is common to all sets.
-        join_path_to_linkable_dimensions: Dict[JoinPathKey, List[LinkableDimension]] = defaultdict(list)
-        join_path_to_linkable_entities: Dict[JoinPathKey, List[LinkableEntity]] = defaultdict(list)
+        join_path_to_linkable_dimensions: Dict[ElementPathKey, List[LinkableDimension]] = defaultdict(list)
+        join_path_to_linkable_entities: Dict[ElementPathKey, List[LinkableEntity]] = defaultdict(list)
 
         for linkable_element_set in linkable_element_sets:
             for path_key, linkable_dimensions in linkable_element_set.path_key_to_linkable_dimensions.items():
@@ -176,8 +176,8 @@ class LinkableElementSet:
         a property in "without_any_of" set are removed.
         """
 
-        key_to_linkable_dimensions: Dict[JoinPathKey, Tuple[LinkableDimension, ...]] = {}
-        key_to_linkable_entities: Dict[JoinPathKey, Tuple[LinkableEntity, ...]] = {}
+        key_to_linkable_dimensions: Dict[ElementPathKey, Tuple[LinkableDimension, ...]] = {}
+        key_to_linkable_entities: Dict[ElementPathKey, Tuple[LinkableEntity, ...]] = {}
 
         for path_key, linkable_dimensions in self.path_key_to_linkable_dimensions.items():
             filtered_linkable_dimensions = tuple(

--- a/metricflow/model/semantics/metric_lookup.py
+++ b/metricflow/model/semantics/metric_lookup.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import MetricReference
 from metricflow.errors.errors import MetricNotFoundError, DuplicateMetricError, NonExistentMeasureError
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
-from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
+from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver, LinkableElementSet
 from metricflow.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HOPS
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.protocols.semantics import MetricAccessor
@@ -54,6 +54,19 @@ class MetricLookup(MetricAccessor):  # noqa: D
         ).as_spec_set
 
         return sorted(all_linkable_specs.as_tuple, key=lambda x: x.qualified_name)
+
+    def linkable_set_for_metrics(
+        self,
+        metric_references: Sequence[MetricReference],
+        with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
+        without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
+    ) -> LinkableElementSet:
+        """Similar to element_specs_for_metrics(), but as a set with more context."""
+        return self._linkable_spec_resolver.get_linkable_elements_for_metrics(
+            metric_references=metric_references,
+            with_any_of=with_any_property,
+            without_any_of=without_any_property,
+        )
 
     def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:  # noqa: D
         res = []

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -102,7 +102,7 @@ class SemanticModelAccessor(ABC):
 
     @abstractmethod
     def get_by_reference(self, semantic_model_reference: SemanticModelReference) -> Optional[SemanticModel]:
-        """Retrieve the semantic model model object matching the input semantic model reference, if any"""
+        """Retrieve the semantic model object matching the input semantic model reference, if any"""
         raise NotImplementedError
 
     @property


### PR DESCRIPTION
### Description

This PR exposes a way to get the semantic model where a dimension was defined when listing the available dimensions for a metric. This feature is for internal developers.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)