### PR TITLE
Remove introspective queries and on the fly creation of time spine tables

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230613-115512.yaml
+++ b/.changes/unreleased/Breaking Changes-20230613-115512.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: Remove time spine introspection and table creation, which may break cumulative
+  metric queries
+time: 2023-06-13T11:55:12.601662-07:00
+custom:
+  Author: tlento
+  Issue: "592"

--- a/metricflow/plan_conversion/time_spine.py
+++ b/metricflow/plan_conversion/time_spine.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-import datetime
 import logging
-import threading
 from dataclasses import dataclass
-from typing import List, Tuple
 
-import pandas as pd
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.filters.time_constraint import TimeRangeConstraint
-from metricflow.protocols.sql_client import SqlClient
-from metricflow.time.time_constants import ISO8601_PYTHON_FORMAT
 
 logger = logging.getLogger(__name__)
 
@@ -32,78 +25,3 @@ class TimeSpineSource:
     def spine_table(self) -> SqlTable:
         """Table containing all dates."""
         return SqlTable(schema_name=self.schema_name, table_name=self.table_name)
-
-
-class TimeSpineTableBuilder:
-    """Helps to build the time spine table based on the definition in a TimeSpineSource."""
-
-    def __init__(  # noqa: D
-        self,
-        time_spine_source: TimeSpineSource,
-        sql_client: SqlClient,
-    ) -> None:
-        self._time_spine_source = time_spine_source
-        self._sql_client = sql_client
-        self._verified_spine_table_exists = False
-        self._create_table_lock = threading.Lock()
-
-    @property
-    def time_spine_source(self) -> TimeSpineSource:  # noqa: D
-        return self._time_spine_source
-
-    def create_if_necessary(self) -> None:  # noqa: D
-        """Creates the spine table if it doesn't already exist."""
-        logger.info("Waiting to get the lock for the time spine table")
-        with self._create_table_lock:
-            spine_table = self.time_spine_source.spine_table
-            logger.info("Got the lock for the time spine table")
-            if self._verified_spine_table_exists:
-                logger.info(f"Previously verified that the spine table {spine_table.sql} exists.")
-                return
-            logger.info(f"Checking if the spine table {spine_table.sql} exists")
-            if self._sql_client.table_exists(spine_table):
-                logger.info(f"Spine table {spine_table.sql} exists")
-                self._verified_spine_table_exists = True
-                return
-            logger.info(f"Spine table {spine_table.sql} does not exist")
-            start_date = TimeRangeConstraint.ALL_TIME_BEGIN()
-            end_date = TimeRangeConstraint.ALL_TIME_END()
-
-            current_date = start_date
-            # Using a union type throws a type error for some reason, so going with this approach
-            date_spine_table_datetime_data: List[Tuple[datetime.datetime]] = []
-            date_spine_table_str_data: List[Tuple[str]] = []
-
-            if self.time_spine_source.time_column_granularity != TimeGranularity.DAY:
-                raise RuntimeError(
-                    f"A time spine source with a granularity {self.time_spine_source.time_column_granularity} is not "
-                    f"yet supported."
-                )
-
-            if self._sql_client.sql_engine_attributes.timestamp_type_supported:
-                while current_date <= end_date:
-                    date_spine_table_datetime_data.append((current_date,))
-                    current_date = current_date + datetime.timedelta(days=1)
-            else:
-                while current_date <= end_date:
-                    date_spine_table_str_data.append((current_date.strftime(ISO8601_PYTHON_FORMAT),))
-                    current_date = current_date + datetime.timedelta(days=1)
-
-            self._sql_client.drop_table(spine_table)
-            num_rows = (
-                len(date_spine_table_datetime_data)
-                if date_spine_table_datetime_data
-                else len(date_spine_table_str_data)
-            )
-
-            logger.info(f"Creating date spine table {spine_table.sql} with {num_rows} rows")
-            self._sql_client.create_table_from_dataframe(
-                sql_table=spine_table,
-                df=pd.DataFrame(
-                    columns=[self._time_spine_source.time_column_name],
-                    data=date_spine_table_datetime_data or date_spine_table_str_data,
-                ),
-                chunk_size=1000,
-            )
-            logger.info(f"Created date spine table {spine_table.sql}")
-            self._verified_spine_table_exists = True

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -29,6 +29,7 @@ from metricflow.cli.main import (
 from metricflow.cli.tutorial import (
     COUNTRIES_TABLE,
     CUSTOMERS_TABLE,
+    TIME_SPINE_TABLE,
     TRANSACTIONS_TABLE,
 )
 from metricflow.test.fixtures.cli_fixtures import MetricFlowCliRunner
@@ -158,12 +159,15 @@ def test_tutorial(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 
     pathlib.Path(cli_context.config.file_path).touch()
     resp = cli_runner.run(tutorial, args=["--skip-dw"])
-    assert "Attempting to generate model configs to your local filesystem in" in resp.output
+    assert (
+        "Attempting to generate model configs to your local filesystem in" in resp.output
+    ), f"Unexpected output: {resp.output}"
 
     table_names = cli_context.sql_client.list_tables(schema_name=cli_context.mf_system_schema)
     assert CUSTOMERS_TABLE in table_names
     assert TRANSACTIONS_TABLE in table_names
     assert COUNTRIES_TABLE in table_names
+    assert TIME_SPINE_TABLE in table_names
 
 
 def test_build_tutorial_model(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D

--- a/metricflow/test/fixtures/dataflow_fixtures.py
+++ b/metricflow/test/fixtures/dataflow_fixtures.py
@@ -7,7 +7,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
-from metricflow.plan_conversion.time_spine import TimeSpineSource, TimeSpineTableBuilder
+from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
@@ -83,7 +83,4 @@ def scd_dataflow_plan_builder(  # noqa: D
 def time_spine_source(  # noqa: D
     sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState  # noqa: F811
 ) -> TimeSpineSource:
-    time_spine_source = TimeSpineSource(schema_name=mf_test_session_state.mf_system_schema)
-    time_spine_table_builder = TimeSpineTableBuilder(time_spine_source=time_spine_source, sql_client=sql_client)
-    time_spine_table_builder.create_if_necessary()
-    return time_spine_source
+    return TimeSpineSource(schema_name=mf_test_session_state.mf_system_schema)

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -4,11 +4,9 @@ import logging
 import os
 from pathlib import Path
 
-import pandas as pd
 import pytest
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 
-from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.table_snapshot.table_snapshots import (
@@ -17,18 +15,6 @@ from metricflow.test.table_snapshot.table_snapshots import (
 )
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_DS = "ds"
-
-
-def create_table(sql_client: SqlClient, sql_table: SqlTable, df: pd.DataFrame) -> None:  # noqa: D
-    # TODO: Replace with table_exists() check.
-    sql_client.drop_table(sql_table)
-
-    sql_client.create_table_from_dataframe(
-        sql_table=sql_table,
-        df=df,
-    )
 
 
 @pytest.fixture(scope="session")

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 from pathlib import Path
+from typing import List, Tuple
 
+import pandas as pd
 import pytest
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 
+from metricflow.filters.time_constraint import TimeRangeConstraint
+from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotRepository,
     SqlTableSnapshotRestorer,
 )
+from metricflow.time.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +33,15 @@ def create_source_tables(
     mf_test_session_state: MetricFlowTestSessionState,
     sql_client: SqlClient,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
+    time_spine_source: TimeSpineSource,
 ) -> None:
     """Creates all tables that should be in the source schema.
 
     If a table with a given name already exists in the source schema, it's assumed to have the expected schema / data.
     """
+    # TODO: consolidate time spine operations with the rest of the table creation configuration
+    _create_time_spine_table_if_necessary(time_spine_source=time_spine_source, local_sql_client=sql_client)
+
     schema_name = mf_test_session_state.mf_source_schema
     # Figure out which tables are missing from the source schema.
     expected_table_names = sorted(
@@ -55,3 +65,34 @@ def create_source_tables(
         if table_snapshot.table_name in missing_table_names:
             logger.info(f"Restoring: {table_snapshot.table_name}")
             snapshot_restorer.restore(table_snapshot)
+
+
+def _create_time_spine_table_if_necessary(time_spine_source: TimeSpineSource, local_sql_client: SqlClient) -> None:
+    """Creates a time spine table for the given time spine source.
+
+    Note this covers a broader-than-necessary time range to ensure test updates work as expected.
+    """
+    if local_sql_client.table_exists(time_spine_source.spine_table):
+        return
+    assert (
+        time_spine_source.time_column_granularity is TimeGranularity.DAY
+    ), f"A time granularity of {time_spine_source.time_column_granularity} is not yet supported."
+    current_period = TimeRangeConstraint.ALL_TIME_BEGIN()
+    # Using a union type throws a type error for some reason, so going with this approach
+    time_spine_table_data: List[Tuple[datetime.datetime]] = []
+
+    while current_period <= TimeRangeConstraint.ALL_TIME_END():
+        time_spine_table_data.append((current_period,))
+        current_period = current_period + datetime.timedelta(days=1)
+
+    local_sql_client.drop_table(time_spine_source.spine_table)
+    len(time_spine_table_data)
+
+    local_sql_client.create_table_from_dataframe(
+        sql_table=time_spine_source.spine_table,
+        df=pd.DataFrame(
+            columns=[time_spine_source.time_column_name],
+            data=time_spine_table_data,
+        ),
+        chunk_size=1000,
+    )


### PR DESCRIPTION
MetricFlow uses a time spine table under certain conditions,
such as when cumulative metric computations require us to fill
in missing dates.

The existing time spine logic would, at query planning time, run
some introspective queries to determine if the time spine table
existed, and create one spanning a range from 2000 to 2040.

MetricFlow is moving away from managing this internally. In order
to accelerate our initial integration with dbt, we will remove
this custom introspection and table creation logic from the
MetricFlow runtime.

This will effectively break any cumulative or date offset metrics
in any data warehouse that does not have a pre-existing time
spine data set matching the default MetricFlow configuration (i.e.,
with a sequence of daily granularity dates stored in a column called
`ds` in a table called `mf_time_spine`). We will add the ability for
users to define their own time spine datasets and configure their
MetricFlow execution accordingly in follow-ups.

resolves #592