### PR TITLE
Use Metrics Instead of Measures To Define Ratio Metrics

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230618-180434.yaml
+++ b/.changes/unreleased/Breaking Changes-20230618-180434.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Remove expr & ratio metrics and bundle with derived metrics.
+time: 2023-06-18T18:04:34.366416-07:00
+custom:
+  Author: plypaul
+  Issue: "504"

--- a/metricflow/cli/sample_models/transactions.yaml
+++ b/metricflow/cli/sample_models/transactions.yaml
@@ -86,8 +86,10 @@ metric:
   name: cancellation_rate
   type: ratio
   type_params:
-    numerator: cancellations_usd
-    denominator: transaction_amount_usd
+    numerator:
+      name: cancellations_usd
+    denominator:
+      name: transaction_amount_usd
 ---
 metric:
   name: revenue_usd
@@ -119,8 +121,7 @@ metric:
   name: transaction_usd_l7d_mx
   type: cumulative
   type_params:
-    measures:
-      - transaction_amount_usd
+    measure: transaction_amount_usd
     window: 7 days
   filter: |
     {{ dimension('country', entity_path=['customer']) }} = 'MX'
@@ -129,16 +130,14 @@ metric:
   name: transaction_usd_mtd
   type: cumulative
   type_params:
-    measures:
-      - transaction_amount_usd
+    measure: transaction_amount_usd
     grain_to_date: month
 ---
 metric:
   name: transaction_usd_na_l7d
   type: cumulative
   type_params:
-    measures:
-      - transaction_amount_usd
+    measure: transaction_amount_usd
     window: 7 days
   filter: |
     {{ dimension('region', entity_path=['customer', 'country']) }} = 'NA'

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from dbt_semantic_interfaces.protocols.dimension import (
     Dimension as SemanticManifestDimension,
@@ -15,6 +15,7 @@ from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.metric import Metric as SemanticManifestMetric
 from dbt_semantic_interfaces.protocols.metric import MetricInputMeasure, MetricType, MetricTypeParams
 from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
+from dbt_semantic_interfaces.transformations.add_input_metric_measures import AddInputMetricMeasuresRule
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
 from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
@@ -47,20 +48,13 @@ class Metric:
         )
 
     @property
-    def input_measures(self) -> List[MetricInputMeasure]:
+    def input_measures(self) -> Sequence[MetricInputMeasure]:
         """Return the complete list of input measure configurations for this metric."""
-        type_params = self.type_params
-
-        measures: List[MetricInputMeasure] = list(
-            type_params.measures if type_params is not None and type_params.measures is not None else []
+        assert self.type_params.input_measures, (
+            f"Metric {self.name} should have had input_measures populated by "
+            f"{AddInputMetricMeasuresRule.__class__.__name__}"
         )
-        if type_params.measure:
-            measures.append(type_params.measure)
-        if type_params.numerator:
-            measures.append(type_params.numerator)
-        if type_params.denominator:
-            measures.append(type_params.denominator)
-        return measures
+        return self.type_params.input_measures
 
 
 @dataclass(frozen=True)

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -650,10 +650,10 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                     numerator is not None and denominator is not None
                 ), "Missing numerator or denominator for ratio metric, this should have been caught in validation!"
                 numerator_column_name = self._column_association_resolver.resolve_spec(
-                    MeasureSpec(element_name=numerator.post_aggregation_measure_reference.element_name)
+                    MetricSpec.from_reference(numerator.post_aggregation_reference)
                 ).column_name
                 denominator_column_name = self._column_association_resolver.resolve_spec(
-                    MeasureSpec(element_name=denominator.post_aggregation_measure_reference.element_name)
+                    MetricSpec.from_reference(denominator.post_aggregation_reference)
                 ).column_name
 
                 metric_expr = SqlRatioComputationExpression(

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -350,6 +350,6 @@ def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
             ),
             dimension_specs=(DataSet.metric_time_dimension_spec(TimeGranularity.DAY),),
         ),
-        expected_num_sources_in_unoptimized=2,
+        expected_num_sources_in_unoptimized=4,
         expected_num_sources_in_optimized=1,
     )

--- a/metricflow/test/fixtures/model_yamls/extended_date_model/metrics/bookings_cumulative.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/metrics/bookings_cumulative.yaml
@@ -3,6 +3,5 @@ metric:
   description: "weekly_bookers"
   type: cumulative
   type_params:
-    measures:
-      - bookings
+    measure: bookings
     window: 7 days

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_metrics.yaml
@@ -4,8 +4,7 @@ metric:
   description: raw booking count
   type: SIMPLE
   type_params:
-    measures:
-      - bookings
+    measure: bookings
 ---
 metric:
   name: family_bookings
@@ -14,8 +13,7 @@ metric:
   filter:
     "{{ dimension('capacity', entity_path=['listing']) }} > 2"
   type_params:
-    measures:
-      - bookings
+    measure: bookings
 ---
 metric:
   name: potentially_lux_bookings
@@ -24,5 +22,4 @@ metric:
   filter:
     "{{ dimension('is_lux', entity_path=['listing']) }} OR {{ dimension('is_lux', entity_path=['listing']) }} IS NULL"
   type_params:
-    measures:
-      - bookings
+    measure: bookings

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -194,32 +194,40 @@ metric:
   description: bookings divided by bookers - single semantic model ratio metric test
   type: ratio
   type_params:
-    numerator: bookings
-    denominator: bookers
+    numerator:
+      name: bookings
+    denominator:
+      name: bookers
 ---
 metric:
   name: bookings_per_view
   description: Bookings divided by views - ratio metric test
   type: ratio
   type_params:
-    numerator: bookings
-    denominator: views
+    numerator:
+      name: bookings
+    denominator:
+      name: views
 ---
 metric:
   name: bookings_per_listing
   description: Bookings divided by listings - ratio with primary identifier test
   type: ratio
   type_params:
-    numerator: bookings
-    denominator: listings
+    numerator:
+      name: bookings
+    denominator:
+      name: listings
 ---
 metric:
   name: bookings_per_dollar
   description: Number of bookings per dollar of value
   type: ratio
   type_params:
-    numerator: bookings
-    denominator: booking_value
+    numerator:
+      name: bookings
+    denominator:
+      name: booking_value
 ---
 metric:
   name: "total_account_balance_first_day"

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -4,56 +4,49 @@ metric:
   description: "bookings metric"
   type: simple
   type_params:
-    measures:
-      - bookings
+    measure: bookings
 ---
 metric:
   name: "average_booking_value"
   description: "average booking value metric"
   type: simple
   type_params:
-    measures:
-      - average_booking_value
+    measure: average_booking_value
 ---
 metric:
   name: "instant_bookings"
   description: "instant bookings"
   type: simple
   type_params:
-    measures:
-      - instant_bookings
+    measure: instant_bookings
 ---
 metric:
   name: "booking_value"
   description: "booking value"
   type: simple
   type_params:
-    measures:
-      - booking_value
+    measure: booking_value
 ---
 metric:
   name: "max_booking_value"
   description: "max booking value"
   type: simple
   type_params:
-    measures:
-      - max_booking_value
+    measure: max_booking_value
 ---
 metric:
   name: "min_booking_value"
   description: "min booking value"
   type: simple
   type_params:
-    measures:
-      - min_booking_value
+    measure: min_booking_value
 ---
 metric:
   name: "instant_booking_value"
   description: "booking value of instant bookings"
   type: simple
   type_params:
-    measures:
-      - booking_value
+    measure: booking_value
   filter: "{{ dimension('is_instant') }}"
 ---
 metric:
@@ -61,8 +54,7 @@ metric:
   description: "average booking value of instant bookings"
   type: simple
   type_params:
-    measures:
-      - average_booking_value
+    measure: average_booking_value
   filter:  "{{ dimension('is_instant') }}"
 ---
 metric:
@@ -70,8 +62,7 @@ metric:
   description: "booking value of instant bookings"
   type: simple
   type_params:
-    measures:
-      - booking_value
+    measure: booking_value
   filter: "{{ entity('listing') }} IS NOT NULL"
 ---
 metric:
@@ -79,40 +70,35 @@ metric:
   description: "bookers"
   type: simple
   type_params:
-    measures:
-      - bookers
+    measure: bookers
 ---
 metric:
   name: "booking_payments"
   description: "Booking payments."
   type: simple
   type_params:
-    measures:
-      - booking_payments
+    measure: booking_payments
 ---
 metric:
   name: "views"
   description: "views"
   type: simple
   type_params:
-    measures:
-      - views
+    measure: views
 ---
 metric:
   name: "listings"
   description: "listings"
   type: simple
   type_params:
-    measures:
-      - listings
+    measure: listings
 ---
 metric:
   name: "lux_listings"
   description: "lux_listings"
   type: simple
   type_params:
-    measures:
-      - listings
+    measure: listings
   filter: "{{ dimension('is_lux_latest') }}"
 ---
 metric:
@@ -120,40 +106,35 @@ metric:
   description: "smallest listing"
   type: simple
   type_params:
-    measures:
-      - smallest_listing
+    measure: smallest_listing
 ---
 metric:
   name: "largest_listing"
   description: "largest listing"
   type: simple
   type_params:
-    measures:
-      - largest_listing
+    measure: largest_listing
 ---
 metric:
   name: "identity_verifications"
   description: "identity_verifications"
   type: simple
   type_params:
-    measures:
-      - identity_verifications
+    measure: identity_verifications
 ---
 metric:
   name: "revenue"
   description: "revenue"
   type: simple
   type_params:
-    measures:
-      - txn_revenue
+    measure: txn_revenue
 ---
 metric:
   name: "trailing_2_months_revenue"
   description: "trailing_2_months_revenue"
   type: cumulative
   type_params:
-    measures:
-      - txn_revenue
+    measure: txn_revenue
     window: 2 month
 ---
 metric:
@@ -161,16 +142,14 @@ metric:
   description: "revenue_all_time"
   type: cumulative
   type_params:
-    measures:
-      - txn_revenue
+    measure: txn_revenue
 ---
 metric:
   name: "every_two_days_bookers" # because the bookings test data only spans 3 days
   description: "every_two_days_bookers"
   type: cumulative
   type_params:
