### PR TITLE
Fix broken publish action

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -22,8 +22,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Hatch Publish
-        run: hatch publish
+        run: hatch build && hatch publish
         env:
           HATCH_INDEX_USER: transform_data
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
-


### PR DESCRIPTION
Hatch publish doesn't have a "build and publish" mode so we have
to update the action to do both.

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)