### PR TITLE
Hide 3rd party library deprecation warnings

### DIFF
--- a/metricflow/specs/column_assoc.py
+++ b/metricflow/specs/column_assoc.py
@@ -16,7 +16,7 @@ class SingleColumnCorrelationKey(ColumnCorrelationKey, SerializableDataclass):
     """Key to use when there's only 1 column association in an instance."""
 
     # Pydantic throws an error during serialization if a dataclass has no fields.
-    __PYDANTIC_BUG_WORKAROUND: bool = True
+    PYDANTIC_BUG_WORKAROUND: bool = True
 
     def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
         return isinstance(other, SingleColumnCorrelationKey)

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import _pytest.config
 import pytest
 from _pytest.fixtures import FixtureRequest
+import sqlalchemy.util
 
 from metricflow.configuration.env_var import EnvironmentVariable
 from metricflow.random_id import random_id
@@ -137,3 +138,11 @@ def mf_test_session_state(  # noqa: D
             request.config.getoption(USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG, default=False)
         ),
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_sql_alchemy_deprecation_warning() -> None:
+    """Since MF is tied to using SQLAlchemy 1.x.x due to the Snowflake connector, silence 2.0 deprecation warnings."""
+
+    # Seeing 'error: Module has no attribute "SILENCE_UBER_WARNING"' in the type checker, but this seems to work.
+    sqlalchemy.util.deprecations.SILENCE_UBER_WARNING = True  # type:ignore

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -33,7 +33,7 @@ def create_context_with_counts(rows: int, distinct: int, nulls: int) -> DataWare
     )
 
 
-class TestLowCardinalityRule(LowCardinalityRatioRule):  # noqa: D
+class ExampleLowCardinalityRule(LowCardinalityRatioRule):  # noqa: D
     type_node = InferenceSignalType.DIMENSION.CATEGORICAL
     confidence = InferenceSignalConfidence.MEDIUM
     only_applies_to_parent_signal = False
@@ -60,7 +60,7 @@ def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext) -> None:  
 
 
 def test_low_cardinality_ratio_rule_high_cardinality_doesnt_match() -> None:  # noqa: D
-    rule = TestLowCardinalityRule(0.1)
+    rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 100, 0)
 
     signals = rule.process(ctx)
@@ -68,7 +68,7 @@ def test_low_cardinality_ratio_rule_high_cardinality_doesnt_match() -> None:  # 
 
 
 def test_low_cardinality_ratio_rule_low_cardinality_lots_of_nulls_doesnt_match() -> None:  # noqa: D
-    rule = TestLowCardinalityRule(0.1)
+    rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 2, 99)
 
     signals = rule.process(ctx)
@@ -76,7 +76,7 @@ def test_low_cardinality_ratio_rule_low_cardinality_lots_of_nulls_doesnt_match()
 
 
 def test_low_cardinality_ratio_rule_low_cardinality_all_nulls_doesnt_match() -> None:  # noqa: D
-    rule = TestLowCardinalityRule(0.1)
+    rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 1, 100)
 
     signals = rule.process(ctx)
@@ -84,7 +84,7 @@ def test_low_cardinality_ratio_rule_low_cardinality_all_nulls_doesnt_match() -> 
 
 
 def test_low_cardinality_ratio_rule_low_cardinality_matches() -> None:  # noqa: D
-    rule = TestLowCardinalityRule(0.1)
+    rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 1, 0)
 
     signals = rule.process(ctx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,12 @@ force-exclude = '''
   )/
 )
 '''
+
+# Many deprecation warnings come from 3rd-party libraries and make the
+# output of pytest noisy. Since no action is going to be taken, hide those
+# warnings.
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Deprecated call to.*",
+    "ignore:pkg_resources is deprecated as an API"
+]


### PR DESCRIPTION
### Description

This PR hides deprecation warnings that come from the 3rd party libraries that are used by MF and show up as noise in the output of `pytest`.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)