-    measures:
-      - bookers
+    measure: bookers
     window: 2 days
 ---
 metric:
@@ -178,8 +157,7 @@ metric:
   description: "revenue mtd"
   type: cumulative
   type_params:
-    measures:
-      - txn_revenue
+    measure: txn_revenue
     grain_to_date: month
 ---
 metric:
@@ -248,16 +226,14 @@ metric:
   description: "total_account_balance_first_day"
   type: simple
   type_params:
-    measures:
-      - total_account_balance_first_day
+    measure: total_account_balance_first_day
 ---
 metric:
   name: "current_account_balance_by_user"
   description: "current_account_balance_by_user"
   type: simple
   type_params:
-    measures:
-      - current_account_balance_by_user
+    measure: current_account_balance_by_user
 ---
 metric:
   name: instant_booking_fraction_of_max_value
@@ -347,8 +323,7 @@ metric:
   description: "bookings made through a referral"
   type: simple
   type_params:
-    measures:
-      - referred_bookings
+    measure: referred_bookings
 ---
 metric:
   name: "non_referred_bookings_pct"
@@ -433,40 +408,35 @@ metric:
   description: "median booking value"
   type: simple
   type_params:
-    measures:
-      - median_booking_value
+    measure: median_booking_value
 ---
 metric:
   name: "booking_value_p99"
   description: "p99 booking value"
   type: simple
   type_params:
-    measures:
-      - booking_value_p99
+    measure: booking_value_p99
 ---
 metric:
   name: "discrete_booking_value_p99"
   description: "discrete p99 booking value"
   type: simple
   type_params:
-    measures:
-      - discrete_booking_value_p99
+    measure: discrete_booking_value_p99
 ---
 metric:
   name: "approximate_continuous_booking_value_p99"
   description: "approximate continuous p99 booking value"
   type: simple
   type_params:
-    measures:
-      - approximate_continuous_booking_value_p99
+    measure: approximate_continuous_booking_value_p99
 ---
 metric:
   name: "approximate_discrete_booking_value_p99"
   description: "approximate discrete p99 booking value"
   type: simple
   type_params:
