### PR TITLE
Remove dependency on PydanticSemanticManifest on validations

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.validations.validator_helpers import SemanticManifestValidationResults
 
@@ -54,7 +54,7 @@ class MetricFlowClient:
     def __init__(
         self,
         sql_client: SqlClient,
-        semantic_manifest: PydanticSemanticManifest,
+        semantic_manifest: SemanticManifest,
         system_schema: str,
     ):
         """Initializer for MetricFlowClient.
@@ -235,4 +235,4 @@ class MetricFlowClient:
         Returns:
             Tuple of validation issues with the model provided.
         """
-        return SemanticManifestValidator[PydanticSemanticManifest]().validate_semantic_manifest(self.semantic_manifest)
+        return SemanticManifestValidator[SemanticManifest]().validate_semantic_manifest(self.semantic_manifest)

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -4,7 +4,7 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 from typing import Dict, Optional
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 
 from metricflow.configuration.config_handler import ConfigHandler
 from metricflow.configuration.constants import (
@@ -27,7 +27,7 @@ class CLIContext:
         self.verbose = False
         self._mf: Optional[MetricFlowEngine] = None
         self._sql_client: Optional[SqlClient] = None
-        self._semantic_manifest: Optional[PydanticSemanticManifest] = None
+        self._semantic_manifest: Optional[SemanticManifest] = None
         self._semantic_manifest_lookup: Optional[SemanticManifestLookup] = None
         self._mf_system_schema: Optional[str] = None
         self.config = ConfigHandler()
@@ -110,7 +110,7 @@ class CLIContext:
         return self._semantic_manifest_lookup
 
     @property
-    def semantic_manifest(self) -> PydanticSemanticManifest:  # noqa: D
+    def semantic_manifest(self) -> SemanticManifest:  # noqa: D
         if self._semantic_manifest is None:
             self._semantic_manifest = build_semantic_manifest_from_config(self.config)
 

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -14,7 +14,7 @@ from typing import Callable, List, Optional
 import click
 import jinja2
 import pandas as pd
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.validations.validator_helpers import SemanticManifestValidationResults
 from halo import Halo
@@ -580,9 +580,9 @@ def _print_issues(
 
 
 def _run_dw_validations(
-    validation_func: Callable[[PydanticSemanticManifest, Optional[int]], SemanticManifestValidationResults],
+    validation_func: Callable[[SemanticManifest, Optional[int]], SemanticManifestValidationResults],
     validation_type: str,
-    model: PydanticSemanticManifest,
+    model: SemanticManifest,
     timeout: Optional[int],
 ) -> SemanticManifestValidationResults:
     """Helper handles the calling of data warehouse issue generating functions."""
@@ -600,7 +600,7 @@ def _run_dw_validations(
 
 
 def _data_warehouse_validations_runner(
-    dw_validator: DataWarehouseModelValidator, model: PydanticSemanticManifest, timeout: Optional[int]
+    dw_validator: DataWarehouseModelValidator, model: SemanticManifest, timeout: Optional[int]
 ) -> SemanticManifestValidationResults:
     """Helper which calls the individual data warehouse validations to run and prints collected issues."""
     semantic_model_results = _run_dw_validations(
@@ -682,7 +682,7 @@ def validate_configs(
     # Semantic validation
     semantic_spinner = Halo(text="Validating semantics of built model", spinner="dots")
     semantic_spinner.start()
-    model_issues = SemanticManifestValidator[PydanticSemanticManifest](
+    model_issues = SemanticManifestValidator[SemanticManifest](
         max_workers=semantic_validation_workers
     ).validate_semantic_manifest(user_model)
 

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -582,14 +582,14 @@ def _print_issues(
 def _run_dw_validations(
     validation_func: Callable[[SemanticManifest, Optional[int]], SemanticManifestValidationResults],
     validation_type: str,
-    model: SemanticManifest,
+    manifest: SemanticManifest,
     timeout: Optional[int],
 ) -> SemanticManifestValidationResults:
     """Helper handles the calling of data warehouse issue generating functions."""
     spinner = Halo(text=f"Validating {validation_type} against data warehouse...", spinner="dots")
     spinner.start()
 
-    results = validation_func(model, timeout)
+    results = validation_func(manifest, timeout)
     if not results.has_blocking_issues:
         spinner.succeed(f"🎉 Successfully validated {validation_type} against data warehouse ({results.summary()})")
     else:
@@ -600,23 +600,23 @@ def _run_dw_validations(
 
 
 def _data_warehouse_validations_runner(
-    dw_validator: DataWarehouseModelValidator, model: SemanticManifest, timeout: Optional[int]
+    dw_validator: DataWarehouseModelValidator, manifest: SemanticManifest, timeout: Optional[int]
 ) -> SemanticManifestValidationResults:
     """Helper which calls the individual data warehouse validations to run and prints collected issues."""
     semantic_model_results = _run_dw_validations(
-        dw_validator.validate_semantic_models, model=model, validation_type="semantic models", timeout=timeout
+        dw_validator.validate_semantic_models, manifest=manifest, validation_type="semantic models", timeout=timeout
     )
     dimension_results = _run_dw_validations(
-        dw_validator.validate_dimensions, model=model, validation_type="dimensions", timeout=timeout
+        dw_validator.validate_dimensions, manifest=manifest, validation_type="dimensions", timeout=timeout
     )
     entity_results = _run_dw_validations(
-        dw_validator.validate_entities, model=model, validation_type="entities", timeout=timeout
+        dw_validator.validate_entities, manifest=manifest, validation_type="entities", timeout=timeout
     )
     measure_results = _run_dw_validations(
-        dw_validator.validate_measures, model=model, validation_type="measures", timeout=timeout
+        dw_validator.validate_measures, manifest=manifest, validation_type="measures", timeout=timeout
     )
     metric_results = _run_dw_validations(
-        dw_validator.validate_metrics, model=model, validation_type="metrics", timeout=timeout
+        dw_validator.validate_metrics, manifest=manifest, validation_type="metrics", timeout=timeout
     )
 
     return SemanticManifestValidationResults.merge(
@@ -677,14 +677,14 @@ def validate_configs(
         _print_issues(parsing_result.issues, show_non_blocking=show_all, verbose=verbose_issues)
         return
 
-    user_model = parsing_result.semantic_manifest
+    semantic_manifest = parsing_result.semantic_manifest
 
     # Semantic validation
     semantic_spinner = Halo(text="Validating semantics of built model", spinner="dots")
     semantic_spinner.start()
     model_issues = SemanticManifestValidator[SemanticManifest](
         max_workers=semantic_validation_workers
-    ).validate_semantic_manifest(user_model)
+    ).validate_semantic_manifest(semantic_manifest)
 
     if not model_issues.has_blocking_issues:
         semantic_spinner.succeed(f"🎉 Successfully validated the semantics of built model ({model_issues.summary()})")
@@ -698,7 +698,9 @@ def validate_configs(
     dw_results = SemanticManifestValidationResults()
     if not skip_dw:
         dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, system_schema=cfg.mf_system_schema)
-        dw_results = _data_warehouse_validations_runner(dw_validator=dw_validator, model=user_model, timeout=dw_timeout)
+        dw_results = _data_warehouse_validations_runner(
+            dw_validator=dw_validator, manifest=semantic_manifest, timeout=dw_timeout
+        )
 
     merged_results = SemanticManifestValidationResults.merge([parsing_result.issues, model_issues, dw_results])
     _print_issues(merged_results, show_non_blocking=show_all, verbose=verbose_issues)

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -41,6 +41,7 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.model.semantics.linkable_element_properties import (
     LinkableElementProperties,
 )
+from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_execution import (
     DataflowToExecutionPlanConverter,
@@ -509,14 +510,15 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             linkable_dimensions_tuple,
         ) in path_key_to_linkable_dimensions.items():
             for linkable_dimension in linkable_dimensions_tuple:
-                semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
+                semantic_model = semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
                     linkable_dimension.semantic_model_origin
                 )
                 assert semantic_model
                 dimensions.append(
                     Dimension.from_pydantic(
-                        pydantic_dimension=semantic_model.get_dimension(
-                            DimensionReference(element_name=linkable_dimension.element_name)
+                        pydantic_dimension=SemanticModelLookup.get_dimension_from_semantic_model(
+                            semantic_model=semantic_model,
+                            dimension_reference=DimensionReference(element_name=linkable_dimension.element_name),
                         ),
                         path_key=path_key,
                     )
@@ -547,8 +549,9 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 assert semantic_model
                 entities.append(
                     Entity.from_pydantic(
-                        pydantic_entity=semantic_model.get_entity(
-                            EntityReference(element_name=linkable_entity.element_name)
+                        pydantic_entity=SemanticModelLookup.get_entity_from_semantic_model(
+                            semantic_model=semantic_model,
+                            entity_reference=EntityReference(element_name=linkable_entity.element_name),
                         )
                     )
                 )

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -510,7 +510,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             linkable_dimensions_tuple,
         ) in path_key_to_linkable_dimensions.items():
             for linkable_dimension in linkable_dimensions_tuple:
-                semantic_model = semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
+                semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
                     linkable_dimension.semantic_model_origin
                 )
                 assert semantic_model

--- a/metricflow/engine/utils.py
+++ b/metricflow/engine/utils.py
@@ -4,11 +4,11 @@ import datetime as dt
 from typing import Optional
 
 from dateutil.parser import parse
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     SemanticManifestBuildResult,
     parse_directory_of_yaml_files_to_semantic_manifest,
 )
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 
 from metricflow.configuration.constants import CONFIG_MODEL_PATH
 from metricflow.configuration.yaml_handler import YamlFileHandler
@@ -42,7 +42,7 @@ def model_build_result_from_config(
         raise ModelCreationException from e
 
 
-def build_semantic_manifest_from_config(handler: YamlFileHandler) -> PydanticSemanticManifest:
+def build_semantic_manifest_from_config(handler: YamlFileHandler) -> SemanticManifest:
     """Given a yaml file, create a SemanticManifest."""
     return model_build_result_from_config(handler=handler).semantic_manifest
 

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -59,7 +59,7 @@ class QueryRenderingTools:
     time_spine_source: TimeSpineSource
     plan_converter: DataflowToSqlQueryPlanConverter
 
-    def __init__(self, model: PydanticSemanticManifest, system_schema: str) -> None:  # noqa: D
+    def __init__(self, model: SemanticManifest, system_schema: str) -> None:  # noqa: D
         self.semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest=model)
         self.source_node_builder = SourceNodeBuilder(semantic_manifest_lookup=self.semantic_manifest_lookup)
         self.time_spine_source = TimeSpineSource(schema_name=system_schema)
@@ -134,7 +134,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_semantic_model_tasks(
-        cls, model: PydanticSemanticManifest, sql_client: SqlClient, system_schema: str
+        cls, model: SemanticManifest, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the semantic models of the model."""
         tasks: List[DataWarehouseValidationTask] = []
@@ -159,7 +159,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_dimension_tasks(
-        cls, model: PydanticSemanticManifest, sql_client: SqlClient, system_schema: str
+        cls, model: SemanticManifest, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the dimensions of the model.
 
@@ -258,7 +258,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_entity_tasks(
-        cls, model: PydanticSemanticManifest, sql_client: SqlClient, system_schema: str
+        cls, model: SemanticManifest, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the entities of the model.
 
@@ -332,7 +332,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_measure_tasks(
-        cls, model: PydanticSemanticManifest, sql_client: SqlClient, system_schema: str
+        cls, model: SemanticManifest, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the measures of the model.
 
@@ -430,7 +430,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_metric_tasks(
-        cls, model: PydanticSemanticManifest, sql_client: SqlClient, system_schema: str
+        cls, model: SemanticManifest, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the model."""
         mf_engine = MetricFlowEngine(
@@ -514,7 +514,7 @@ class DataWarehouseModelValidator:
         return SemanticManifestValidationResults.from_issues_sequence(issues)
 
     def validate_semantic_models(
-        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
+        self, model: SemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the semantic models of the model and then runs them.
 
@@ -531,7 +531,7 @@ class DataWarehouseModelValidator:
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_dimensions(
-        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
+        self, model: SemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the dimensions of the model and then runs them.
 
@@ -548,7 +548,7 @@ class DataWarehouseModelValidator:
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_entities(
-        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
+        self, model: SemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the entities of the model and then runs them.
 
@@ -565,7 +565,7 @@ class DataWarehouseModelValidator:
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_measures(
-        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
+        self, model: SemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the measures of the model and then runs them.
 
@@ -582,7 +582,7 @@ class DataWarehouseModelValidator:
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_metrics(
-        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
+        self, model: SemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the metrics of the model and then runs them.
 

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -11,7 +11,6 @@ from typing import Callable, DefaultDict, Dict, List, Optional, Sequence, Tuple,
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
-from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.protocols.dimension import DimensionType
 from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
@@ -539,7 +538,7 @@ class DataWarehouseModelValidator:
         return SemanticManifestValidationResults.from_issues_sequence(issues)
 
     def validate_semantic_models(
-        self, model: PydanticSemanticModel, timeout: Optional[int] = None
+        self, model: PydanticSemanticManifest, timeout: Optional[int] = None
     ) -> SemanticManifestValidationResults:
         """Generates a list of tasks for validating the semantic models of the model and then runs them.
 

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 
 from metricflow.model.semantics.metric_lookup import MetricLookup
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
@@ -10,13 +10,13 @@ from metricflow.protocols.semantics import SemanticModelAccessor
 class SemanticManifestLookup:
     """Adds semantics information to the user configured model."""
 
-    def __init__(self, semantic_manifest: PydanticSemanticManifest) -> None:  # noqa: D
+    def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
         self._semantic_manifest = semantic_manifest
         self._semantic_model_lookup = SemanticModelLookup(semantic_manifest)
         self._metric_lookup = MetricLookup(self._semantic_manifest, self._semantic_model_lookup)
 
     @property
-    def semantic_manifest(self) -> PydanticSemanticManifest:  # noqa: D
+    def semantic_manifest(self) -> SemanticManifest:  # noqa: D
         return self._semantic_manifest
 
     @property

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -5,11 +5,11 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import Dict, List, Optional, Sequence, Set
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     DimensionReference,
@@ -40,7 +40,7 @@ class SemanticModelLookup(SemanticModelAccessor):
 
     def __init__(  # noqa: D
         self,
-        model: PydanticSemanticManifest,
+        model: SemanticManifest,
     ) -> None:
         self._model = model
         self._measure_index: Dict[MeasureReference, List[PydanticSemanticModel]] = defaultdict(list)

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import Dict, List, Optional, Sequence, Set
 
-from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
@@ -43,15 +43,15 @@ class SemanticModelLookup(SemanticModelAccessor):
         model: SemanticManifest,
     ) -> None:
         self._model = model
-        self._measure_index: Dict[MeasureReference, List[PydanticSemanticModel]] = defaultdict(list)
+        self._measure_index: Dict[MeasureReference, List[SemanticModel]] = defaultdict(list)
         self._measure_aggs: Dict[
             MeasureReference, AggregationType
         ] = {}  # maps measures to their one consistent aggregation
         self._measure_agg_time_dimension: Dict[MeasureReference, TimeDimensionReference] = {}
         self._measure_non_additive_dimension_specs: Dict[MeasureReference, NonAdditiveDimensionSpec] = {}
-        self._dimension_index: Dict[DimensionReference, List[PydanticSemanticModel]] = defaultdict(list)
-        self._linkable_reference_index: Dict[LinkableElementReference, List[PydanticSemanticModel]] = defaultdict(list)
-        self._entity_index: Dict[Optional[str], List[PydanticSemanticModel]] = defaultdict(list)
+        self._dimension_index: Dict[DimensionReference, List[SemanticModel]] = defaultdict(list)
+        self._linkable_reference_index: Dict[LinkableElementReference, List[SemanticModel]] = defaultdict(list)
+        self._entity_index: Dict[Optional[str], List[SemanticModel]] = defaultdict(list)
         self._entity_ref_to_entity: Dict[EntityReference, Optional[str]] = {}
         self._semantic_model_names: Set[str] = set()
 
@@ -59,7 +59,7 @@ class SemanticModelLookup(SemanticModelAccessor):
             SemanticModelReference, ElementGrouper[TimeDimensionReference, MeasureSpec]
         ] = {}
 
-        self._semantic_model_reference_to_semantic_model: Dict[SemanticModelReference, PydanticSemanticModel] = {}
+        self._semantic_model_reference_to_semantic_model: Dict[SemanticModelReference, SemanticModel] = {}
         for semantic_model in self._model.semantic_models:
             self._add_semantic_model(semantic_model)
 
@@ -116,7 +116,7 @@ class SemanticModelLookup(SemanticModelAccessor):
     # DSC interface
     def get_semantic_models_for_measure(  # noqa: D
         self, measure_reference: MeasureReference
-    ) -> Sequence[PydanticSemanticModel]:
+    ) -> Sequence[SemanticModel]:
         return self._measure_index[measure_reference]
 
     def get_agg_time_dimension_for_measure(  # noqa: D
@@ -137,10 +137,10 @@ class SemanticModelLookup(SemanticModelAccessor):
 
     def get_by_reference(  # noqa: D
         self, semantic_model_reference: SemanticModelReference
-    ) -> Optional[PydanticSemanticModel]:
+    ) -> Optional[SemanticModel]:
         return self._semantic_model_reference_to_semantic_model.get(semantic_model_reference)
 
-    def _add_semantic_model(self, semantic_model: PydanticSemanticModel) -> None:
+    def _add_semantic_model(self, semantic_model: SemanticModel) -> None:
         """Add semantic model semantic information, validating consistency with existing semantic models."""
         errors = []
 

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -67,7 +67,7 @@ class SemanticModelLookup(SemanticModelAccessor):
 
     @staticmethod
     def get_dimension_from_semantic_model(
-        semantic_model: SemanticModel, dimension_reference: DimensionReference
+        semantic_model: SemanticModel, dimension_reference: LinkableElementReference
     ) -> Dimension:
         """Get dimension from semantic model."""
         for dim in semantic_model.dimensions:
@@ -231,3 +231,16 @@ class SemanticModelLookup(SemanticModelAccessor):
         """Return all semantic models associated with an entity reference."""
         entity = self._entity_ref_to_entity[entity_reference]
         return set(self._entity_index[entity])
+
+    @staticmethod
+    def get_entity_from_semantic_model(
+        semantic_model: SemanticModel, entity_reference: LinkableElementReference
+    ) -> Entity:
+        """Get entity from semantic model."""
+        for entity in semantic_model.entities:
+            if entity.reference == entity_reference:
+                return entity
+
+        raise ValueError(
+            f"No entity with name ({entity_reference}) in semantic_model with name ({semantic_model.name})"
+        )

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Dict, FrozenSet, Optional, Sequence, Set
 
-from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
@@ -103,7 +102,7 @@ class SemanticModelAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_by_reference(self, semantic_model_reference: SemanticModelReference) -> Optional[PydanticSemanticModel]:
+    def get_by_reference(self, semantic_model_reference: SemanticModelReference) -> Optional[SemanticModel]:
         """Retrieve the semantic model object matching the input semantic model reference, if any."""
         raise NotImplementedError
 

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -5,8 +5,8 @@ import pathlib
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.parsing.dir_to_model import parse_directory_of_yaml_files_to_semantic_manifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationResults,
@@ -179,7 +179,7 @@ def test_build_tutorial_model(cli_runner: MetricFlowCliRunner) -> None:  # noqa:
     )
     assert model_build_result.issues.has_blocking_issues is False
 
-    SemanticManifestValidator[PydanticSemanticManifest]().checked_validations(model_build_result.semantic_manifest)
+    SemanticManifestValidator[SemanticManifest]().checked_validations(model_build_result.semantic_manifest)
 
 
 def test_list_entities(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 import click
 import pytest
 from click.testing import CliRunner, Result
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.test_utils import as_datetime
 
 from metricflow.cli.cli_context import CLIContext
@@ -21,7 +21,7 @@ from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 @pytest.fixture
 def cli_context(  # noqa: D
     sql_client: SqlClient,
-    simple_semantic_manifest: PydanticSemanticManifest,
+    simple_semantic_manifest: SemanticManifest,
     time_spine_source: TimeSpineSource,
     mf_test_session_state: MetricFlowTestSessionState,
     create_source_tables: bool,

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Sequence
 
 import pytest
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_directory_of_yaml_files_to_semantic_manifest,
     parse_yaml_files_to_validation_ready_semantic_manifest,
@@ -64,9 +63,7 @@ def query_parser_from_yaml(
             yaml_contents, apply_transformations=True
         ).semantic_manifest
     )
-    SemanticManifestValidator[PydanticSemanticManifest]().checked_validations(
-        semantic_manifest_lookup.semantic_manifest
-    )
+    SemanticManifestValidator[SemanticManifest]().checked_validations(semantic_manifest_lookup.semantic_manifest)
     source_nodes = _data_set_to_source_nodes(semantic_manifest_lookup, create_data_sets(semantic_manifest_lookup))
     return MetricFlowQueryParser(
         model=semantic_manifest_lookup,
@@ -235,7 +232,7 @@ def scd_semantic_manifest_lookup(template_mapping: Dict[str, str]) -> SemanticMa
 
 
 @pytest.fixture(scope="session")
-def data_warehouse_validation_model(template_mapping: Dict[str, str]) -> PydanticSemanticManifest:
+def data_warehouse_validation_model(template_mapping: Dict[str, str]) -> SemanticManifest:
     """Model used for data warehouse validation tests."""
     build_result = parse_directory_of_yaml_files_to_semantic_manifest(
         os.path.join(os.path.dirname(__file__), "model_yamls/data_warehouse_validation_model"),

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -48,7 +48,7 @@ def test_build_semantic_model_tasks(  # noqa:D
     sql_client: SqlClient,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(
-        model=data_warehouse_validation_model,
+        manifest=data_warehouse_validation_model,
         sql_client=sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
@@ -116,7 +116,7 @@ def test_build_dimension_tasks(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
-        model=data_warehouse_validation_model,
+        manifest=data_warehouse_validation_model,
         sql_client=sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
@@ -156,7 +156,7 @@ def test_build_entities_tasks(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_entity_tasks(
-        model=data_warehouse_validation_model,
+        manifest=data_warehouse_validation_model,
         sql_client=sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
@@ -194,7 +194,7 @@ def test_build_measure_tasks(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
-        model=data_warehouse_validation_model,
+        manifest=data_warehouse_validation_model,
         sql_client=sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
@@ -233,7 +233,7 @@ def test_build_metric_tasks(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
-        model=data_warehouse_validation_model,
+        manifest=data_warehouse_validation_model,
         system_schema=mf_test_session_state.mf_system_schema,
         sql_client=sql_client,
     )

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 import pytest
-from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference, MeasureReference, MetricReference
 
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def semantic_model_lookup(simple_semantic_manifest: PydanticSemanticManifest) -> SemanticModelLookup:  # Noqa: D
+def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> SemanticModelLookup:  # Noqa: D
     return SemanticModelLookup(
         model=simple_semantic_manifest,
     )
@@ -22,7 +22,7 @@ def semantic_model_lookup(simple_semantic_manifest: PydanticSemanticManifest) ->
 
 @pytest.fixture
 def metric_lookup(  # Noqa: D
-    simple_semantic_manifest: PydanticSemanticManifest, semantic_model_lookup: SemanticModelLookup
+    simple_semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
 ) -> MetricLookup:
     return MetricLookup(semantic_manifest=simple_semantic_manifest, semantic_model_lookup=semantic_model_lookup)
 


### PR DESCRIPTION
resolves #587

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Refactored the semanticmodel validation to use hardcode SQL query instead of creating a dummy dimension and rendering SQL to query that. This removes the need to mutate the `SemanticManifest` which allows us to remove the pydantic object. Similarly, remove the pydantic dependency for the remaining objects in the Lookup classes.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)