### PR TITLE
Eliminate engine attribute structs from SqlClient protocol

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230614-173609.yaml
+++ b/.changes/unreleased/Breaking Changes-20230614-173609.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: Remove SqlEngineAttributes construct from SqlClient interface in favor of dialect
+  rendering and engine type properties
+time: 2023-06-14T17:36:09.827638-07:00
+custom:
+  Author: tlento
+  Issue: "577"

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -113,7 +113,7 @@ class CLIContext:
                     err_string = str(e)
                     logger.error(f"Health Check Item {step}: failed with error {err_string}")
 
-                results[f"{self.sql_client.sql_engine_attributes.sql_engine_type} - {step}"] = {
+                results[f"{self.sql_client.sql_engine_type} - {step}"] = {
                     "status": status,
                     "error_message": err_string,
                 }

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -358,7 +358,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
         self._to_execution_plan_converter = DataflowToExecutionPlanConverter[SemanticModelDataSet](
             sql_plan_converter=self._to_sql_query_plan_converter,
-            sql_plan_renderer=self._sql_client.sql_engine_attributes.sql_query_plan_renderer,
+            sql_plan_renderer=self._sql_client.sql_query_plan_renderer,
             sql_client=sql_client,
         )
         self._executor = SequentialPlanExecutor()

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -128,12 +128,12 @@ class DataWarehouseTaskBuilder:
     ) -> Tuple[str, SqlBindParameters]:
         """Generates a sql query plan and returns the rendered sql and bind_parameters."""
         sql_plan = plan_converter.convert_to_sql_query_plan(
-            sql_engine_attributes=sql_client.sql_engine_attributes,
+            sql_engine_type=sql_client.sql_engine_type,
             sql_query_plan_id=plan_id,
             dataflow_plan_node=nodes,
         )
 
-        rendered_plan = sql_client.sql_engine_attributes.sql_query_plan_renderer.render_sql_query_plan(sql_plan)
+        rendered_plan = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_plan)
         return (rendered_plan.sql, rendered_plan.bind_parameters)
 
     @classmethod