-    measures:
-      - approximate_discrete_booking_value_p99
+    measure: approximate_discrete_booking_value_p99
 ---
 metric:
   name: "bookings_growth_2_weeks"

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -103,8 +103,7 @@ METRICS_YAML = textwrap.dedent(
       description: Cumulative metric for revenue for testing purposes
       type: cumulative
       type_params:
-        measures:
-          - revenue
+        measure: revenue
         window: 7 days
     ---
     metric:

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = wrd_0 -->
         <ComputeMetricsNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = cm_0 -->
+            <!-- node_id = cm_2 -->
             <!-- metric_spec =                                      -->
             <!--   {'class': 'MetricSpec',                          -->
             <!--    'element_name': 'instant_booking_value_ratio',  -->
@@ -12,29 +12,29 @@
             <!--    'alias': None,                                  -->
             <!--    'offset_window': None,                          -->
             <!--    'offset_to_grain': None}                        -->
-            <FilterElementsNode>
-                <!-- description =                                                                     -->
-                <!--   Pass Only Elements:                                                             -->
-                <!--     ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']  -->
-                <!-- node_id = pfe_3 -->
-                <!-- include_spec =                                                  -->
-                <!--   {'class': 'MeasureSpec',                                      -->
-                <!--    'element_name': 'booking_value_with_is_instant_constraint',  -->
-                <!--    'non_additive_dimension_spec': None}                         -->
-                <!-- include_spec =                           -->
-                <!--   {'class': 'MeasureSpec',               -->
-                <!--    'element_name': 'booking_value',      -->
-                <!--    'non_additive_dimension_spec': None}  -->
-                <!-- include_spec =                               -->
-                <!--   {'class': 'TimeDimensionSpec',             -->
-                <!--    'element_name': 'metric_time',            -->
-                <!--    'entity_links': (),                       -->
-                <!--    'time_granularity': TimeGranularity.DAY,  -->
-                <!--    'aggregation_state': None}                -->
-                <JoinAggregatedMeasuresByGroupByColumnsNode>
-                    <!-- description = Join Aggregated Measures with Standard Outputs -->
-                    <!-- node_id = jamgc_0 -->
-                    <!-- Join aggregated measure nodes:  = [am_0, am_1] -->
+            <CombineMetricsNode>
+                <!-- description = Combine Metrics -->
+                <!-- node_id = cbm_0 -->
+                <!-- join type = SqlJoinType.INNER -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_0 -->
+                    <!-- metric_spec =                                                                               -->
+                    <!--   {'class': 'MetricSpec',                                                                   -->
+                    <!--    'element_name': 'booking_value',                                                         -->
+                    <!--    'constraint': {'class': 'WhereFilterSpec',                                               -->
+                    <!--                   'where_sql': 'is_instant',                                                -->
+                    <!--                   'bind_parameters': {'class': 'SqlBindParameters',                         -->
+                    <!--                                       'param_items': ()},                                   -->
+                    <!--                   'linkable_spec_set': {'class': 'LinkableSpecSet',                         -->
+                    <!--                                         'dimension_specs': ({'class': 'DimensionSpec',      -->
+                    <!--                                                              'element_name': 'is_instant',  -->
+                    <!--                                                              'entity_links': ()},),         -->
+                    <!--                                         'time_dimension_specs': (),                         -->
+                    <!--                                         'entity_specs': ()}},                               -->
+                    <!--    'alias': 'booking_value_with_is_instant_constraint',                                     -->
+                    <!--    'offset_window': None,                                                                   -->
+                    <!--    'offset_to_grain': None}                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = Aggregate Measures -->
                         <!-- node_id = am_0 -->
@@ -98,6 +98,17 @@
                             </WhereConstraintNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_1 -->
+                    <!-- metric_spec =                        -->
+                    <!--   {'class': 'MetricSpec',            -->
+                    <!--    'element_name': 'booking_value',  -->
+                    <!--    'constraint': None,               -->
+                    <!--    'alias': None,                    -->
+                    <!--    'offset_window': None,            -->
+                    <!--    'offset_to_grain': None}          -->
                     <AggregateMeasuresNode>
                         <!-- description = Aggregate Measures -->
                         <!-- node_id = am_1 -->
@@ -130,8 +141,8 @@
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
-                </JoinAggregatedMeasuresByGroupByColumnsNode>
-            </FilterElementsNode>
+                </ComputeMetricsNode>
+            </CombineMetricsNode>
         </ComputeMetricsNode>
     </WriteToResultDataframeNode>
 </DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = wrd_0 -->
         <ComputeMetricsNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = cm_0 -->
+            <!-- node_id = cm_2 -->
             <!-- metric_spec =                            -->
             <!--   {'class': 'MetricSpec',                -->
             <!--    'element_name': 'bookings_per_view',  -->
@@ -12,33 +12,20 @@
             <!--    'alias': None,                        -->
             <!--    'offset_window': None,                -->
             <!--    'offset_to_grain': None}              -->
-            <FilterElementsNode>
-                <!-- description =                                                        -->
-                <!--   Pass Only Elements:                                                -->
-                <!--     ['bookings', 'views', 'listing__country_latest', 'metric_time']  -->
-                <!-- node_id = pfe_6 -->
-                <!-- include_spec =                           -->
-                <!--   {'class': 'MeasureSpec',               -->
-                <!--    'element_name': 'bookings',           -->
-                <!--    'non_additive_dimension_spec': None}  -->
-                <!-- include_spec =                           -->
-                <!--   {'class': 'MeasureSpec',               -->
-                <!--    'element_name': 'views',              -->
-                <!--    'non_additive_dimension_spec': None}  -->
-                <!-- include_spec =                                                                  -->
-                <!--   {'class': 'DimensionSpec',                                                    -->
-                <!--    'element_name': 'country_latest',                                            -->
-                <!--    'entity_links': ({'class': 'EntityReference', 'element_name': 'listing'},)}  -->
-                <!-- include_spec =                               -->
-                <!--   {'class': 'TimeDimensionSpec',             -->
-                <!--    'element_name': 'metric_time',            -->
-                <!--    'entity_links': (),                       -->
-                <!--    'time_granularity': TimeGranularity.DAY,  -->
-                <!--    'aggregation_state': None}                -->
-                <JoinAggregatedMeasuresByGroupByColumnsNode>
-                    <!-- description = Join Aggregated Measures with Standard Outputs -->
-                    <!-- node_id = jamgc_0 -->
-                    <!-- Join aggregated measure nodes:  = [am_0, am_1] -->
+            <CombineMetricsNode>
+                <!-- description = Combine Metrics -->
+                <!-- node_id = cbm_0 -->
+                <!-- join type = SqlJoinType.INNER -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_0 -->
+                    <!-- metric_spec =                   -->
+                    <!--   {'class': 'MetricSpec',       -->
+                    <!--    'element_name': 'bookings',  -->
+                    <!--    'constraint': None,          -->
+                    <!--    'alias': None,               -->
+                    <!--    'offset_window': None,       -->
+                    <!--    'offset_to_grain': None}     -->
                     <AggregateMeasuresNode>
                         <!-- description = Aggregate Measures -->
                         <!-- node_id = am_0 -->
@@ -126,6 +113,17 @@
                             </JoinToBaseOutputNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_1 -->
+                    <!-- metric_spec =                -->
+                    <!--   {'class': 'MetricSpec',    -->
+                    <!--    'element_name': 'views',  -->
+                    <!--    'constraint': None,       -->
+                    <!--    'alias': None,            -->
+                    <!--    'offset_window': None,    -->
+                    <!--    'offset_to_grain': None}  -->
                     <AggregateMeasuresNode>
                         <!-- description = Aggregate Measures -->
                         <!-- node_id = am_1 -->
@@ -213,8 +211,8 @@
                             </JoinToBaseOutputNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
-                </JoinAggregatedMeasuresByGroupByColumnsNode>
-            </FilterElementsNode>
+                </ComputeMetricsNode>
+            </CombineMetricsNode>
         </ComputeMetricsNode>
     </WriteToResultDataframeNode>
 </DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = wrd_0 -->
         <ComputeMetricsNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = cm_0 -->
+            <!-- node_id = cm_2 -->
             <!-- metric_spec =                              -->
             <!--   {'class': 'MetricSpec',                  -->
             <!--    'element_name': 'bookings_per_booker',  -->
@@ -12,101 +12,207 @@
             <!--    'alias': None,                          -->
             <!--    'offset_window': None,                  -->
             <!--    'offset_to_grain': None}                -->
-            <AggregateMeasuresNode>
-                <!-- description = Aggregate Measures -->
-                <!-- node_id = am_0 -->
-                <FilterElementsNode>
-                    <!-- description =                                                          -->
-                    <!--   Pass Only Elements:                                                  -->
-                    <!--     ['bookings', 'bookers', 'listing__country_latest', 'metric_time']  -->
-                    <!-- node_id = pfe_2 -->
-                    <!-- include_spec =                           -->
-                    <!--   {'class': 'MeasureSpec',               -->
-                    <!--    'element_name': 'bookings',           -->
-                    <!--    'non_additive_dimension_spec': None}  -->
-                    <!-- include_spec =                           -->
-                    <!--   {'class': 'MeasureSpec',               -->
-                    <!--    'element_name': 'bookers',            -->
-                    <!--    'non_additive_dimension_spec': None}  -->
-                    <!-- include_spec =                                                                  -->
-                    <!--   {'class': 'DimensionSpec',                                                    -->
-                    <!--    'element_name': 'country_latest',                                            -->
-                    <!--    'entity_links': ({'class': 'EntityReference', 'element_name': 'listing'},)}  -->
-                    <!-- include_spec =                               -->
-                    <!--   {'class': 'TimeDimensionSpec',             -->
-                    <!--    'element_name': 'metric_time',            -->
-                    <!--    'entity_links': (),                       -->
-                    <!--    'time_granularity': TimeGranularity.DAY,  -->
-                    <!--    'aggregation_state': None}                -->
-                    <JoinToBaseOutputNode>
-                        <!-- description = Join Standard Outputs -->
-                        <!-- node_id = jso_0 -->
-                        <!-- join0_for_node_id_pfe_1 =                             -->
-                        <!--   {'class': 'JoinDescription',                        -->
-                        <!--    'join_node': FilterElementsNode(node_id=pfe_1),    -->
-                        <!--    'join_on_entity': {'class': 'LinklessEntitySpec',  -->
-                        <!--                       'element_name': 'listing',      -->
-                        <!--                       'entity_links': ()},            -->
-                        <!--    'join_on_partition_dimensions': (),                -->
-                        <!--    'join_on_partition_time_dimensions': (),           -->
-                        <!--    'validity_window': None}                           -->
+            <CombineMetricsNode>
+                <!-- description = Combine Metrics -->
+                <!-- node_id = cbm_0 -->
+                <!-- join type = SqlJoinType.INNER -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_0 -->
+                    <!-- metric_spec =                   -->
+                    <!--   {'class': 'MetricSpec',       -->
+                    <!--    'element_name': 'bookings',  -->
+                    <!--    'constraint': None,          -->
+                    <!--    'alias': None,               -->
+                    <!--    'offset_window': None,       -->
+                    <!--    'offset_to_grain': None}     -->
+                    <AggregateMeasuresNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = am_0 -->
                         <FilterElementsNode>
-                            <!-- description =                                          -->
-                            <!--   Pass Only Elements:                                  -->
-                            <!--     ['bookings', 'bookers', 'metric_time', 'listing']  -->
-                            <!-- node_id = pfe_0 -->
+                            <!-- description =                                               -->
+                            <!--   Pass Only Elements:                                       -->
+                            <!--     ['bookings', 'listing__country_latest', 'metric_time']  -->
+                            <!-- node_id = pfe_2 -->
                             <!-- include_spec =                           -->
                             <!--   {'class': 'MeasureSpec',               -->
                             <!--    'element_name': 'bookings',           -->
                             <!--    'non_additive_dimension_spec': None}  -->
-                            <!-- include_spec =                           -->
-                            <!--   {'class': 'MeasureSpec',               -->
-                            <!--    'element_name': 'bookers',            -->
-                            <!--    'non_additive_dimension_spec': None}  -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   {'class': 'DimensionSpec',                                                    -->
+                            <!--    'element_name': 'country_latest',                                            -->
+                            <!--    'entity_links': ({'class': 'EntityReference', 'element_name': 'listing'},)}  -->
                             <!-- include_spec =                               -->
                             <!--   {'class': 'TimeDimensionSpec',             -->
                             <!--    'element_name': 'metric_time',            -->
                             <!--    'entity_links': (),                       -->
                             <!--    'time_granularity': TimeGranularity.DAY,  -->
                             <!--    'aggregation_state': None}                -->
-                            <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
-                            <MetricTimeDimensionTransformNode>
-                                <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10001 -->
-                                <!-- aggregation_time_dimension = ds -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                                    -->
-                                    <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
-                                    <!-- data_set =                                                                             -->
-                                    <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                </ReadSqlSourceNode>
-                            </MetricTimeDimensionTransformNode>
+                            <JoinToBaseOutputNode>
+                                <!-- description = Join Standard Outputs -->
+                                <!-- node_id = jso_0 -->
+                                <!-- join0_for_node_id_pfe_1 =                             -->
+                                <!--   {'class': 'JoinDescription',                        -->
+                                <!--    'join_node': FilterElementsNode(node_id=pfe_1),    -->
+                                <!--    'join_on_entity': {'class': 'LinklessEntitySpec',  -->
+                                <!--                       'element_name': 'listing',      -->
+                                <!--                       'entity_links': ()},            -->
+                                <!--    'join_on_partition_dimensions': (),                -->
+                                <!--    'join_on_partition_time_dimensions': (),           -->
+                                <!--    'validity_window': None}                           -->
+                                <FilterElementsNode>
+                                    <!-- description =                               -->
+                                    <!--   Pass Only Elements:                       -->
+                                    <!--     ['bookings', 'metric_time', 'listing']  -->
+                                    <!-- node_id = pfe_0 -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'bookings',           -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
+                                    <!-- include_spec =                               -->
+                                    <!--   {'class': 'TimeDimensionSpec',             -->
+                                    <!--    'element_name': 'metric_time',            -->
+                                    <!--    'entity_links': (),                       -->
+                                    <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                    <!--    'aggregation_state': None}                -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = Metric Time Dimension 'ds' -->
+                                        <!-- node_id = sma_10001 -->
+                                        <!-- aggregation_time_dimension = ds -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                                    -->
+                                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                             -->
+                                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                </FilterElementsNode>
+                                <FilterElementsNode>
+                                    <!-- description =                      -->
+                                    <!--   Pass Only Elements:              -->
+                                    <!--     ['country_latest', 'listing']  -->
+                                    <!-- node_id = pfe_1 -->
+                                    <!-- include_spec =                                                                      -->
+                                    <!--   {'class': 'DimensionSpec', 'element_name': 'country_latest', 'entity_links': ()}  -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = Metric Time Dimension 'ds' -->
+                                        <!-- node_id = sma_10004 -->
+                                        <!-- aggregation_time_dimension = ds -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                                    -->
+                                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                             -->
+                                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                </FilterElementsNode>
+                            </JoinToBaseOutputNode>
                         </FilterElementsNode>
+                    </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_1 -->
+                    <!-- metric_spec =                  -->
+                    <!--   {'class': 'MetricSpec',      -->
+                    <!--    'element_name': 'bookers',  -->
+                    <!--    'constraint': None,         -->
+                    <!--    'alias': None,              -->
+                    <!--    'offset_window': None,      -->
+                    <!--    'offset_to_grain': None}    -->
+                    <AggregateMeasuresNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = am_1 -->
                         <FilterElementsNode>
-                            <!-- description =                      -->
-                            <!--   Pass Only Elements:              -->
-                            <!--     ['country_latest', 'listing']  -->
-                            <!-- node_id = pfe_1 -->
-                            <!-- include_spec =                                                                      -->
-                            <!--   {'class': 'DimensionSpec', 'element_name': 'country_latest', 'entity_links': ()}  -->
-                            <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
-                            <MetricTimeDimensionTransformNode>
-                                <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10004 -->
-                                <!-- aggregation_time_dimension = ds -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                                    -->
-                                    <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
-                                    <!-- node_id = rss_10014 -->
-                                    <!-- data_set =                                                                             -->
-                                    <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
-                                </ReadSqlSourceNode>
-                            </MetricTimeDimensionTransformNode>
+                            <!-- description =                                              -->
+                            <!--   Pass Only Elements:                                      -->
+                            <!--     ['bookers', 'listing__country_latest', 'metric_time']  -->
+                            <!-- node_id = pfe_5 -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookers',            -->
+                            <!--    'non_additive_dimension_spec': None}  -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   {'class': 'DimensionSpec',                                                    -->
+                            <!--    'element_name': 'country_latest',                                            -->
+                            <!--    'entity_links': ({'class': 'EntityReference', 'element_name': 'listing'},)}  -->
+                            <!-- include_spec =                               -->
+                            <!--   {'class': 'TimeDimensionSpec',             -->
+                            <!--    'element_name': 'metric_time',            -->
+                            <!--    'entity_links': (),                       -->
+                            <!--    'time_granularity': TimeGranularity.DAY,  -->
+                            <!--    'aggregation_state': None}                -->
+                            <JoinToBaseOutputNode>
+                                <!-- description = Join Standard Outputs -->
+                                <!-- node_id = jso_1 -->
+                                <!-- join0_for_node_id_pfe_4 =                             -->
+                                <!--   {'class': 'JoinDescription',                        -->
+                                <!--    'join_node': FilterElementsNode(node_id=pfe_4),    -->
+                                <!--    'join_on_entity': {'class': 'LinklessEntitySpec',  -->
+                                <!--                       'element_name': 'listing',      -->
+                                <!--                       'entity_links': ()},            -->
+                                <!--    'join_on_partition_dimensions': (),                -->
+                                <!--    'join_on_partition_time_dimensions': (),           -->
+                                <!--    'validity_window': None}                           -->
+                                <FilterElementsNode>
+                                    <!-- description =                              -->
+                                    <!--   Pass Only Elements:                      -->
+                                    <!--     ['bookers', 'metric_time', 'listing']  -->
+                                    <!-- node_id = pfe_3 -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'bookers',            -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
+                                    <!-- include_spec =                               -->
+                                    <!--   {'class': 'TimeDimensionSpec',             -->
+                                    <!--    'element_name': 'metric_time',            -->
+                                    <!--    'entity_links': (),                       -->
+                                    <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                    <!--    'aggregation_state': None}                -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = Metric Time Dimension 'ds' -->
+                                        <!-- node_id = sma_10001 -->
+                                        <!-- aggregation_time_dimension = ds -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                                    -->
+                                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                             -->
+                                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                </FilterElementsNode>
+                                <FilterElementsNode>
+                                    <!-- description =                      -->
+                                    <!--   Pass Only Elements:              -->
+                                    <!--     ['country_latest', 'listing']  -->
+                                    <!-- node_id = pfe_4 -->
+                                    <!-- include_spec =                                                                      -->
+                                    <!--   {'class': 'DimensionSpec', 'element_name': 'country_latest', 'entity_links': ()}  -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='listing', entity_links=()) -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = Metric Time Dimension 'ds' -->
+                                        <!-- node_id = sma_10004 -->
+                                        <!-- aggregation_time_dimension = ds -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                                    -->
+                                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                             -->
+                                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                </FilterElementsNode>
+                            </JoinToBaseOutputNode>
                         </FilterElementsNode>
