### PR TITLE
Fix type signatures for log_call decorator

### DIFF
--- a/.changes/unreleased/Fixes-20230523-164125.yaml
+++ b/.changes/unreleased/Fixes-20230523-164125.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix broken type signature for log_call decorator
+time: 2023-05-23T16:41:25.095233-07:00
+custom:
+  Author: tlento
+  Issue: None

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         verbose: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy # configured via mypy.ini
-    rev: v0.942
+    rev: v1.3.0
     hooks:
       - id: mypy
         name: mypy_metricflow

--- a/metricflow/telemetry/reporter.py
+++ b/metricflow/telemetry/reporter.py
@@ -8,8 +8,8 @@ import time
 import traceback
 import uuid
 from hashlib import sha256
-from typing import Callable, Optional, Any
-from typing import List
+from typing import Callable, List, Optional, TypeVar
+from typing_extensions import ParamSpec
 
 from metricflow.configuration.config_handler import ConfigHandler
 from metricflow.configuration.constants import CONFIG_EMAIL
@@ -121,7 +121,11 @@ class TelemetryReporter:
                 )
 
 
-def log_call(telemetry_reporter: TelemetryReporter, module_name: str) -> Callable[..., Any]:  # type: ignore[misc]
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def log_call(telemetry_reporter: TelemetryReporter, module_name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator to make it easier to log telemetry for function calls.
 
     Using module_name instead of introspection since it seems more robust.
@@ -134,9 +138,9 @@ def log_call(telemetry_reporter: TelemetryReporter, module_name: str) -> Callabl
 
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
-        def wrapped(*args, **kwargs) -> Callable:  # type: ignore
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
             # Not every Callable has a __name__
             function_name = getattr(func, "__name__", repr(func))
             invocation_id = f"call_{random_id()}"


### PR DESCRIPTION
The original implementation of the log_call decorator returned an
object of type Callable[..., Any] because the version of mypy we
were using at the time did not support parameter binding correctly.

This resulted in implicit Any typing for every method wrapped with
this decorator, which means mypy would not catch errors with input
parameters. For example, the MetricFlowEngine.query() method is
typed to accept a single parameter, but callers could pass in any
combination of parameters without a typechecking error because
the `query` method was wrapped in a decorator that converted it from
it's original signature to Callable[..., Any].

Now that we are up to date on mypy, we can follow the typing guide
for decorators (or, as in this case, decorator factories) to
ensure the wrapped function types remain consistent.