--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -59,7 +59,7 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
         output_table: Optional[SqlTable] = None,
     ) -> ExecutionPlan:
         sql_plan = self._sql_plan_converter.convert_to_sql_query_plan(
-            sql_engine_attributes=self._sql_client.sql_engine_attributes,
+            sql_engine_type=self._sql_client.sql_engine_type,
             sql_query_plan_id=IdGeneratorRegistry.for_class(SqlQueryPlan).create_id(SQL_QUERY_PLAN_PREFIX),
             dataflow_plan_node=node,
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -70,7 +70,7 @@ from metricflow.plan_conversion.sql_join_builder import (
     SqlQueryPlanJoinBuilder,
 )
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.specs.column_assoc import ColumnAssociation, ColumnAssociationResolver, SingleColumnCorrelationKey
 from metricflow.specs.specs import (
     MeasureSpec,
@@ -1061,7 +1061,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
 
     def convert_to_sql_query_plan(
         self,
-        sql_engine_attributes: SqlEngineAttributes,
+        sql_engine_type: SqlEngine,
         sql_query_plan_id: str,
         dataflow_plan_node: Union[BaseOutput, ComputedMetricsOutput],
         optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
@@ -1071,7 +1071,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
 
         # TODO: Make this a more generally accessible attribute instead of checking against the
         # BigQuery-ness of the engine
-        use_column_alias_in_group_by = sql_engine_attributes.sql_engine_type is SqlEngine.BIGQUERY
+        use_column_alias_in_group_by = sql_engine_type is SqlEngine.BIGQUERY
 
         for optimizer in SqlQueryOptimizerConfiguration.optimizers_for_level(
             optimization_level, use_column_alias_in_group_by=use_column_alias_in_group_by

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from enum import Enum
-from typing import ClassVar, Optional, Protocol, Sequence
+from typing import Optional, Protocol, Sequence
 
 from pandas import DataFrame
 
@@ -31,12 +31,17 @@ class SqlClient(Protocol):
 
     @property
     @abstractmethod
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Return a struct of engine-specific metadata.
+    def sql_engine_type(self) -> SqlEngine:
+        """Enumerated value representing the underlying SqlEngine for this SqlClient instance."""
+        raise NotImplementedError
 
-        See documentation on SqlEngineAttributes for details. This property is configured as a tagged
-        method rather than a simple property because defining it as a simple property makes it settable,
-        and we should not be re-using SqlClient instances with different SqlEngineAttributes.
+    @property
+    @abstractmethod
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        """Dialect-specific SQL query plan renderer used for converting MetricFlow's query plan to executable SQL.
+
+        This is bundled with the SqlClient partly as a convenenience for accessing a single instance of the renderer,
+        and partly due to the close relationship between dialect and engine capabilities.
         """
         raise NotImplementedError
 
@@ -119,19 +124,3 @@ class SqlClient(Protocol):
     def render_bind_parameter_key(self, bind_parameter_key: str) -> str:
         """Wrap the bind parameter key with syntax accepted by engine."""
         raise NotImplementedError
-
-
-class SqlEngineAttributes(Protocol):
-    """Base interface for SQL engine-specific attributes and features.
-
-    Concrete implementations would typically be the equivalent of frozen dataclass literals, one per
-    MetricFlowSupportedDBEngine, as we would not expect these properties to change from one client to the next.
-
-    Concrete implementations SHOULD NOT inherit from this protocol, as the typechecker may not catch issues
-    caused by changes to the protocol itself when inheritance is used.
-    """
-
-    sql_engine_type: ClassVar[SqlEngine]
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer]

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -133,11 +133,5 @@ class SqlEngineAttributes(Protocol):
 
     sql_engine_type: ClassVar[SqlEngine]
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool]
-    discrete_percentile_aggregation_supported: ClassVar[bool]
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool]
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool]
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer]

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -139,10 +139,5 @@ class SqlEngineAttributes(Protocol):
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool]
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool]
 
-    # SQL Dialect replacement strings
-    # TODO: Move these to rendering classes
-    double_data_type_name: ClassVar[str]
-    timestamp_type_name: ClassVar[Optional[str]]
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer]

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Collection
+
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from typing_extensions import override
 
 from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
@@ -14,6 +17,11 @@ from metricflow.sql.sql_exprs import SqlPercentileExpression, SqlPercentileFunct
 
 class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the Databricks engine."""
+
+    @property
+    @override
+    def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
+        return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.APPROXIMATE_DISCRETE}
 
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Databricks."""

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -23,6 +23,7 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
         return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.APPROXIMATE_DISCRETE}
 
+    @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Databricks."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
@@ -62,5 +63,6 @@ class DatabricksSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
     EXPR_RENDERER = DatabricksSqlExpressionRenderer()
 
     @property
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+    @override
+    def expr_renderer(self) -> SqlExpressionRenderer:
         return self.EXPR_RENDERER

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -33,7 +33,9 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
         }
 
-    def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:
+        """Render time delta expression for DuckDB, which requires slightly different syntax from other engines."""
         arg_rendered = node.arg.accept(self)
         if node.grain_to_date:
             return SqlExpressionRenderResult(
@@ -52,12 +54,14 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             bind_parameters=arg_rendered.bind_parameters,
         )
 
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         return SqlExpressionRenderResult(
             sql="GEN_RANDOM_UUID()",
             bind_parameters=SqlBindParameters(),
         )
 