-                    </JoinToBaseOutputNode>
-                </FilterElementsNode>
-            </AggregateMeasuresNode>
+                    </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+            </CombineMetricsNode>
         </ComputeMetricsNode>
     </WriteToResultDataframeNode>
 </DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS FLOAT64) / CAST(NULLIF(subq_19.views, 0) AS FLOAT64) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS FLOAT64) / CAST(NULLIF(subq_20.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         ds
         , listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
         ds
         , listing__country_latest
-    ) subq_17
-    ON
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS FLOAT64) / CAST(NULLIF(subq_37.views, 0) AS FLOAT64) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS FLOAT64) / CAST(NULLIF(subq_40.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
     ds
     , listing__country_latest
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
     ds
     , listing__country_latest
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_11.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_12.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
         metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_21.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_24.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     metric_time
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS FLOAT64) / CAST(NULLIF(subq_9.listings, 0) AS FLOAT64) AS bookings_per_listing
+  CAST(subq_10.bookings AS FLOAT64) / CAST(NULLIF(subq_10.listings, 0) AS FLOAT64) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS FLOAT64) / CAST(NULLIF(subq_17.listings, 0) AS FLOAT64) AS bookings_per_listing
+  CAST(subq_15.bookings AS FLOAT64) / CAST(NULLIF(subq_20.listings, 0) AS FLOAT64) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS DOUBLE) / CAST(NULLIF(subq_20.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         subq_7.ds
         , subq_7.listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
-    ) subq_17
-    ON
+        subq_17.ds
+        , subq_17.listing__country_latest
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS DOUBLE) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_22.ds
+    subq_23.ds
     , listings_latest_src_10004.country
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_31.ds
+    subq_33.ds
     , listings_latest_src_10004.country
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         subq_4.metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_8.metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+        subq_9.metric_time
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     ds
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS DOUBLE) / CAST(NULLIF(subq_9.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_10.bookings AS DOUBLE) / CAST(NULLIF(subq_10.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_17.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_15.bookings AS DOUBLE) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS DOUBLE) / CAST(NULLIF(subq_20.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         subq_7.ds
         , subq_7.listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
-    ) subq_17
-    ON
+        subq_17.ds
+        , subq_17.listing__country_latest
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS DOUBLE) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_22.ds
+    subq_23.ds
     , listings_latest_src_10004.country
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_31.ds
+    subq_33.ds
     , listings_latest_src_10004.country
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         subq_4.metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_8.metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+        subq_9.metric_time
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     ds
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS DOUBLE) / CAST(NULLIF(subq_9.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_10.bookings AS DOUBLE) / CAST(NULLIF(subq_10.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_17.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_15.bookings AS DOUBLE) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_20.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         subq_7.ds
         , subq_7.listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
-    ) subq_17
-    ON
+        subq_17.ds
+        , subq_17.listing__country_latest
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_22.ds
+    subq_23.ds
     , listings_latest_src_10004.country
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_31.ds
+    subq_33.ds
     , listings_latest_src_10004.country
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         subq_4.metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_8.metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+        subq_9.metric_time
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     ds
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_9.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
+  CAST(subq_10.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_10.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
+  CAST(subq_15.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_20.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         subq_7.ds
         , subq_7.listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
-    ) subq_17
-    ON
+        subq_17.ds
+        , subq_17.listing__country_latest
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_22.ds
+    subq_23.ds
     , listings_latest_src_10004.country
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_31.ds
+    subq_33.ds
     , listings_latest_src_10004.country
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         subq_4.metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_8.metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+        subq_9.metric_time
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     ds
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_9.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
+  CAST(subq_10.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_10.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_17.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
+  CAST(subq_15.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE PRECISION) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -1,23 +1,21 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.ds
-  , subq_19.listing__country_latest
-  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_20.ds
+  , subq_20.listing__country_latest
+  , CAST(subq_20.bookings AS DOUBLE) / CAST(NULLIF(subq_20.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'views', 'listing__country_latest', 'ds']
+  -- Combine Metrics
   SELECT
-    subq_18.ds
-    , subq_18.listing__country_latest
-    , subq_18.bookings
-    , subq_18.views
+    COALESCE(subq_9.ds, subq_19.ds) AS ds
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
+    , subq_9.bookings AS bookings
+    , subq_19.views AS views
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_8.ds AS ds
-      , subq_8.listing__country_latest AS listing__country_latest
-      , subq_8.bookings AS bookings
-      , subq_17.views AS views
+      subq_8.ds
+      , subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -258,67 +256,74 @@ FROM (
         subq_7.ds
         , subq_7.listing__country_latest
     ) subq_8
-    INNER JOIN (
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_18.ds
+      , subq_18.listing__country_latest
+      , subq_18.views
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_16.ds
-        , subq_16.listing__country_latest
-        , SUM(subq_16.views) AS views
+        subq_17.ds
+        , subq_17.listing__country_latest
+        , SUM(subq_17.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_15.ds
-          , subq_15.listing__country_latest
-          , subq_15.views
+          subq_16.ds
+          , subq_16.listing__country_latest
+          , subq_16.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_11.ds AS ds
-            , subq_11.listing AS listing
-            , subq_14.country_latest AS listing__country_latest
-            , subq_11.views AS views
+            subq_12.ds AS ds
+            , subq_12.listing AS listing
+            , subq_15.country_latest AS listing__country_latest
+            , subq_12.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_10.ds
-              , subq_10.listing
-              , subq_10.views
+              subq_11.ds
+              , subq_11.listing
+              , subq_11.views
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_9.ds
-                , subq_9.ds__week
-                , subq_9.ds__month
-                , subq_9.ds__quarter
-                , subq_9.ds__year
-                , subq_9.ds_partitioned
-                , subq_9.ds_partitioned__week
-                , subq_9.ds_partitioned__month
-                , subq_9.ds_partitioned__quarter
-                , subq_9.ds_partitioned__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds
-                , subq_9.create_a_cycle_in_the_join_graph__ds__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds__year
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_9.ds AS metric_time
-                , subq_9.ds__week AS metric_time__week
-                , subq_9.ds__month AS metric_time__month
-                , subq_9.ds__quarter AS metric_time__quarter
-                , subq_9.ds__year AS metric_time__year
-                , subq_9.listing
-                , subq_9.user
-                , subq_9.create_a_cycle_in_the_join_graph
-                , subq_9.create_a_cycle_in_the_join_graph__listing
-                , subq_9.create_a_cycle_in_the_join_graph__user
-                , subq_9.views
+                subq_10.ds
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds_partitioned
+                , subq_10.ds_partitioned__week
+                , subq_10.ds_partitioned__month
+                , subq_10.ds_partitioned__quarter
+                , subq_10.ds_partitioned__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds
+                , subq_10.create_a_cycle_in_the_join_graph__ds__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds__year
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_10.ds AS metric_time
+                , subq_10.ds__week AS metric_time__week
+                , subq_10.ds__month AS metric_time__month
+                , subq_10.ds__quarter AS metric_time__quarter
+                , subq_10.ds__year AS metric_time__year
+                , subq_10.listing
+                , subq_10.user
+                , subq_10.create_a_cycle_in_the_join_graph
+                , subq_10.create_a_cycle_in_the_join_graph__listing
+                , subq_10.create_a_cycle_in_the_join_graph__user
+                , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
@@ -349,55 +354,55 @@ FROM (
                   , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
                   , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_10
+            ) subq_11
+          ) subq_12
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['country_latest', 'listing']
             SELECT
-              subq_13.listing
-              , subq_13.country_latest
+              subq_14.listing
+              , subq_14.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_12.ds
-                , subq_12.ds__week
-                , subq_12.ds__month
-                , subq_12.ds__quarter
-                , subq_12.ds__year
-                , subq_12.created_at
-                , subq_12.created_at__week
-                , subq_12.created_at__month
-                , subq_12.created_at__quarter
-                , subq_12.created_at__year
-                , subq_12.listing__ds
-                , subq_12.listing__ds__week
-                , subq_12.listing__ds__month
-                , subq_12.listing__ds__quarter
-                , subq_12.listing__ds__year
-                , subq_12.listing__created_at
-                , subq_12.listing__created_at__week
-                , subq_12.listing__created_at__month
-                , subq_12.listing__created_at__quarter
-                , subq_12.listing__created_at__year
-                , subq_12.ds AS metric_time
-                , subq_12.ds__week AS metric_time__week
-                , subq_12.ds__month AS metric_time__month
-                , subq_12.ds__quarter AS metric_time__quarter
-                , subq_12.ds__year AS metric_time__year
-                , subq_12.listing
-                , subq_12.user
-                , subq_12.listing__user
-                , subq_12.country_latest
-                , subq_12.is_lux_latest
-                , subq_12.capacity_latest
-                , subq_12.listing__country_latest
-                , subq_12.listing__is_lux_latest
-                , subq_12.listing__capacity_latest
-                , subq_12.listings
-                , subq_12.largest_listing
-                , subq_12.smallest_listing
+                subq_13.ds
+                , subq_13.ds__week
+                , subq_13.ds__month
+                , subq_13.ds__quarter
+                , subq_13.ds__year
+                , subq_13.created_at
+                , subq_13.created_at__week
+                , subq_13.created_at__month
+                , subq_13.created_at__quarter
+                , subq_13.created_at__year
+                , subq_13.listing__ds
+                , subq_13.listing__ds__week
+                , subq_13.listing__ds__month
+                , subq_13.listing__ds__quarter
+                , subq_13.listing__ds__year
+                , subq_13.listing__created_at
+                , subq_13.listing__created_at__week
+                , subq_13.listing__created_at__month
+                , subq_13.listing__created_at__quarter
+                , subq_13.listing__created_at__year
+                , subq_13.ds AS metric_time
+                , subq_13.ds__week AS metric_time__week
+                , subq_13.ds__month AS metric_time__month
+                , subq_13.ds__quarter AS metric_time__quarter
+                , subq_13.ds__year AS metric_time__year
+                , subq_13.listing
+                , subq_13.user
+                , subq_13.listing__user
+                , subq_13.country_latest
+                , subq_13.is_lux_latest
+                , subq_13.capacity_latest
+                , subq_13.listing__country_latest
+                , subq_13.listing__is_lux_latest
+                , subq_13.listing__capacity_latest
+                , subq_13.listings
+                , subq_13.largest_listing
+                , subq_13.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -434,34 +439,34 @@ FROM (
                   , listings_latest_src_10004.user_id AS user
                   , listings_latest_src_10004.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_10004
-              ) subq_12
-            ) subq_13
-          ) subq_14
+              ) subq_13
+            ) subq_14
+          ) subq_15
           ON
