### PR TITLE
Add support for query tags and isolation in main query and execute methods

### DIFF
--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -90,6 +90,8 @@ class SqlClient(Protocol):
         self,
         stmt: str,
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> DataFrame:
         """Base query method, upon execution will run a query that returns a pandas DataFrame."""
         raise NotImplementedError
@@ -99,6 +101,8 @@ class SqlClient(Protocol):
         self,
         stmt: str,
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> None:
         """Base execute method."""
         raise NotImplementedError


### PR DESCRIPTION
Previously, support for query tags and isolation level were only available
in the AsyncSqlClient protocol. As part of the streamlining effort we will
be consolidating the async_query and query methods, so we add support
for these features to the base query methods in order to be able to
remove the async variations.