+    @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for DuckDB."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
@@ -93,5 +97,6 @@ class DuckDbSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
     EXPR_RENDERER = DuckDbSqlExpressionRenderer()
 
     @property
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+    @override
+    def expr_renderer(self) -> SqlExpressionRenderer:
         return self.EXPR_RENDERER

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Collection
+
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from typing_extensions import override
 
 from metricflow.sql.render.expr_renderer import (
     DefaultSqlExpressionRenderer,
@@ -20,6 +23,15 @@ from metricflow.sql.sql_exprs import (
 
 class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the DuckDB engine."""
+
+    @property
+    @override
+    def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
+        return {
+            SqlPercentileFunctionType.CONTINUOUS,
+            SqlPercentileFunctionType.DISCRETE,
+            SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
+        }
 
     def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:  # noqa: D
         arg_rendered = node.arg.accept(self)

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from typing_extensions import override
 
 from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
@@ -23,6 +24,7 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the PostgreSQL engine."""
 
     @property
+    @override
     def double_data_type(self) -> str:
         """Custom double data type for the PostgreSQL engine."""
         return "DOUBLE PRECISION"

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -36,7 +36,9 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
         return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.DISCRETE}
 
-    def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:
+        """Render time delta operations for PostgreSQL, which needs custom support for quarterly granularity."""
         arg_rendered = node.arg.accept(self)
         if node.grain_to_date:
             return SqlExpressionRenderResult(
@@ -54,12 +56,14 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             bind_parameters=arg_rendered.bind_parameters,
         )
 
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         return SqlExpressionRenderResult(
             sql="GEN_RANDOM_UUID()",
             bind_parameters=SqlBindParameters(),
         )
 
+    @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Postgres."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
@@ -95,5 +99,6 @@ class PostgresSQLSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
     EXPR_RENDERER = PostgresSqlExpressionRenderer()
 
     @property
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+    @override
+    def expr_renderer(self) -> SqlExpressionRenderer:
         return self.EXPR_RENDERER

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Collection
+
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from typing_extensions import override
@@ -28,6 +30,11 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def double_data_type(self) -> str:
         """Custom double data type for the PostgreSQL engine."""
         return "DOUBLE PRECISION"
+
+    @property
+    @override
+    def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
+        return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.DISCRETE}
 
     def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:  # noqa: D
         arg_rendered = node.arg.accept(self)

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from typing_extensions import override
 
 from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
@@ -17,6 +18,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the Redshift engine."""
 
     @property
+    @override
     def double_data_type(self) -> str:
         """Custom double data type for the Redshift engine."""
         return "DOUBLE PRECISION"

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -30,6 +30,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
         return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.APPROXIMATE_DISCRETE}
 
+    @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Redshift."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
@@ -58,7 +59,8 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             bind_parameters=params,
         )
 
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         """Generates a "good enough" random key to simulate a UUID.
 
         NOTE: This is a temporary hacky solution as redshift does not have any UUID generation function.
@@ -78,5 +80,6 @@ class RedshiftSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
     EXPR_RENDERER = RedshiftSqlExpressionRenderer()
 
     @property
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+    @override
+    def expr_renderer(self) -> SqlExpressionRenderer:
         return self.EXPR_RENDERER

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Collection
+
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from typing_extensions import override
 
@@ -22,6 +24,11 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def double_data_type(self) -> str:
         """Custom double data type for the Redshift engine."""
         return "DOUBLE PRECISION"