-            subq_11.listing = subq_14.listing
-        ) subq_15
-      ) subq_16
+            subq_12.listing = subq_15.listing
+        ) subq_16
+      ) subq_17
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
-    ) subq_17
-    ON
+        subq_17.ds
+        , subq_17.listing__country_latest
+    ) subq_18
+  ) subq_19
+  ON
+    (
       (
+        subq_9.listing__country_latest = subq_19.listing__country_latest
+      ) OR (
         (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
-        )
-      ) AND (
-        (
-          subq_8.listing__country_latest = subq_17.listing__country_latest
-        ) OR (
-          (
-            subq_8.listing__country_latest IS NULL
-          ) AND (
-            subq_17.listing__country_latest IS NULL
-          )
+          subq_9.listing__country_latest IS NULL
+        ) AND (
+          subq_19.listing__country_latest IS NULL
         )
       )
-  ) subq_18
-) subq_19
+    ) AND (
+      (
+        subq_9.ds = subq_19.ds
+      ) OR (
+        (subq_9.ds IS NULL) AND (subq_19.ds IS NULL)
+      )
+    )
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,20 +1,19 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'views', 'listing__country_latest', 'ds']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_28.ds AS ds
-  , subq_28.listing__country_latest AS listing__country_latest
-  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
+  COALESCE(subq_30.ds, subq_40.ds) AS ds
+  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+  , CAST(subq_30.bookings AS DOUBLE) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_22.ds AS ds
+    subq_23.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_22.bookings) AS bookings
+    , SUM(subq_23.bookings) AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -25,24 +24,25 @@ FROM (
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_22
+  ) subq_23
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_22.listing = listings_latest_src_10004.listing_id
+    subq_23.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_22.ds
+    subq_23.ds
     , listings_latest_src_10004.country
-) subq_28
+) subq_30
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    subq_31.ds AS ds
+    subq_33.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_31.views) AS views
+    , SUM(subq_33.views) AS views
   FROM (
     -- Read Elements From Semantic Model 'views_source'
     -- Metric Time Dimension 'ds'
@@ -53,30 +53,30 @@ INNER JOIN (
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009
-  ) subq_31
+  ) subq_33
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_31.listing = listings_latest_src_10004.listing_id
+    subq_33.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_31.ds
+    subq_33.ds
     , listings_latest_src_10004.country
-) subq_37
+) subq_40
 ON
   (
     (
-      subq_28.ds = subq_37.ds
+      subq_30.listing__country_latest = subq_40.listing__country_latest
     ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+      (
+        subq_30.listing__country_latest IS NULL
+      ) AND (
+        subq_40.listing__country_latest IS NULL
+      )
     )
   ) AND (
     (
-      subq_28.listing__country_latest = subq_37.listing__country_latest
+      subq_30.ds = subq_40.ds
     ) OR (
-      (
-        subq_28.listing__country_latest IS NULL
-      ) AND (
-        subq_37.listing__country_latest IS NULL
-      )
+      (subq_30.ds IS NULL) AND (subq_40.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,25 +1,23 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time
-  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
-  -- Pass Only Elements:
-  --   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+  -- Combine Metrics
   SELECT
-    subq_10.metric_time
-    , subq_10.booking_value_with_is_instant_constraint
-    , subq_10.booking_value
+    COALESCE(subq_6.metric_time, subq_11.metric_time) AS metric_time
+    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+    , subq_11.booking_value AS booking_value
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_5.metric_time AS metric_time
-      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_9.booking_value AS booking_value
+      subq_5.metric_time
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
         subq_4.metric_time
-        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
@@ -165,77 +163,83 @@ FROM (
       GROUP BY
         subq_4.metric_time
     ) subq_5
-    INNER JOIN (
+  ) subq_6
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time
+      , subq_10.booking_value
+    FROM (
       -- Aggregate Measures
       SELECT
-        subq_8.metric_time
-        , SUM(subq_8.booking_value) AS booking_value
+        subq_9.metric_time
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_7.metric_time
-          , subq_7.booking_value
+          subq_8.metric_time
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_6.ds
-            , subq_6.ds__week
-            , subq_6.ds__month
-            , subq_6.ds__quarter
-            , subq_6.ds__year
-            , subq_6.ds_partitioned
-            , subq_6.ds_partitioned__week
-            , subq_6.ds_partitioned__month
-            , subq_6.ds_partitioned__quarter
-            , subq_6.ds_partitioned__year
-            , subq_6.booking_paid_at
-            , subq_6.booking_paid_at__week
-            , subq_6.booking_paid_at__month
-            , subq_6.booking_paid_at__quarter
-            , subq_6.booking_paid_at__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds
-            , subq_6.create_a_cycle_in_the_join_graph__ds__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds__year
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_6.ds AS metric_time
-            , subq_6.ds__week AS metric_time__week
-            , subq_6.ds__month AS metric_time__month
-            , subq_6.ds__quarter AS metric_time__quarter
-            , subq_6.ds__year AS metric_time__year
-            , subq_6.listing
-            , subq_6.guest
-            , subq_6.host
-            , subq_6.create_a_cycle_in_the_join_graph
-            , subq_6.create_a_cycle_in_the_join_graph__listing
-            , subq_6.create_a_cycle_in_the_join_graph__guest
-            , subq_6.create_a_cycle_in_the_join_graph__host
-            , subq_6.is_instant
-            , subq_6.create_a_cycle_in_the_join_graph__is_instant
-            , subq_6.bookings
-            , subq_6.instant_bookings
-            , subq_6.booking_value
-            , subq_6.max_booking_value
-            , subq_6.min_booking_value
-            , subq_6.bookers
-            , subq_6.average_booking_value
-            , subq_6.referred_bookings
-            , subq_6.median_booking_value
-            , subq_6.booking_value_p99
-            , subq_6.discrete_booking_value_p99
-            , subq_6.approximate_continuous_booking_value_p99
-            , subq_6.approximate_discrete_booking_value_p99
+            subq_7.ds
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds_partitioned
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.booking_paid_at
+            , subq_7.booking_paid_at__week
+            , subq_7.booking_paid_at__month
+            , subq_7.booking_paid_at__quarter
+            , subq_7.booking_paid_at__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds
+            , subq_7.create_a_cycle_in_the_join_graph__ds__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds__year
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_7.ds AS metric_time
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.create_a_cycle_in_the_join_graph
+            , subq_7.create_a_cycle_in_the_join_graph__listing
+            , subq_7.create_a_cycle_in_the_join_graph__guest
+            , subq_7.create_a_cycle_in_the_join_graph__host
+            , subq_7.is_instant
+            , subq_7.create_a_cycle_in_the_join_graph__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -293,17 +297,17 @@ FROM (
               , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
               , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
-          ) subq_6
-        ) subq_7
-      ) subq_8
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_8.metric_time
-    ) subq_9
-    ON
-      (
-        subq_5.metric_time = subq_9.metric_time
-      ) OR (
-        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-      )
-  ) subq_10
-) subq_11
+        subq_9.metric_time
+    ) subq_10
+  ) subq_11
+  ON
+    (
+      subq_6.metric_time = subq_11.metric_time
+    ) OR (
+      (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+    )
+) subq_12

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,15 +1,14 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  subq_17.metric_time AS metric_time
-  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  COALESCE(subq_19.metric_time, subq_24.metric_time) AS metric_time
+  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     metric_time
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
@@ -23,27 +22,28 @@ FROM (
       , is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_14
+  ) subq_15
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_17
+) subq_19
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     ds AS metric_time
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
     ds
