### PR TITLE
duplicate input_measures property to engine.model.Metric

### DIFF
--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.objects.elements.dimension import (
 from dbt_semantic_interfaces.objects.filters.where_filter import WhereFilter
 from dbt_semantic_interfaces.objects.metadata import Metadata
 from dbt_semantic_interfaces.objects.metric import Metric as SemanticManifestMetric
-from dbt_semantic_interfaces.objects.metric import MetricType, MetricTypeParams
+from dbt_semantic_interfaces.objects.metric import MetricInputMeasure, MetricType, MetricTypeParams
 
 from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
 from metricflow.specs.specs import DimensionSpec, EntityReference
@@ -43,6 +43,19 @@ class Metric:
             metadata=pydantic_metric.metadata,
             dimensions=dimensions,
         )
+
+    @property
+    def input_measures(self) -> List[MetricInputMeasure]:
+        """Return the complete list of input measure configurations for this metric."""
+        type_params = self.type_params
+        measures = type_params.measures or []
+        if type_params.measure:
+            measures.append(type_params.measure)
+        if type_params.numerator:
+            measures.append(type_params.numerator)
+        if type_params.denominator:
+            measures.append(type_params.denominator)
+        return measures
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
In the DSI implementation of Metric, we populated all the measures associated with the Metric via a property called `input_measures` this is useful and also needed in the public facing object `engine.model.Metric`. So duplicating that logic over to that.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)