+
+    @property
+    @override
+    def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
+        return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.APPROXIMATE_DISCRETE}
 
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Redshift."""

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -28,12 +28,14 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
         }
 
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
+    @override
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         return SqlExpressionRenderResult(
             sql="UUID_STRING()",
             bind_parameters=SqlBindParameters(),
         )
 
+    @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Snowflake."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
@@ -69,5 +71,6 @@ class SnowflakeSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
     EXPR_RENDERER = SnowflakeSqlExpressionRenderer()
 
     @property
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+    @override
+    def expr_renderer(self) -> SqlExpressionRenderer:
         return self.EXPR_RENDERER

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Collection
+
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from typing_extensions import override
 
 from metricflow.errors.errors import UnsupportedEngineFeatureError
 from metricflow.sql.render.expr_renderer import (
@@ -15,6 +18,15 @@ from metricflow.sql.sql_exprs import SqlGenerateUuidExpression, SqlPercentileExp
 
 class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     """Expression renderer for the Snowflake engine."""
+
+    @property
+    @override
+    def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
+        return {
+            SqlPercentileFunctionType.CONTINUOUS,
+            SqlPercentileFunctionType.DISCRETE,
+            SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
+        }
 
     def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
         return SqlExpressionRenderResult(

--- a/metricflow/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/sql_clients/base_sql_client_implementation.py
@@ -12,7 +12,6 @@ from metricflow.dataflow.sql_table import SqlTable
 from metricflow.logging.formatting import indent_log_line
 from metricflow.protocols.sql_client import (
     SqlClient,
-    SqlEngineAttributes,
 )
 from metricflow.protocols.sql_request import SqlJsonTag, SqlRequestId, SqlRequestTagSet
 from metricflow.random_id import random_id
@@ -121,15 +120,6 @@ class BaseSqlClientImplementation(ABC, SqlClient):
         stop = time.time()
         logger.info(f"Finished running the dry_run in {stop - start:.2f}s")
         return results
-
-    @property
-    @abstractmethod
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Struct of SQL engine attributes.
-
-        This is used by MetricFlow for things like SQL rendering and safe use of multi-threading.
-        """
-        raise NotImplementedError
 
     @abstractmethod
     def _engine_specific_query_implementation(

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -35,10 +35,6 @@ class BigQueryEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "FLOAT64"
-    timestamp_type_name: ClassVar[Optional[str]] = "DATETIME"
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = BigQuerySqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -29,12 +29,6 @@ class BigQueryEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.BIGQUERY
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = False
-    discrete_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = BigQuerySqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import ClassVar, Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 import google.oauth2.service_account
 import sqlalchemy
 from google.cloud.bigquery import Client
+from typing_extensions import override
 
 from metricflow.protocols.sql_client import (
     SqlEngine,
-    SqlEngineAttributes,
 )
 from metricflow.sql.render.big_query import BigQuerySqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
@@ -19,18 +19,6 @@ from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 logger = logging.getLogger(__name__)
-
-
-class BigQueryEngineAttributes:
-    """Engine-specific attributes for the BigQuery query engine.
-
-    This is an implementation of the SqlEngineAttributes protocol for BigQuery
-    """
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.BIGQUERY
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = BigQuerySqlQueryPlanRenderer()
 
 
 class BigQuerySqlClient(SqlAlchemySqlClient):
@@ -103,9 +91,15 @@ class BigQuerySqlClient(SqlAlchemySqlClient):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
+    @override
+    def sql_engine_type(self) -> SqlEngine:
         """Collection of attributes and features specific to the BigQuery SQL engine."""
-        return BigQueryEngineAttributes()
+        return SqlEngine.BIGQUERY
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return BigQuerySqlQueryPlanRenderer()
 
     def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
         with self._engine_connection(engine=self._engine) as conn:

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -50,9 +50,6 @@ class DatabricksEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = True
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "DOUBLE"
-    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DatabricksSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -44,12 +44,6 @@ class DatabricksEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DATABRICKS
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    discrete_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = True
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DatabricksSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import ClassVar, Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 import pandas as pd
 import sqlalchemy
 from databricks import sql
+from typing_extensions import override
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.protocols.sql_request import SqlJsonTag, SqlRequestTagSet
 from metricflow.sql.render.databricks import DatabricksSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
@@ -37,15 +38,6 @@ PANDAS_TO_SQL_DTYPES = {
     "int64": "int",
     "datetime64[ns]": "timestamp",
 }
-
-
-class DatabricksEngineAttributes:
-    """SQL engine attributes for Databricks."""
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DATABRICKS
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DatabricksSqlQueryPlanRenderer()
 
 
 class DatabricksSqlClient(BaseSqlClientImplementation):
@@ -118,9 +110,14 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Databricks engine attributes."""
-        return DatabricksEngineAttributes()
+    @override
+    def sql_engine_type(self) -> SqlEngine:
+        return SqlEngine.DATABRICKS
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return DatabricksSqlQueryPlanRenderer()
 
     @staticmethod
     def params_or_none(bind_params: SqlBindParameters) -> Optional[Dict[str, SqlColumnType]]:

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import ClassVar, Optional, Sequence
+from typing import Optional, Sequence
 
 import pandas as pd
 import sqlalchemy
 from sqlalchemy import inspect
 from sqlalchemy.pool import StaticPool
+from typing_extensions import override
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.protocols.sql_request import SqlJsonTag, SqlRequestTagSet
 from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
@@ -19,15 +20,6 @@ from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 logger = logging.getLogger(__name__)
-
-
-class DuckDbEngineAttributes:
-    """Engine-specific attributes for the DuckDb query engine."""
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DUCKDB
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DuckDbSqlQueryPlanRenderer()
 
 
 class DuckDbSqlClient(SqlAlchemySqlClient):
@@ -58,9 +50,14 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Collection of attributes and features specific to the Snowflake SQL engine."""
-        return DuckDbEngineAttributes()
+    @override
+    def sql_engine_type(self) -> SqlEngine:
+        return SqlEngine.DUCKDB
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return DuckDbSqlQueryPlanRenderer()
 
     def _engine_specific_query_implementation(
         self,

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -26,12 +26,6 @@ class DuckDbEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DUCKDB
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    discrete_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DuckDbSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -32,10 +32,6 @@ class DuckDbEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "DOUBLE"
-    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DuckDbSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -28,10 +28,6 @@ class PostgresEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "DOUBLE PRECISION"
-    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = PostgresSQLSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -1,29 +1,18 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, Mapping, Optional, Sequence, Union
+from typing import Mapping, Optional, Sequence, Union
 
 import sqlalchemy
+from typing_extensions import override
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 logger = logging.getLogger(__name__)
-
-
-class PostgresEngineAttributes:
-    """Engine-specific attributes for the Postgres query engine.
-
-    This is an implementation of the SqlEngineAttributes protocol for Postgres
-    """
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.POSTGRES
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = PostgresSQLSqlQueryPlanRenderer()
 
 
 class PostgresSqlClient(SqlAlchemySqlClient):
@@ -71,6 +60,11 @@ class PostgresSqlClient(SqlAlchemySqlClient):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Collection of attributes and features specific to the Postgres SQL engine."""
-        return PostgresEngineAttributes()
+    @override
+    def sql_engine_type(self) -> SqlEngine:
+        return SqlEngine.POSTGRES
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return PostgresSQLSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -22,12 +22,6 @@ class PostgresEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.POSTGRES
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    discrete_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = PostgresSQLSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -22,12 +22,6 @@ class RedshiftEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.REDSHIFT
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    discrete_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = True
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = RedshiftSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -28,10 +28,6 @@ class RedshiftEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = True
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "DOUBLE PRECISION"
-    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = RedshiftSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -1,29 +1,18 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, Mapping, Optional, Sequence, Union
+from typing import Mapping, Optional, Sequence, Union
 
 import sqlalchemy
+from typing_extensions import override
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 logger = logging.getLogger(__name__)
-
-
-class RedshiftEngineAttributes:
-    """Engine-specific attributes for the Redshift query engine.
-
-    This is an implementation of the SqlEngineAttributes protocol for Redshift
-    """
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.REDSHIFT
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = RedshiftSqlQueryPlanRenderer()
 
 
 class RedshiftSqlClient(SqlAlchemySqlClient):
@@ -71,6 +60,11 @@ class RedshiftSqlClient(SqlAlchemySqlClient):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Collection of attributes and features specific to the Snowflake SQL engine."""
-        return RedshiftEngineAttributes()
+    @override
+    def sql_engine_type(self) -> SqlEngine:
+        return SqlEngine.REDSHIFT
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return RedshiftSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -44,10 +44,6 @@ class SnowflakeEngineAttributes:
     approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
     approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
 
-    # SQL Dialect replacement strings
-    double_data_type_name: ClassVar[str] = "DOUBLE"
-    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = SnowflakeSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -38,12 +38,6 @@ class SnowflakeEngineAttributes:
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.SNOWFLAKE
 
-    # SQL Engine capabilities
-    continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    discrete_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = True
-    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
-
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = SnowflakeSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -7,13 +7,14 @@ import threading
 import urllib.parse
 from collections import OrderedDict
 from contextlib import contextmanager
-from typing import ClassVar, Dict, Iterator, Optional, Sequence, Set
+from typing import Dict, Iterator, Optional, Sequence, Set
 
 import pandas as pd
 import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
+from typing_extensions import override
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.protocols.sql_request import (
     MF_EXTRA_TAGS_KEY,
     MF_SYSTEM_TAGS_KEY,
@@ -28,18 +29,6 @@ from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 logger = logging.getLogger(__name__)
-
-
-class SnowflakeEngineAttributes:
-    """Engine-specific attributes for the Snowflake query engine.
-
-    This is an implementation of the SqlEngineAttributes protocol for Snowflake
-    """
-
-    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.SNOWFLAKE
-
-    # MetricFlow attributes
-    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = SnowflakeSqlQueryPlanRenderer()
 
 
 class SnowflakeSqlClient(SqlAlchemySqlClient):
@@ -146,9 +135,14 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
         )
 
     @property
-    def sql_engine_attributes(self) -> SqlEngineAttributes:
-        """Collection of attributes and features specific to the Snowflake SQL engine."""
-        return SnowflakeEngineAttributes()
+    @override
+    def sql_engine_type(self) -> SqlEngine:
+        return SqlEngine.SNOWFLAKE
+
+    @property
+    @override
+    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+        return SnowflakeSqlQueryPlanRenderer()
 
     @contextmanager
     def _engine_connection(

--- a/metricflow/test/examples/test_node_sql.py
+++ b/metricflow/test/examples/test_node_sql.py
@@ -44,7 +44,7 @@ def test_view_sql_generated_at_a_node(
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
         time_spine_source=time_spine_source,
     )
-    sql_renderer: SqlQueryPlanRenderer = sql_client.sql_engine_attributes.sql_query_plan_renderer
+    sql_renderer: SqlQueryPlanRenderer = sql_client.sql_query_plan_renderer
     node_output_resolver = DataflowPlanNodeOutputDataSetResolver[SqlDataSet](
         column_association_resolver=column_association_resolver,
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
@@ -55,7 +55,7 @@ def test_view_sql_generated_at_a_node(
     bookings_source_data_set = to_data_set_converter.create_sql_source_data_set(bookings_semantic_model)
     read_source_node = ReadSqlSourceNode[SqlDataSet](bookings_source_data_set)
     sql_plan_at_read_node = to_sql_plan_converter.convert_to_sql_query_plan(
-        sql_engine_attributes=sql_client.sql_engine_attributes,
+        sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id="example_sql_plan",
         dataflow_plan_node=read_source_node,
         optimization_level=SqlQueryOptimizationLevel.O4,
@@ -80,7 +80,7 @@ def test_view_sql_generated_at_a_node(
         ),
     )
     sql_plan_at_filter_elements_node = to_sql_plan_converter.convert_to_sql_query_plan(
-        sql_engine_attributes=sql_client.sql_engine_attributes,
+        sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id="example_sql_plan",
         dataflow_plan_node=filter_elements_node,
         optimization_level=SqlQueryOptimizationLevel.O4,

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -26,6 +26,7 @@ from metricflow.sql.sql_exprs import (
     SqlDateTruncExpression,
     SqlPercentileExpression,
     SqlPercentileExpressionArgument,
+    SqlPercentileFunctionType,
     SqlStringExpression,
     SqlTimeDeltaExpression,
 )
@@ -166,16 +167,24 @@ def filter_not_supported_features(
     not_supported_features: List[RequiredDwEngineFeatures] = []
     for required_feature in required_features:
         if required_feature is RequiredDwEngineFeatures.CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.continuous_percentile_aggregation_supported:
+            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+                SqlPercentileFunctionType.CONTINUOUS
+            ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.discrete_percentile_aggregation_supported:
+            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+                SqlPercentileFunctionType.DISCRETE
+            ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.approximate_continuous_percentile_aggregation_supported:
+            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+                SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
+            ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.approximate_discrete_percentile_aggregation_supported:
+            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+                SqlPercentileFunctionType.APPROXIMATE_DISCRETE
+            ):
                 not_supported_features.append(required_feature)
         else:
             assert_values_exhausted(required_feature)

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -67,7 +67,7 @@ class CheckQueryHelpers:
 
     def cast_expr_to_ts(self, expr: str) -> str:
         """Returns the expression as a new expression cast to the timestamp type, if applicable for the DB."""
-        return f"CAST({expr} AS {self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
+        return f"CAST({expr} AS {self._sql_client.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
 
     def cast_to_ts(self, string_literal: str) -> str:
         """Similar to cast_expr_to_ts, but assumes the input string is to be converted into a string literal."""
@@ -86,7 +86,7 @@ class CheckQueryHelpers:
             count=count,
             granularity=granularity,
         )
-        return self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.render_sql_expr(expr).sql
+        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(expr).sql
 
     def render_date_trunc(self, expr: str, granularity: TimeGranularity) -> str:
         """Return the DATE_TRUNC() call that can be used for converting the given expr to the granularity."""
@@ -99,9 +99,7 @@ class CheckQueryHelpers:
                 )
             ),
         )
-        return self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.render_sql_expr(
-            renderable_expr
-        ).sql
+        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
 
     def render_percentile_expr(
         self, expr: str, percentile: float, use_discrete_percentile: bool, use_approximate_percentile: bool
@@ -122,14 +120,12 @@ class CheckQueryHelpers:
             ),
             percentile_args=percentile_args,
         )
-        return self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.render_sql_expr(
-            renderable_expr
-        ).sql
+        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
 
     @property
     def double_data_type_name(self) -> str:
         """Return the name of the double data type for the relevant SQL engine."""
-        return self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.double_data_type
+        return self._sql_client.sql_query_plan_renderer.expr_renderer.double_data_type
 
     def render_dimension_template(self, dimension_name: str, entity_path: Sequence[str] = ()) -> str:
         """Renders a template that can be used to retrieve a dimension.
@@ -167,22 +163,22 @@ def filter_not_supported_features(
     not_supported_features: List[RequiredDwEngineFeatures] = []
     for required_feature in required_features:
         if required_feature is RequiredDwEngineFeatures.CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.DISCRETE
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_DISCRETE
             ):
                 not_supported_features.append(required_feature)

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -66,7 +66,7 @@ class CheckQueryHelpers:
 
     def cast_expr_to_ts(self, expr: str) -> str:
         """Returns the expression as a new expression cast to the timestamp type, if applicable for the DB."""
-        return f"CAST({expr} AS {self._sql_client.sql_engine_attributes.timestamp_type_name})"
+        return f"CAST({expr} AS {self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
 
     def cast_to_ts(self, string_literal: str) -> str:
         """Similar to cast_expr_to_ts, but assumes the input string is to be converted into a string literal."""
@@ -128,7 +128,7 @@ class CheckQueryHelpers:
     @property
     def double_data_type_name(self) -> str:
         """Return the name of the double data type for the relevant SQL engine."""
-        return self._sql_client.sql_engine_attributes.double_data_type_name
+        return self._sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.double_data_type
 
     def render_dimension_template(self, dimension_name: str, entity_path: Sequence[str] = ()) -> str:
         """Renders a template that can be used to retrieve a dimension.

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -94,7 +94,7 @@ def convert_and_check(
     """Convert the dataflow plan to SQL and compare with snapshots."""
     # Generate plans w/o optimizers
     sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
-        sql_engine_attributes=sql_client.sql_engine_attributes,
+        sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id="plan0",
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O0,
@@ -121,7 +121,7 @@ def convert_and_check(
 
     # Generate plans with optimizers
     sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
-        sql_engine_attributes=sql_client.sql_engine_attributes,
+        sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id="plan0_optimized",
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O4,

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -58,7 +58,7 @@ def assert_rendered_sql_from_plan_equal(
     sql_client: SqlClient,
 ) -> None:
     """Similar to assert_rendered_sql_equal, but takes in a SQL query plan."""
-    rendered_sql = sql_client.sql_engine_attributes.sql_query_plan_renderer.render_sql_query_plan(sql_query_plan).sql
+    rendered_sql = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_query_plan).sql
 
     assert_plan_snapshot_text_equal(
         request=request,

--- a/metricflow/test/sql/test_engine_specific_rendering.py
+++ b/metricflow/test/sql/test_engine_specific_rendering.py
@@ -109,7 +109,9 @@ def test_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the continuous percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.continuous_percentile_aggregation_supported:
+    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+        SqlPercentileFunctionType.CONTINUOUS
+    ):
         pytest.skip("Warehouse does not support continuous percentile expressions")
 
     select_columns = [
@@ -155,7 +157,9 @@ def test_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the discrete percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.discrete_percentile_aggregation_supported:
+    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+        SqlPercentileFunctionType.DISCRETE
+    ):
         pytest.skip("Warehouse does not support discrete percentile expressions")
 
     select_columns = [
@@ -201,7 +205,9 @@ def test_approximate_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate continuous percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.approximate_continuous_percentile_aggregation_supported:
+    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+        SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
+    ):
         pytest.skip("Warehouse does not support approximate_continuous percentile expressions")
 
     select_columns = [
@@ -247,7 +253,9 @@ def test_approximate_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate discrete percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.approximate_discrete_percentile_aggregation_supported:
+    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+        SqlPercentileFunctionType.APPROXIMATE_DISCRETE
+    ):
         pytest.skip("Warehouse does not support percentile expressions")
 
     select_columns = [

--- a/metricflow/test/sql/test_engine_specific_rendering.py
+++ b/metricflow/test/sql/test_engine_specific_rendering.py
@@ -109,7 +109,7 @@ def test_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the continuous percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.CONTINUOUS
     ):
         pytest.skip("Warehouse does not support continuous percentile expressions")
@@ -157,7 +157,7 @@ def test_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the discrete percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.DISCRETE
     ):
         pytest.skip("Warehouse does not support discrete percentile expressions")
@@ -205,7 +205,7 @@ def test_approximate_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate continuous percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
     ):
         pytest.skip("Warehouse does not support approximate_continuous percentile expressions")
