### PR TITLE
Roll pre-release version number back to 0.200.0.dev2 from 0.200.1.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow"
-version = "0.200.1.dev1"
+version = "0.200.0.dev2"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
 requires-python = ">=3.8,<3.10"


### PR DESCRIPTION
Somehow or other we ended up in 0.200.1. This rolls us back to
0.200.0 as our base version, and pushes the dev build up to the next
version mark.

The downside of this is 0.200.1.dev1 is no longer a usable version
number, but we can contend with that if we come to it. Given
MetricFlow's current state of development it's unlikely we'll need
to roll multiple dev builds on patch releases, so this seems like
the right trade.