-) subq_21
+) subq_24
 ON
   (
-    subq_17.metric_time = subq_21.metric_time
+    subq_19.metric_time = subq_24.metric_time
   ) OR (
-    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    (subq_19.metric_time IS NULL) AND (subq_24.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -1,17 +1,15 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_9.bookings AS DOUBLE) / CAST(NULLIF(subq_9.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_10.bookings AS DOUBLE) / CAST(NULLIF(subq_10.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
-  -- Pass Only Elements:
-  --   ['bookings', 'listings']
+  -- Combine Metrics
   SELECT
-    subq_8.bookings
-    , subq_8.listings
+    subq_4.bookings AS bookings
+    , subq_9.listings AS listings
   FROM (
-    -- Join Aggregated Measures with Standard Outputs
+    -- Compute Metrics via Expressions
     SELECT
-      subq_3.bookings AS bookings
-      , subq_7.listings AS listings
+      subq_3.bookings
     FROM (
       -- Aggregate Measures
       SELECT
@@ -142,55 +140,60 @@ FROM (
         ) subq_1
       ) subq_2
     ) subq_3
-    CROSS JOIN (
+  ) subq_4
+  CROSS JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_8.listings
+    FROM (
       -- Aggregate Measures
       SELECT
-        SUM(subq_6.listings) AS listings
+        SUM(subq_7.listings) AS listings
       FROM (
         -- Pass Only Elements:
         --   ['listings']
         SELECT
-          subq_5.listings
+          subq_6.listings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.created_at
-            , subq_4.created_at__week
-            , subq_4.created_at__month
-            , subq_4.created_at__quarter
-            , subq_4.created_at__year
-            , subq_4.listing__ds
-            , subq_4.listing__ds__week
-            , subq_4.listing__ds__month
-            , subq_4.listing__ds__quarter
-            , subq_4.listing__ds__year
-            , subq_4.listing__created_at
-            , subq_4.listing__created_at__week
-            , subq_4.listing__created_at__month
-            , subq_4.listing__created_at__quarter
-            , subq_4.listing__created_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.user
-            , subq_4.listing__user
-            , subq_4.country_latest
-            , subq_4.is_lux_latest
-            , subq_4.capacity_latest
-            , subq_4.listing__country_latest
-            , subq_4.listing__is_lux_latest
-            , subq_4.listing__capacity_latest
-            , subq_4.listings
-            , subq_4.largest_listing
-            , subq_4.smallest_listing
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.created_at
+            , subq_5.created_at__week
+            , subq_5.created_at__month
+            , subq_5.created_at__quarter
+            , subq_5.created_at__year
+            , subq_5.listing__ds
+            , subq_5.listing__ds__week
+            , subq_5.listing__ds__month
+            , subq_5.listing__ds__quarter
+            , subq_5.listing__ds__year
+            , subq_5.listing__created_at
+            , subq_5.listing__created_at__week
+            , subq_5.listing__created_at__month
+            , subq_5.listing__created_at__quarter
+            , subq_5.listing__created_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.user
+            , subq_5.listing__user
+            , subq_5.country_latest
+            , subq_5.is_lux_latest
+            , subq_5.capacity_latest
+            , subq_5.listing__country_latest
+            , subq_5.listing__is_lux_latest
+            , subq_5.listing__capacity_latest
+            , subq_5.listings
+            , subq_5.largest_listing
+            , subq_5.smallest_listing
           FROM (
             -- Read Elements From Semantic Model 'listings_latest'
             SELECT
@@ -227,9 +230,9 @@ FROM (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_4
-        ) subq_5
-      ) subq_6
-    ) subq_7
-  ) subq_8
-) subq_9
+          ) subq_5
+        ) subq_6
+      ) subq_7
+    ) subq_8
+  ) subq_9
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,26 +1,26 @@
--- Join Aggregated Measures with Standard Outputs
--- Pass Only Elements:
---   ['bookings', 'listings']
+-- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_13.bookings AS DOUBLE) / CAST(NULLIF(subq_17.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(subq_15.bookings AS DOUBLE) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-) subq_13
+) subq_15
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings']
   -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_17
+) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -1,70 +1,64 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_23 -->
+        <!-- node_id = ss_24 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_437),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
         <!--    'column_alias': 'ds'}                                  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_436),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_440),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
         <!--    'column_alias': 'bookings_per_view'}                  -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
-            <!-- description =                                               -->
-            <!--   Pass Only Elements:                                       -->
-            <!--     ['bookings', 'views', 'listing__country_latest', 'ds']  -->
-            <!-- node_id = ss_22 -->
-            <!-- col0 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
-            <!--    'column_alias': 'ds'}                                  -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
-            <!--    'column_alias': 'listing__country_latest'}             -->
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_23 -->
+            <!-- col0 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'ds'}                                                          -->
+            <!-- col1 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'listing__country_latest'}                                     -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_432),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_433),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
             <!--    'column_alias': 'views'}                               -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_22),  -->
+            <!--    'right_source_alias': 'subq_19',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_4)}     -->
             <!-- where = None -->
             <SqlSelectStatementNode>
-                <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_21 -->
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_430),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                 <!--    'column_alias': 'bookings'}                            -->
-                <!-- col3 =                                                    -->
-                <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_431),  -->
-                <!--    'column_alias': 'views'}                               -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                <!-- join_0 =                                                   -->
-                <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),  -->
-                <!--    'right_source_alias': 'subq_17',                        -->
-                <!--    'join_type': SqlJoinType.INNER,                         -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_4)}     -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
@@ -926,74 +920,92 @@
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_22 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
+                <!--    'column_alias': 'ds'}                                  -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
+                <!--    'column_alias': 'listing__country_latest'}             -->
+                <!-- col2 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
+                <!--    'column_alias': 'views'}                               -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+                <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_20 -->
+                    <!-- node_id = ss_21 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
                     <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                     <!--    'column_alias': 'views'}                                                  -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- group_by1 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                   -->
                         <!--   Pass Only Elements:                           -->
                         <!--     ['views', 'listing__country_latest', 'ds']  -->
-                        <!-- node_id = ss_19 -->
+                        <!-- node_id = ss_20 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
                         <!--    'column_alias': 'views'}                               -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_18 -->
+                            <!-- node_id = ss_19 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_415),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
                             <!--    'column_alias': 'views'}                               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_17),   -->
-                            <!--    'right_source_alias': 'subq_14',                         -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),   -->
+                            <!--    'right_source_alias': 'subq_15',                         -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
                             <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
                             <!-- where = None -->
@@ -1001,147 +1013,147 @@
                                 <!-- description =                   -->
                                 <!--   Pass Only Elements:           -->
                                 <!--     ['views', 'ds', 'listing']  -->
-                                <!-- node_id = ss_15 -->
+                                <!-- node_id = ss_16 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
                                 <!--    'column_alias': 'views'}                               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_14 -->
+                                    <!-- node_id = ss_15 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col11 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col12 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col13 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col14 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col15 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col16 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col17 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col18 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col19 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col28 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col29 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                                     <!--    'column_alias': 'views'}                               -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10009) -->
                                     <!-- where = None -->
@@ -1266,167 +1278,167 @@
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['country_latest', 'listing']  -->
-                                <!-- node_id = ss_17 -->
+                                <!-- node_id = ss_18 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_413),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_16 -->
+                                    <!-- node_id = ss_17 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_412),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
@@ -1,58 +1,52 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_17 -->
+        <!-- node_id = ss_18 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
         <!--    'column_alias': 'instant_booking_value_ratio'}        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
-            <!-- description =                                                                     -->
-            <!--   Pass Only Elements:                                                             -->
-            <!--     ['booking_value_with_is_instant_constraint', 'booking_value', 'metric_time']  -->
-            <!-- node_id = ss_16 -->
-            <!-- col0 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
-            <!--    'column_alias': 'metric_time'}                         -->
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_17 -->
+            <!-- col0 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                  -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),        -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),        -->
             <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
             <!--    'column_alias': 'booking_value'}                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
+            <!--    'right_source_alias': 'subq_11',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
             <!-- where = None -->
             <SqlSelectStatementNode>
-                <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_15 -->
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_12 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),        -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),        -->
                 <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
-                <!-- col2 =                                                    -->
-                <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
-                <!--    'column_alias': 'booking_value'}                       -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
-                <!-- join_0 =                                                   -->
-                <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
-                <!--    'right_source_alias': 'subq_9',                         -->
-                <!--    'join_type': SqlJoinType.INNER,                         -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
@@ -64,7 +58,7 @@
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
                     <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
-                    <!--    'column_alias': 'booking_value_with_is_instant_constraint'}               -->
+                    <!--    'column_alias': 'booking_value'}                                          -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
@@ -583,268 +577,282 @@
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_16 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                <!--    'column_alias': 'booking_value'}                       -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_14 -->
+                    <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
                     <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                     <!--    'column_alias': 'booking_value'}                                          -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                         -->
                         <!--   Pass Only Elements:                 -->
                         <!--     ['booking_value', 'metric_time']  -->
-                        <!-- node_id = ss_13 -->
+                        <!-- node_id = ss_14 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_12 -->
+                            <!-- node_id = ss_13 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),    -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                             <!-- col16 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                             <!-- col17 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),           -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                             <!-- col18 =                                                              -->
                             <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),             -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),             -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                             <!-- col19 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                             <!-- col20 =                                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                             <!-- col21 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                             <!-- col22 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                             <!-- col23 =                                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                             <!-- col24 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                             <!-- col25 =                                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),                 -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                             <!-- col26 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                             <!-- col27 =                                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),                        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),                        -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                             <!-- col28 =                                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),                          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                             <!-- col29 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                             <!--    'column_alias': 'guest'}                               -->
                             <!-- col37 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                             <!--    'column_alias': 'host'}                                -->
                             <!-- col38 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                             <!-- col39 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                             <!-- col40 =                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                             <!-- col41 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- col42 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col43 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),            -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                             <!-- col44 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- col45 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                             <!--    'column_alias': 'instant_bookings'}                    -->
                             <!-- col46 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
                             <!-- col47 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                             <!--    'column_alias': 'max_booking_value'}                   -->
                             <!-- col48 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                             <!--    'column_alias': 'min_booking_value'}                   -->
                             <!-- col49 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                             <!--    'column_alias': 'bookers'}                             -->
                             <!-- col50 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col51 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                             <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col52 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                             <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col53 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                             <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col54 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
                             <!-- col55 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
                             <!-- col56 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
@@ -1,18 +1,16 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_15 -->
+        <!-- node_id = ss_16 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
         <!--    'column_alias': 'bookings_per_listing'}               -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
