### PR TITLE
Get dimension values via SQL

### DIFF
--- a/.changes/unreleased/Under the Hood-20230605-145703.yaml
+++ b/.changes/unreleased/Under the Hood-20230605-145703.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Enable the ability to return only dimensions requested in the query, specifically
+  used for dimension values queries.
+time: 2023-06-05T14:57:03.614589-04:00
+custom:
+  Author: WilliamDee
+  Issue: None

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -141,7 +141,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         self,
         query_spec: MetricFlowQuerySpec,
         output_sql_table: Optional[SqlTable] = None,
-        filter_column_spec_set: Optional[InstanceSpecSet] = None,
+        output_selection_specs: Optional[InstanceSpecSet] = None,
         optimizers: Sequence[DataflowPlanOptimizer[SqlDataSetT]] = (),
     ) -> DataflowPlan[SqlDataSetT]:
         """Generate a plan for reading the results of a query with the given spec into a dataframe or table."""
@@ -157,7 +157,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             order_by_specs=query_spec.order_by_specs,
             output_sql_table=output_sql_table,
             limit=query_spec.limit,
-            filter_by_specs=filter_column_spec_set,
+            output_selection_specs=output_selection_specs,
         )
 
         plan_id = IdGeneratorRegistry.for_class(DataflowPlanBuilder).create_id(DATAFLOW_PLAN_PREFIX)
@@ -333,7 +333,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         order_by_specs: Sequence[OrderBySpec],
         output_sql_table: Optional[SqlTable] = None,
         limit: Optional[int] = None,
-        filter_by_specs: Optional[InstanceSpecSet] = None,
+        output_selection_specs: Optional[InstanceSpecSet] = None,
     ) -> SinkOutput[SqlDataSetT]:
         """Adds order by / limit / write nodes."""
         pre_result_node: Optional[BaseOutput[SqlDataSetT]] = None
@@ -345,10 +345,10 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                 parent_node=computed_metrics_output,
             )
 
-        if filter_by_specs:
+        if output_selection_specs:
             pre_result_node = FilterElementsNode(
                 parent_node=pre_result_node or computed_metrics_output,
-                include_specs=filter_by_specs,
+                include_specs=output_selection_specs,
             )
 
         write_result_node: SinkOutput[SqlDataSetT]

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Optional, Sequence
 
 import pandas as pd
@@ -77,6 +78,13 @@ class MetricFlowRequestId:
     mf_rid: str
 
 
+class MetricFlowQueryType(Enum):
+    """An enum to designate what type of MetricFlow query it is."""
+
+    METRIC = "metric"
+    DIMENSION_VALUES = "dimension_values"
+
+
 @dataclass(frozen=True)
 class MetricFlowQueryRequest:
     """Encapsulates the parameters for a metric query.
@@ -90,6 +98,7 @@ class MetricFlowQueryRequest:
     order_by_names: metric and group by names to order by. A "-" can be used to specify reverse order e.g. "-ds"
     output_table: If specified, output the result data to this table instead of a result dataframe.
     sql_optimization_level: The level of optimization for the generated SQL.
+    query_type: Type of MetricFlow query.
     """
 
     request_id: MetricFlowRequestId
@@ -102,6 +111,7 @@ class MetricFlowQueryRequest:
     order_by_names: Optional[Sequence[str]] = None
     output_table: Optional[str] = None
     sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4
+    query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
 
     @staticmethod
     def create_with_random_request_id(  # noqa: D
@@ -114,6 +124,7 @@ class MetricFlowQueryRequest:
         order_by_names: Optional[Sequence[str]] = None,
         output_table: Optional[str] = None,
         sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
+        query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
     ) -> MetricFlowQueryRequest:
         return MetricFlowQueryRequest(
             request_id=MetricFlowRequestId(mf_rid=f"{random_id()}"),
@@ -126,6 +137,7 @@ class MetricFlowQueryRequest:
             order_by_names=order_by_names,
             output_table=output_table,
             sql_optimization_level=sql_optimization_level,
+            query_type=query_type,
         )
 
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -54,6 +54,7 @@ from metricflow.plan_conversion.dataflow_to_execution import (
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource, TimeSpineTableBuilder
 from metricflow.protocols.async_sql_client import AsyncSqlClient
+from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.random_id import random_id
 from metricflow.specs.column_assoc import ColumnAssociationResolver
@@ -452,6 +453,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         output_selection_specs: Optional[InstanceSpecSet] = None
         if mf_query_request.query_type == MetricFlowQueryType.DIMENSION_VALUES:
             # Filter result by dimension columns if it's a dimension values query
+            if len(query_spec.entity_specs) > 0:
+                raise InvalidQueryException("Querying dimension values for entities is not allowed.")
             output_selection_specs = InstanceSpecSet(
                 dimension_specs=query_spec.dimension_specs,
                 time_dimension_specs=query_spec.time_dimension_specs,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
There needs to be a way to get dimension values via SQL instead of needing to make a metric query and then process the dimension values in python. In this PR, we introduce a new field to a MetricFlowQueryRequest (that is yet to be surfaced via the CLI/public interfaces). This field is `query_type` which is an enum used to determine whether the query is a metric/dim_vals query. Currently, metric query is how every query works now and dimension values query will basically return ONLY the dimensions requested in the query without the metric data.


<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)