### PR TITLE
Specific error for unsupported data platform feature

### DIFF
--- a/.changes/unreleased/Under the Hood-20230608-130409.yaml
+++ b/.changes/unreleased/Under the Hood-20230608-130409.yaml
@@ -1,7 +1,0 @@
-kind: Under the Hood
-body: Change the generic RuntimeError to be a BigQueryApproximatePercentileError when
-  using percentile expressions with BigQuery
-time: 2023-06-08T13:04:09.342061-05:00
-custom:
-  Author: DevonFulcher
-  Issue: None

--- a/.changes/unreleased/Under the Hood-20230608-130409.yaml
+++ b/.changes/unreleased/Under the Hood-20230608-130409.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Change the generic RuntimeError to be a BigQueryApproximatePercentileError when
+  using percentile expressions with BigQuery
+time: 2023-06-08T13:04:09.342061-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/.changes/unreleased/Under the Hood-20230608-135447.yaml
+++ b/.changes/unreleased/Under the Hood-20230608-135447.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Raising a UnsupportedEngineFeatureError instead of a generic RuntimeError when
+  a data platform doesn't support a feature
+time: 2023-06-08T13:54:47.478597-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -80,3 +80,12 @@ class ModelCreationException(Exception):
 
 class InferenceError(Exception):
     """Exception to represent errors related to inference."""
+
+class BigQueryApproximatePercentileError(Exception):
+    """Raised when percentile aggregations are used without approximation for BigQuery."""
+
+    def __init__(self) -> None:  # noqa: D
+        super().__init__(
+            "Only approximate continous percentile aggregations are supported for BigQuery. Set "
+            + "use_approximate_percentile and disable use_discrete_percentile in all percentile measures.",
+        )

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -81,6 +81,7 @@ class ModelCreationException(Exception):
 class InferenceError(Exception):
     """Exception to represent errors related to inference."""
 
+
 class BigQueryApproximatePercentileError(RuntimeError):
     """Raised when percentile aggregations are used without approximation for BigQuery."""
 

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -82,11 +82,5 @@ class InferenceError(Exception):
     """Exception to represent errors related to inference."""
 
 
-class BigQueryApproximatePercentileError(RuntimeError):
-    """Raised when percentile aggregations are used without approximation for BigQuery."""
-
-    def __init__(self) -> None:  # noqa: D
-        super().__init__(
-            "Only approximate continous percentile aggregations are supported for BigQuery. Set "
-            + "use_approximate_percentile and disable use_discrete_percentile in all percentile measures.",
-        )
+class UnsupportedEngineFeatureError(RuntimeError):
+    """Raised when the user attempts to use a feature that isn't supported by the data platform."""

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -81,7 +81,7 @@ class ModelCreationException(Exception):
 class InferenceError(Exception):
     """Exception to represent errors related to inference."""
 
-class BigQueryApproximatePercentileError(Exception):
+class BigQueryApproximatePercentileError(RuntimeError):
     """Raised when percentile aggregations are used without approximation for BigQuery."""
 
     def __init__(self) -> None:  # noqa: D

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -4,6 +4,7 @@ from fractions import Fraction
 
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
+from metricflow.errors.errors import BigQueryApproximatePercentileError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -20,7 +21,7 @@ from metricflow.sql.sql_exprs import (
     SqlTimeDeltaExpression,
 )
 from metricflow.sql.sql_plan import SqlSelectColumn
-from metricflow.errors.errors import BigQueryApproximatePercentileError
+
 
 class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the BigQuery engine."""

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
-from metricflow.errors.errors import BigQueryApproximatePercentileError
+from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -66,7 +66,10 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
                 sql=f"APPROX_QUANTILES({arg_rendered.sql}, {fraction.denominator})[OFFSET({fraction.numerator})]",
                 bind_parameters=params,
             )
-        raise BigQueryApproximatePercentileError()
+        raise UnsupportedEngineFeatureError(
+            "Only approximate continous percentile aggregations are supported for BigQuery. Set "
+            + "use_approximate_percentile and disable use_discrete_percentile in all percentile measures."
+        )
 
     def visit_cast_to_timestamp_expr(self, node: SqlCastToTimestampExpression) -> SqlExpressionRenderResult:
         """Casts the time value expression to DATETIME, as per standard BigQuery preferences."""

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -20,7 +20,7 @@ from metricflow.sql.sql_exprs import (
     SqlTimeDeltaExpression,
 )
 from metricflow.sql.sql_plan import SqlSelectColumn
-
+from metricflow.errors.errors import BigQueryApproximatePercentileError
 
 class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the BigQuery engine."""
@@ -65,10 +65,7 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
                 sql=f"APPROX_QUANTILES({arg_rendered.sql}, {fraction.denominator})[OFFSET({fraction.numerator})]",
                 bind_parameters=params,
             )
-        raise RuntimeError(
-            "Only approximate continous percentile aggregations are supported for BigQuery. Set "
-            + "use_approximate_percentile and disable use_discrete_percentile in all percentile measures."
-        )
+        raise BigQueryApproximatePercentileError()
 
     def visit_cast_to_timestamp_expr(self, node: SqlCastToTimestampExpression) -> SqlExpressionRenderResult:
         """Casts the time value expression to DATETIME, as per standard BigQuery preferences."""

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 
+from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -24,12 +25,12 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             function_str = "PERCENTILE_CONT"
         elif node.percentile_args.function_type is SqlPercentileFunctionType.DISCRETE:
             # discrete percentile only supported on databricks 11.0 >=. Disable for now.
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Discrete percentile aggregate not supported for Databricks.  Use "
                 + "continuous or approximate discrete percentile in all percentile measures."
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Approximate continuous percentile aggregate not supported for Databricks. Use "
                 + "continuous or approximate discrete percentile in all percentile measures."
             )

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
+from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -61,12 +62,12 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         elif node.percentile_args.function_type is SqlPercentileFunctionType.DISCRETE:
             function_str = "PERCENTILE_DISC"
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Approximate continuous percentile aggregate not supported for Postgres. Set "
                 + "use_approximate_percentile to false in all percentile measures."
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_DISCRETE:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Approximate discrete percentile aggregate not supported for Postgres. Set "
                 + "use_approximate_percentile to false in all percentile measures."
             )

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 
+from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -29,12 +30,12 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         if node.percentile_args.function_type is SqlPercentileFunctionType.CONTINUOUS:
             function_str = "PERCENTILE_CONT"
         elif node.percentile_args.function_type is SqlPercentileFunctionType.DISCRETE:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Discrete percentile aggregate not supported for Redshift. Use "
                 + "continuous or approximate discrete percentile in all percentile measures."
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Approximate continuous percentile aggregate not supported for Redshift. Use "
                 + "continuous or approximate discrete percentile in all percentile measures."
             )

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 
+from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
     SqlExpressionRenderer,
@@ -37,7 +38,7 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
                 bind_parameters=params,
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_DISCRETE:
-            raise RuntimeError(
+            raise UnsupportedEngineFeatureError(
                 "Approximate discrete percentile aggregate not supported for Snowflake. Set "
                 + "use_discrete_percentile and/or use_approximate_percentile to false in all percentile measures."
             )


### PR DESCRIPTION
### Description

This PR replaces a generic `RuntimeError` for a more specific exception, `UnsupportedEngineFeatureError`. This makes it easier for clients to handle this exception. I ran the unit tests locally, but other than that I didn't do much testing.