### PR TITLE
Dedupe Items Returned By ValidLinkableSpecResolver.get_linkable_elements_for_metrics()

### DIFF
--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -149,23 +149,34 @@ class LinkableElementSet:
         )
 
         # Create a new LinkableElementSet that only includes items where the path key is common to all sets.
-        join_path_to_linkable_dimensions: Dict[ElementPathKey, List[LinkableDimension]] = defaultdict(list)
-        join_path_to_linkable_entities: Dict[ElementPathKey, List[LinkableEntity]] = defaultdict(list)
+        join_path_to_linkable_dimensions: Dict[ElementPathKey, Set[LinkableDimension]] = defaultdict(set)
+        join_path_to_linkable_entities: Dict[ElementPathKey, Set[LinkableEntity]] = defaultdict(set)
 
         for linkable_element_set in linkable_element_sets:
             for path_key, linkable_dimensions in linkable_element_set.path_key_to_linkable_dimensions.items():
                 if path_key in common_linkable_dimension_path_keys:
-                    join_path_to_linkable_dimensions[path_key].extend(linkable_dimensions)
+                    join_path_to_linkable_dimensions[path_key].update(linkable_dimensions)
             for path_key, linkable_entities in linkable_element_set.path_key_to_linkable_entities.items():
                 if path_key in common_linkable_entity_path_keys:
-                    join_path_to_linkable_entities[path_key].extend(linkable_entities)
+                    join_path_to_linkable_entities[path_key].update(linkable_entities)
 
         return LinkableElementSet(
             path_key_to_linkable_dimensions={
-                path_key: tuple(dimensions) for path_key, dimensions in join_path_to_linkable_dimensions.items()
+                path_key: tuple(
+                    sorted(
+                        dimensions,
+                        key=lambda linkable_dimension: linkable_dimension.semantic_model_origin.semantic_model_name,
+                    )
+                )
+                for path_key, dimensions in join_path_to_linkable_dimensions.items()
             },
             path_key_to_linkable_entities={
-                path_key: tuple(entities) for path_key, entities in join_path_to_linkable_entities.items()
+                path_key: tuple(
+                    sorted(
+                        entities, key=lambda linkable_entity: linkable_entity.semantic_model_origin.semantic_model_name
+                    )
+                )
+                for path_key, entities in join_path_to_linkable_entities.items()
             },
         )
 

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -62,6 +62,8 @@ class LinkableDimension:
 class LinkableEntity:
     """Describes how an entity can be realized by joining based on entity links."""
 
+    # The semantic model where this entity was defined.
+    semantic_model_origin: SemanticModelReference
     element_name: str
     properties: FrozenSet[LinkableElementProperties]
     entity_links: Tuple[str, ...]
@@ -348,6 +350,7 @@ class SemanticModelJoinPath:
             if entity.reference.element_name != entity_links[-1]:
                 linkable_entities.append(
                     LinkableEntity(
+                        semantic_model_origin=semantic_model.reference,
                         element_name=entity.reference.element_name,
                         entity_links=entity_links,
                         join_path=self.path_elements,
@@ -467,6 +470,7 @@ class ValidLinkableSpecResolver:
         for entity in semantic_model.entities:
             linkable_entities.append(
                 LinkableEntity(
+                    semantic_model_origin=semantic_model.reference,
                     element_name=entity.reference.element_name,
                     entity_links=(),
                     join_path=(),

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -242,3 +242,91 @@ def test_linkable_set(metric_lookup: MetricLookup) -> None:  # noqa: D
         (("user",), "home_state", "users_ds_source"),
         (("user",), "home_state_latest", "users_latest"),
     ]
+
+
+def test_linkable_set_for_common_dimensions_in_different_models(metric_lookup: MetricLookup) -> None:  # noqa: D
+    """Tests case where a metric has dimensions with the same path.
+
+    In this example, "ds" is defined in both "bookings_source" and "views_source".
+    """
+    linkable_set = metric_lookup.linkable_set_for_metrics(
+        (MetricReference(element_name="bookings_per_view"),),
+        without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
+    )
+
+    result_to_compare = sorted(
+        tuple(
+            (
+                # Checking a limited set of fields as the result is large due to the paths in the object.
+                linkable_dimension.entity_links,
+                linkable_dimension.element_name,
+                linkable_dimension.semantic_model_origin.semantic_model_name,
+                # Abbreviated version of the join path.
+                tuple(
+                    join_path_element.semantic_model_reference.semantic_model_name
+                    for join_path_element in linkable_dimension.join_path
+                ),
+            )
+            for linkable_dimensions in linkable_set.path_key_to_linkable_dimensions.values()
+            for linkable_dimension in linkable_dimensions
+        )
+    )
+
+    assert result_to_compare == [
+        ((), "ds", "bookings_source", ()),
+        ((), "ds", "views_source", ()),
+        ((), "ds_partitioned", "bookings_source", ()),
+        ((), "ds_partitioned", "views_source", ()),
+        (("create_a_cycle_in_the_join_graph",), "booking_paid_at", "bookings_source", ()),
+        (("create_a_cycle_in_the_join_graph",), "booking_paid_at", "bookings_source", ()),
+        (("create_a_cycle_in_the_join_graph",), "is_instant", "bookings_source", ()),
+        (("create_a_cycle_in_the_join_graph",), "is_instant", "bookings_source", ("bookings_source",)),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "capacity_latest",
+            "listings_latest",
+            ("bookings_source", "listings_latest"),
+        ),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "capacity_latest",
+            "listings_latest",
+            ("views_source", "listings_latest"),
+        ),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "country_latest",
+            "listings_latest",
+            ("bookings_source", "listings_latest"),
+        ),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "country_latest",
+            "listings_latest",
+            ("views_source", "listings_latest"),
+        ),
+        (("create_a_cycle_in_the_join_graph", "listing"), "created_at", "listings_latest", ()),
+        (("create_a_cycle_in_the_join_graph", "listing"), "ds", "listings_latest", ()),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "is_lux_latest",
+            "listings_latest",
+            ("bookings_source", "listings_latest"),
+        ),
+        (
+            ("create_a_cycle_in_the_join_graph", "listing"),
+            "is_lux_latest",
+            "listings_latest",
+            ("views_source", "listings_latest"),
+        ),
+        (("listing",), "capacity_latest", "listings_latest", ("listings_latest",)),
+        (("listing",), "country_latest", "listings_latest", ("listings_latest",)),
+        (("listing",), "created_at", "listings_latest", ()),
+        (("listing",), "ds", "listings_latest", ()),
+        (("listing",), "is_lux_latest", "listings_latest", ("listings_latest",)),
+        (("listing", "user"), "company_name", "companies", ("listings_latest", "companies")),
+        (("listing", "user"), "created_at", "users_ds_source", ()),
+        (("listing", "user"), "ds_partitioned", "users_ds_source", ()),
+        (("listing", "user"), "home_state", "users_ds_source", ("listings_latest", "users_ds_source")),
+        (("listing", "user"), "home_state_latest", "users_latest", ("listings_latest", "users_latest")),
+    ]


### PR DESCRIPTION
### Description

This PR updates `ValidLinkableSpecResolver.get_linkable_elements_for_metrics()` to dedupe results in cases where there is a common path to get the same dimension from multiple measures of a metric.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)