### PR TITLE
Build a semantic manifest from dbt project root directory

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230616-125446.yaml
+++ b/.changes/unreleased/Breaking Changes-20230616-125446.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: CLI needs to be ran in a dbt project root directory
+time: 2023-06-16T12:54:46.372347-04:00
+custom:
+  Author: WilliamDee
+  Issue: None

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -125,7 +125,7 @@ class CLIContext:
     def _initialize_metricflow_engine(self) -> None:
         """Initialize the MetricFlowEngine."""
         try:
-            self._mf = MetricFlowEngine.from_config(self.config)
+            self._mf = MetricFlowEngine.from_dbt_project_root(self.config)
         except Exception as e:
             raise MetricFlowInitException from e
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -31,6 +31,7 @@ from metricflow.engine.models import Dimension, Entity, Metric
 from metricflow.engine.time_source import ServerTimeSource
 from metricflow.engine.utils import (
     build_semantic_manifest_from_config,
+    build_semantic_manifest_from_dbt_project_root,
 )
 from metricflow.errors.errors import ExecutionException
 from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
@@ -298,6 +299,19 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         # Ideally we should put this getting of of CONFIG_DBT_REPO in a helper
         semantic_manifest_lookup = SemanticManifestLookup(build_semantic_manifest_from_config(handler))
         system_schema = not_empty(handler.get_value(CONFIG_DWH_SCHEMA), CONFIG_DWH_SCHEMA, handler.url)
+        return MetricFlowEngine(
+            semantic_manifest_lookup=semantic_manifest_lookup,
+            sql_client=sql_client,
+            system_schema=system_schema,
+        )
+
+    @staticmethod
+    def from_dbt_project_root(handler: YamlFileHandler) -> MetricFlowEngine:
+        """Initialize MetricFlowEngine via the dbt project root directory."""
+        sql_client = make_sql_client_from_config(handler)
+        system_schema = not_empty(handler.get_value(CONFIG_DWH_SCHEMA), CONFIG_DWH_SCHEMA, handler.url)
+        semantic_manifest_lookup = SemanticManifestLookup(build_semantic_manifest_from_dbt_project_root())
+
         return MetricFlowEngine(
             semantic_manifest_lookup=semantic_manifest_lookup,
             sql_client=sql_client,

--- a/metricflow/engine/utils.py
+++ b/metricflow/engine/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import pathlib
 from typing import Optional
 
 from dateutil.parser import parse
@@ -45,6 +46,31 @@ def model_build_result_from_config(
 def build_semantic_manifest_from_config(handler: YamlFileHandler) -> SemanticManifest:
     """Given a yaml file, create a SemanticManifest."""
     return model_build_result_from_config(handler=handler).semantic_manifest
+
+
+def parse_semantic_manifest_from_json_file(filepath: str) -> PydanticSemanticManifest:
+    """Parses a semantic_manifest json to the pydantic object."""
+    try:
+        with open(filepath, "r") as file:
+            raw_contents = file.read()
+            return PydanticSemanticManifest.parse_raw(raw_contents)
+    except Exception as e:
+        raise ModelCreationException from e
+
+
+def build_semantic_manifest_from_dbt_project_root() -> PydanticSemanticManifest:
+    """In the dbt project root, retrieve the manifest path and parse the SemanticManifest."""
+    DEFAULT_TARGET_PATH = "target/semantic_manifest.json"
+    full_path_to_manifest = pathlib.Path(DEFAULT_TARGET_PATH).resolve()
+    if not full_path_to_manifest.exists():
+        raise ModelCreationException(
+            "Unable to find {DBT_PROJECT_ROOT}/"
+            + DEFAULT_TARGET_PATH
+            + "\nPlease ensure that you are running `mf` in the root directory of a dbt project"
+            + " and that the semantic_manifest JSON exists."
+        )
+
+    return parse_semantic_manifest_from_json_file(full_path_to_manifest.as_posix())
 
 
 def convert_to_datetime(datetime_str: Optional[str]) -> Optional[dt.datetime]:

--- a/metricflow/engine/utils.py
+++ b/metricflow/engine/utils.py
@@ -5,6 +5,7 @@ import pathlib
 from typing import Optional
 
 from dateutil.parser import parse
+from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     SemanticManifestBuildResult,
     parse_directory_of_yaml_files_to_semantic_manifest,
@@ -48,7 +49,7 @@ def build_semantic_manifest_from_config(handler: YamlFileHandler) -> SemanticMan
     return model_build_result_from_config(handler=handler).semantic_manifest
 
 
-def parse_semantic_manifest_from_json_file(filepath: str) -> PydanticSemanticManifest:
+def parse_semantic_manifest_from_json_file(filepath: str) -> SemanticManifest:
     """Parses a semantic_manifest json to the pydantic object."""
     try:
         with open(filepath, "r") as file:
@@ -58,7 +59,7 @@ def parse_semantic_manifest_from_json_file(filepath: str) -> PydanticSemanticMan
         raise ModelCreationException from e
 
 
-def build_semantic_manifest_from_dbt_project_root() -> PydanticSemanticManifest:
+def build_semantic_manifest_from_dbt_project_root() -> SemanticManifest:
     """In the dbt project root, retrieve the manifest path and parse the SemanticManifest."""
     DEFAULT_TARGET_PATH = "target/semantic_manifest.json"
     full_path_to_manifest = pathlib.Path(DEFAULT_TARGET_PATH).resolve()

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -72,10 +72,11 @@ class MetricFlowInitException(Exception):
 class ModelCreationException(Exception):
     """Exception to represent errors related to the building a model."""
 
-    def __init__(self) -> None:  # noqa: D
-        super().__init__(
-            "An error occurred when attempting to build the semantic model",
-        )
+    def __init__(self, msg: str = "") -> None:  # noqa: D
+        error_msg = "An error occurred when attempting to build the semantic model"
+        if msg:
+            error_msg += f"\n{msg}"
+        super().__init__(error_msg)
 
 
 class InferenceError(Exception):


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
This PR is the first step to removing the MF configuration file and relying on a dbt project to instantiate MetricFlow. In this PR for the CLI, we move away from parsing the semantic manifest from a given path to a group of MF yaml files, but instead parse a generated `semantic_manifest.json` to a `SemanticManifest` object. There are a few assumptions in this current state in order for MF to work.

1. You must be running `mf` in a dbt project root directory
2. The `target-path` specified in `dbt_project.yml` is assumed to be the default which is `target`
3. A `semantic_manifest.json` is generated in the default path `{DBT_ROOT}/target/semantic_manifest.json`

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->
Resolves SEM-327
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  4. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  5. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)