-            <!-- description =                 -->
-            <!--   Pass Only Elements:         -->
-            <!--     ['bookings', 'listings']  -->
-            <!-- node_id = ss_14 -->
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
@@ -21,26 +19,22 @@
             <!--   {'class': 'SqlSelectColumn',                            -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
             <!--    'column_alias': 'listings'}                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
+            <!--    'right_source_alias': 'subq_9',                         -->
+            <!--    'join_type': SqlJoinType.CROSS_JOIN,                    -->
+            <!--    'on_condition': None}                                   -->
             <!-- where = None -->
             <SqlSelectStatementNode>
-                <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_13 -->
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                 <!--    'column_alias': 'bookings'}                            -->
-                <!-- col1 =                                                    -->
-                <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
-                <!--    'column_alias': 'listings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
-                <!-- join_0 =                                                   -->
-                <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_12),  -->
-                <!--    'right_source_alias': 'subq_7',                         -->
-                <!--    'join_type': SqlJoinType.CROSS_JOIN,                    -->
-                <!--    'on_condition': None}                                   -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
@@ -521,176 +515,186 @@
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_14 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
+                <!--    'column_alias': 'listings'}                            -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_12 -->
+                    <!-- node_id = ss_13 -->
                     <!-- col0 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
                     <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                     <!--    'column_alias': 'listings'}                                               -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =          -->
                         <!--   Pass Only Elements:  -->
                         <!--     ['listings']       -->
-                        <!-- node_id = ss_11 -->
+                        <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                         <!--    'column_alias': 'listings'}                            -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_10 -->
+                            <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                             <!--    'column_alias': 'created_at'}                          -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                             <!--    'column_alias': 'created_at__week'}                    -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                             <!--    'column_alias': 'created_at__month'}                   -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                             <!--    'column_alias': 'created_at__quarter'}                 -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                             <!--    'column_alias': 'created_at__year'}                    -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                             <!--    'column_alias': 'listing__ds'}                         -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                             <!--    'column_alias': 'listing__ds__week'}                   -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                             <!--    'column_alias': 'listing__ds__month'}                  -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                             <!--    'column_alias': 'listing__ds__year'}                   -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                             <!--    'column_alias': 'listing__created_at'}                 -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                             <!--    'column_alias': 'listing__created_at__week'}           -->
                             <!-- col17 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                             <!--    'column_alias': 'listing__created_at__month'}          -->
                             <!-- col18 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                             <!--    'column_alias': 'listing__created_at__year'}           -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col21 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col22 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col23 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col24 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col25 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col26 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                             <!--    'column_alias': 'user'}                                -->
                             <!-- col27 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                             <!--    'column_alias': 'listing__user'}                       -->
                             <!-- col28 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                             <!--    'column_alias': 'country_latest'}                      -->
                             <!-- col29 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                             <!--    'column_alias': 'is_lux_latest'}                       -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                             <!--    'column_alias': 'capacity_latest'}                     -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                             <!--    'column_alias': 'listings'}                            -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                             <!--    'column_alias': 'largest_listing'}                     -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                             <!--    'column_alias': 'smallest_listing'}                    -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = wrd_0 -->
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
-            <!-- node_id = cbm_0 -->
+            <!-- node_id = cbm_2 -->
             <!-- join type = SqlJoinType.FULL_OUTER -->
             <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
-                <!-- node_id = cm_0 -->
+                <!-- node_id = cm_2 -->
                 <!-- metric_spec =                              -->
                 <!--   {'class': 'MetricSpec',                  -->
                 <!--    'element_name': 'bookings_per_booker',  -->
@@ -17,46 +17,101 @@
                 <!--    'alias': None,                          -->
                 <!--    'offset_window': None,                  -->
                 <!--    'offset_to_grain': None}                -->
-                <AggregateMeasuresNode>
-                    <!-- description = Aggregate Measures -->
-                    <!-- node_id = am_0 -->
-                    <FilterElementsNode>
-                        <!-- description =                               -->
-                        <!--   Pass Only Elements:                       -->
-                        <!--     ['bookings', 'bookers', 'metric_time']  -->
-                        <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                           -->
-                        <!--   {'class': 'MeasureSpec',               -->
-                        <!--    'element_name': 'bookings',           -->
-                        <!--    'non_additive_dimension_spec': None}  -->
-                        <!-- include_spec =                           -->
-                        <!--   {'class': 'MeasureSpec',               -->
-                        <!--    'element_name': 'bookers',            -->
-                        <!--    'non_additive_dimension_spec': None}  -->
-                        <!-- include_spec =                               -->
-                        <!--   {'class': 'TimeDimensionSpec',             -->
-                        <!--    'element_name': 'metric_time',            -->
-                        <!--    'entity_links': (),                       -->
-                        <!--    'time_granularity': TimeGranularity.DAY,  -->
-                        <!--    'aggregation_state': None}                -->
-                        <MetricTimeDimensionTransformNode>
-                            <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10001 -->
-                            <!-- aggregation_time_dimension = ds -->
-                            <ReadSqlSourceNode>
-                                <!-- description =                                                                                    -->
-                                <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                <!-- node_id = rss_10011 -->
-                                <!-- data_set =                                                                             -->
-                                <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                            </ReadSqlSourceNode>
-                        </MetricTimeDimensionTransformNode>
-                    </FilterElementsNode>
-                </AggregateMeasuresNode>
+                <CombineMetricsNode>
+                    <!-- description = Combine Metrics -->
+                    <!-- node_id = cbm_0 -->
+                    <!-- join type = SqlJoinType.INNER -->
+                    <ComputeMetricsNode>
+                        <!-- description = Compute Metrics via Expressions -->
+                        <!-- node_id = cm_0 -->
+                        <!-- metric_spec =                   -->
+                        <!--   {'class': 'MetricSpec',       -->
+                        <!--    'element_name': 'bookings',  -->
+                        <!--    'constraint': None,          -->
+                        <!--    'alias': None,               -->
+                        <!--    'offset_window': None,       -->
+                        <!--    'offset_to_grain': None}     -->
+                        <AggregateMeasuresNode>
+                            <!-- description = Aggregate Measures -->
+                            <!-- node_id = am_0 -->
+                            <FilterElementsNode>
+                                <!-- description =                    -->
+                                <!--   Pass Only Elements:            -->
+                                <!--     ['bookings', 'metric_time']  -->
+                                <!-- node_id = pfe_0 -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'bookings',           -->
+                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!-- include_spec =                               -->
+                                <!--   {'class': 'TimeDimensionSpec',             -->
+                                <!--    'element_name': 'metric_time',            -->
+                                <!--    'entity_links': (),                       -->
+                                <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                <!--    'aggregation_state': None}                -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = Metric Time Dimension 'ds' -->
+                                    <!-- node_id = sma_10001 -->
+                                    <!-- aggregation_time_dimension = ds -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                                    -->
+                                        <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        <!-- node_id = rss_10011 -->
+                                        <!-- data_set =                                                                             -->
+                                        <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </AggregateMeasuresNode>
+                    </ComputeMetricsNode>
+                    <ComputeMetricsNode>
+                        <!-- description = Compute Metrics via Expressions -->
+                        <!-- node_id = cm_1 -->
+                        <!-- metric_spec =                  -->
+                        <!--   {'class': 'MetricSpec',      -->
+                        <!--    'element_name': 'bookers',  -->
+                        <!--    'constraint': None,         -->
+                        <!--    'alias': None,              -->
+                        <!--    'offset_window': None,      -->
+                        <!--    'offset_to_grain': None}    -->
+                        <AggregateMeasuresNode>
+                            <!-- description = Aggregate Measures -->
+                            <!-- node_id = am_1 -->
+                            <FilterElementsNode>
+                                <!-- description =                   -->
+                                <!--   Pass Only Elements:           -->
+                                <!--     ['bookers', 'metric_time']  -->
+                                <!-- node_id = pfe_1 -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'bookers',            -->
+                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!-- include_spec =                               -->
+                                <!--   {'class': 'TimeDimensionSpec',             -->
+                                <!--    'element_name': 'metric_time',            -->
+                                <!--    'entity_links': (),                       -->
+                                <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                <!--    'aggregation_state': None}                -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = Metric Time Dimension 'ds' -->
+                                    <!-- node_id = sma_10001 -->
+                                    <!-- aggregation_time_dimension = ds -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                                    -->
+                                        <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        <!-- node_id = rss_10011 -->
+                                        <!-- data_set =                                                                             -->
+                                        <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </AggregateMeasuresNode>
+                    </ComputeMetricsNode>
+                </CombineMetricsNode>
             </ComputeMetricsNode>
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
-                <!-- node_id = cm_1 -->
+                <!-- node_id = cm_5 -->
                 <!-- metric_spec =                              -->
                 <!--   {'class': 'MetricSpec',                  -->
                 <!--    'element_name': 'bookings_per_dollar',  -->
@@ -64,42 +119,97 @@
                 <!--    'alias': None,                          -->
                 <!--    'offset_window': None,                  -->
                 <!--    'offset_to_grain': None}                -->