@@ -253,7 +253,7 @@ def test_approximate_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate discrete percentile expression in a query."""
-    if not sql_client.sql_engine_attributes.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.APPROXIMATE_DISCRETE
     ):
         pytest.skip("Warehouse does not support percentile expressions")


### PR DESCRIPTION
The SqlClient protocol originally included a struct of engine properties which
was used to indicate certain engine-specific attributes which could be useful
to know about in various parts of the codebase where the SqlClient itself was
not required. The direct impetus of this construction was the need for a
backwards-compatible approach to the pre-MetricFlow implementation inside
Transform.

As time has gone by, this property struct has become increasingly cumbersome,
serving as a living record of all of the engine-specific quirks we've ever
encountered, and conflating various dialect-specific rendering elements with
core engine capabilities and python API implementation quirks.

Now that we are narrowing MetricFlow's scope of responsibility for SqlClient
state and capability management, it has become clear that these engine-specific
property structs have outlived their usefulness. The majority of engine-specific
capability checks are either superfluous (e.g., FULL OUTER JOIN support is now
standard) or were rendered irrelevant (e.g., we no longer support isolation levels).
The remaining attributes are more appropriate as part of dialect rendering support,
leaving only the need for the SqlClient to hold pointers to the engine type and the
dialect renderer.

This PR makes this change, eliminating the cumbersome secondary struct, and moving
capability management to the components most appropriate for handling it.