-                <AggregateMeasuresNode>
-                    <!-- description = Aggregate Measures -->
-                    <!-- node_id = am_1 -->
-                    <FilterElementsNode>
-                        <!-- description =                                     -->
-                        <!--   Pass Only Elements:                             -->
-                        <!--     ['bookings', 'booking_value', 'metric_time']  -->
-                        <!-- node_id = pfe_1 -->
-                        <!-- include_spec =                           -->
-                        <!--   {'class': 'MeasureSpec',               -->
-                        <!--    'element_name': 'bookings',           -->
-                        <!--    'non_additive_dimension_spec': None}  -->
-                        <!-- include_spec =                           -->
-                        <!--   {'class': 'MeasureSpec',               -->
-                        <!--    'element_name': 'booking_value',      -->
-                        <!--    'non_additive_dimension_spec': None}  -->
-                        <!-- include_spec =                               -->
-                        <!--   {'class': 'TimeDimensionSpec',             -->
-                        <!--    'element_name': 'metric_time',            -->
-                        <!--    'entity_links': (),                       -->
-                        <!--    'time_granularity': TimeGranularity.DAY,  -->
-                        <!--    'aggregation_state': None}                -->
-                        <MetricTimeDimensionTransformNode>
-                            <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10001 -->
-                            <!-- aggregation_time_dimension = ds -->
-                            <ReadSqlSourceNode>
-                                <!-- description =                                                                                    -->
-                                <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                <!-- node_id = rss_10011 -->
-                                <!-- data_set =                                                                             -->
-                                <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                            </ReadSqlSourceNode>
-                        </MetricTimeDimensionTransformNode>
-                    </FilterElementsNode>
-                </AggregateMeasuresNode>
+                <CombineMetricsNode>
+                    <!-- description = Combine Metrics -->
+                    <!-- node_id = cbm_1 -->
+                    <!-- join type = SqlJoinType.INNER -->
+                    <ComputeMetricsNode>
+                        <!-- description = Compute Metrics via Expressions -->
+                        <!-- node_id = cm_3 -->
+                        <!-- metric_spec =                   -->
+                        <!--   {'class': 'MetricSpec',       -->
+                        <!--    'element_name': 'bookings',  -->
+                        <!--    'constraint': None,          -->
+                        <!--    'alias': None,               -->
+                        <!--    'offset_window': None,       -->
+                        <!--    'offset_to_grain': None}     -->
+                        <AggregateMeasuresNode>
+                            <!-- description = Aggregate Measures -->
+                            <!-- node_id = am_2 -->
+                            <FilterElementsNode>
+                                <!-- description =                    -->
+                                <!--   Pass Only Elements:            -->
+                                <!--     ['bookings', 'metric_time']  -->
+                                <!-- node_id = pfe_2 -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'bookings',           -->
+                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!-- include_spec =                               -->
+                                <!--   {'class': 'TimeDimensionSpec',             -->
+                                <!--    'element_name': 'metric_time',            -->
+                                <!--    'entity_links': (),                       -->
+                                <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                <!--    'aggregation_state': None}                -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = Metric Time Dimension 'ds' -->
+                                    <!-- node_id = sma_10001 -->
+                                    <!-- aggregation_time_dimension = ds -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                                    -->
+                                        <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        <!-- node_id = rss_10011 -->
+                                        <!-- data_set =                                                                             -->
+                                        <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </AggregateMeasuresNode>
+                    </ComputeMetricsNode>
+                    <ComputeMetricsNode>
+                        <!-- description = Compute Metrics via Expressions -->
+                        <!-- node_id = cm_4 -->
+                        <!-- metric_spec =                        -->
+                        <!--   {'class': 'MetricSpec',            -->
+                        <!--    'element_name': 'booking_value',  -->
+                        <!--    'constraint': None,               -->
+                        <!--    'alias': None,                    -->
+                        <!--    'offset_window': None,            -->
+                        <!--    'offset_to_grain': None}          -->
+                        <AggregateMeasuresNode>
+                            <!-- description = Aggregate Measures -->
+                            <!-- node_id = am_3 -->
+                            <FilterElementsNode>
+                                <!-- description =                         -->
+                                <!--   Pass Only Elements:                 -->
+                                <!--     ['booking_value', 'metric_time']  -->
+                                <!-- node_id = pfe_3 -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'booking_value',      -->
+                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!-- include_spec =                               -->
+                                <!--   {'class': 'TimeDimensionSpec',             -->
+                                <!--    'element_name': 'metric_time',            -->
+                                <!--    'entity_links': (),                       -->
+                                <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                <!--    'aggregation_state': None}                -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = Metric Time Dimension 'ds' -->
+                                    <!-- node_id = sma_10001 -->
+                                    <!-- aggregation_time_dimension = ds -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                                    -->
+                                        <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        <!-- node_id = rss_10011 -->
+                                        <!-- data_set =                                                                             -->
+                                        <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </AggregateMeasuresNode>
+                    </ComputeMetricsNode>
+                </CombineMetricsNode>
             </ComputeMetricsNode>
         </CombineMetricsNode>
     </WriteToResultDataframeNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = wrd_1 -->
         <ComputeMetricsNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = cm_4 -->
+            <!-- node_id = cm_15 -->
             <!-- metric_spec =                              -->
             <!--   {'class': 'MetricSpec',                  -->
             <!--    'element_name': 'bookings_per_booker',  -->
@@ -19,46 +19,78 @@
             <!--    'alias': None,                          -->
             <!--    'offset_window': None,                  -->
             <!--    'offset_to_grain': None}                -->
-            <AggregateMeasuresNode>
-                <!-- description = Aggregate Measures -->
-                <!-- node_id = am_4 -->
-                <FilterElementsNode>
-                    <!-- description =                                                -->
-                    <!--   Pass Only Elements:                                        -->
-                    <!--     ['bookings', 'bookers', 'booking_value', 'metric_time']  -->
-                    <!-- node_id = pfe_4 -->
-                    <!-- include_spec =                           -->
-                    <!--   {'class': 'MeasureSpec',               -->
-                    <!--    'element_name': 'bookings',           -->
-                    <!--    'non_additive_dimension_spec': None}  -->
-                    <!-- include_spec =                           -->
-                    <!--   {'class': 'MeasureSpec',               -->
-                    <!--    'element_name': 'bookers',            -->
-                    <!--    'non_additive_dimension_spec': None}  -->
-                    <!-- include_spec =                           -->
-                    <!--   {'class': 'MeasureSpec',               -->
-                    <!--    'element_name': 'booking_value',      -->
-                    <!--    'non_additive_dimension_spec': None}  -->
-                    <!-- include_spec =                               -->
-                    <!--   {'class': 'TimeDimensionSpec',             -->
-                    <!--    'element_name': 'metric_time',            -->
-                    <!--    'entity_links': (),                       -->
-                    <!--    'time_granularity': TimeGranularity.DAY,  -->
-                    <!--    'aggregation_state': None}                -->
-                    <MetricTimeDimensionTransformNode>
-                        <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = sma_2 -->
-                        <!-- aggregation_time_dimension = ds -->
-                        <ReadSqlSourceNode>
-                            <!-- description =                                                                                    -->
-                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                            <!-- node_id = rss_2 -->
-                            <!-- data_set =                                                                             -->
-                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                        </ReadSqlSourceNode>
-                    </MetricTimeDimensionTransformNode>
-                </FilterElementsNode>
-            </AggregateMeasuresNode>
+            <ComputeMetricsNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = cm_14 -->
+                <!-- metric_spec =                   -->
+                <!--   {'class': 'MetricSpec',       -->
+                <!--    'element_name': 'bookings',  -->
+                <!--    'constraint': None,          -->
+                <!--    'alias': None,               -->
+                <!--    'offset_window': None,       -->
+                <!--    'offset_to_grain': None}     -->
+                <!-- metric_spec =                  -->
+                <!--   {'class': 'MetricSpec',      -->
+                <!--    'element_name': 'bookers',  -->
+                <!--    'constraint': None,         -->
+                <!--    'alias': None,              -->
+                <!--    'offset_window': None,      -->
+                <!--    'offset_to_grain': None}    -->
+                <!-- metric_spec =                   -->
+                <!--   {'class': 'MetricSpec',       -->
+                <!--    'element_name': 'bookings',  -->
+                <!--    'constraint': None,          -->
+                <!--    'alias': None,               -->
+                <!--    'offset_window': None,       -->
+                <!--    'offset_to_grain': None}     -->
+                <!-- metric_spec =                        -->
+                <!--   {'class': 'MetricSpec',            -->
+                <!--    'element_name': 'booking_value',  -->
+                <!--    'constraint': None,               -->
+                <!--    'alias': None,                    -->
+                <!--    'offset_window': None,            -->
+                <!--    'offset_to_grain': None}          -->
+                <AggregateMeasuresNode>
+                    <!-- description = Aggregate Measures -->
+                    <!-- node_id = am_10 -->
+                    <FilterElementsNode>
+                        <!-- description =                                                -->
+                        <!--   Pass Only Elements:                                        -->
+                        <!--     ['bookings', 'bookers', 'booking_value', 'metric_time']  -->
+                        <!-- node_id = pfe_10 -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookers',            -->
+                        <!--    'non_additive_dimension_spec': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'booking_value',      -->
+                        <!--    'non_additive_dimension_spec': None}  -->
+                        <!-- include_spec =                               -->
+                        <!--   {'class': 'TimeDimensionSpec',             -->
+                        <!--    'element_name': 'metric_time',            -->
+                        <!--    'entity_links': (),                       -->
+                        <!--    'time_granularity': TimeGranularity.DAY,  -->
+                        <!--    'aggregation_state': None}                -->
+                        <MetricTimeDimensionTransformNode>
+                            <!-- description = Metric Time Dimension 'ds' -->
+                            <!-- node_id = sma_6 -->
+                            <!-- aggregation_time_dimension = ds -->
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                                    -->
+                                <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                <!-- node_id = rss_6 -->
+                                <!-- data_set =                                                                             -->
+                                <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
+                        </MetricTimeDimensionTransformNode>
+                    </FilterElementsNode>
+                </AggregateMeasuresNode>
+            </ComputeMetricsNode>
         </ComputeMetricsNode>
     </WriteToResultDataframeNode>
 </DataflowPlan>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "more-itertools==8.10.0",
   "numpy>=1.22.2",
   "pandas~=1.3.0",
-  "psycopg2~=2.9.3",
+  "psycopg2-binary~=2.9.3",
   "pydantic~=1.10.0",
   "python-dateutil==2.8.2",
   "rapidfuzz==3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "databricks-sql-connector==2.0.3",
   # Pin to 1.5 for now
   "dbt-core==1.5.0",
-  "dbt-semantic-interfaces==0.1.0.dev6",
+  "dbt-semantic-interfaces==0.1.0.dev7",
   "duckdb-engine~=0.1.8",
   "duckdb==0.3.4",
   "google-auth~=2.13.0",


### PR DESCRIPTION
Resolves #504

### Description

When defining ratio metrics, measures are currently used to define them. To provide the most flexibility, this PR changes ratio metrics to use metrics when defining them instead.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)