### PR TITLE
`explain_get_dimension_values` & `get_dimension_values` takes metrics lists

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230623-103932.yaml
+++ b/.changes/unreleased/Breaking Changes-20230623-103932.yaml
@@ -1,7 +1,0 @@
-kind: Breaking Changes
-body: This change allows `explain_get_dimension_values` to take a list of metrics
-  and group_by parameters to allow for more flexible integrations.
-time: 2023-06-23T10:39:32.629896-05:00
-custom:
-  Author: DevonFulcher
-  Issue: None

--- a/.changes/unreleased/Breaking Changes-20230623-103932.yaml
+++ b/.changes/unreleased/Breaking Changes-20230623-103932.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: This change allows `explain_get_dimension_values` to take a list of metrics
+  and group_by parameters to allow for more flexible integrations.
+time: 2023-06-23T10:39:32.629896-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/.changes/unreleased/Breaking Changes-20230626-113920.yaml
+++ b/.changes/unreleased/Breaking Changes-20230626-113920.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: '`explain_get_dimension_values` & `get_dimension_values` take a list of metrics
+  parameters'
+time: 2023-06-26T11:39:20.189704-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -207,7 +207,11 @@ class MetricFlowClient:
         return self.engine.simple_dimensions_for_metrics(metric_names=metric_names)
 
     def get_dimension_values(
-        self, metric_names: List[str], dimension_name: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+        self,
+        metric_names: List[str],
+        dimension_name: str,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
     ) -> List[str]:
         """Retrieves a list of dimension values given a [metric_name, dimension_name].
 

--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -212,7 +212,7 @@ class MetricFlowClient:
         """Retrieves a list of dimension values given a [metric_name, dimension_name].
 
         Args:
-            metric_name: Name of metric that contains the group_by.
+            metric_names: Names of metrics that contain the group_by.
             dimension_name: Name of group_by to get values from.
             start_time: Get data for the start of this time range.
             end_time: Get data for the end of this time range.

--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -207,7 +207,7 @@ class MetricFlowClient:
         return self.engine.simple_dimensions_for_metrics(metric_names=metric_names)
 
     def get_dimension_values(
-        self, metric_name: str, dimension_name: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+        self, metric_names: List[str], dimension_name: str, start_time: Optional[str] = None, end_time: Optional[str] = None
     ) -> List[str]:
         """Retrieves a list of dimension values given a [metric_name, dimension_name].
 
@@ -223,7 +223,7 @@ class MetricFlowClient:
         parsed_start_time = convert_to_datetime(start_time)
         parsed_end_time = convert_to_datetime(end_time)
         return self.engine.get_dimension_values(
-            metric_name=metric_name,
+            metric_names=metric_names,
             get_group_by_values=dimension_name,
             time_constraint_start=parsed_start_time,
             time_constraint_end=parsed_end_time,

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -521,7 +521,12 @@ def health_checks(cfg: CLIContext) -> None:
 
 @list.command()
 @click.option("--dimension", required=True, type=str, help="Dimension to query values from")
-@click.option("--metrics", required=True, type=click_custom.SequenceParamType(min_length=1), help="Metrics that are associated with the dimension")
+@click.option(
+    "--metrics",
+    required=True,
+    type=click_custom.SequenceParamType(min_length=1),
+    help="Metrics that are associated with the dimension",
+)
 @start_end_time_options
 @pass_config
 @exception_handler
@@ -562,7 +567,9 @@ def dimension_values(
         exit(1)
 
     assert dim_vals
-    spinner.succeed(f"🌱 We've found {len(dim_vals)} dimension values for dimension {dimension} of metrics {', '.join(metrics)}.")
+    spinner.succeed(
+        f"🌱 We've found {len(dim_vals)} dimension values for dimension {dimension} of metrics {', '.join(metrics)}."
+    )
     for dim_val in dim_vals:
         click.echo(f"• {click.style(dim_val, bold=True, fg='green')}")
 

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -533,7 +533,7 @@ def dimension_values(
     start_time: Optional[dt.datetime] = None,
     end_time: Optional[dt.datetime] = None,
 ) -> None:
-    """List all dimension values with the corresponding metric."""
+    """List all dimension values with the corresponding metrics."""
     spinner = Halo(
         text=f"🔍 Retrieving dimension values for dimension '{dimension}' of metrics '{', '.join(metrics)}'...",
         spinner="dots",

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -521,21 +521,21 @@ def health_checks(cfg: CLIContext) -> None:
 
 @list.command()
 @click.option("--dimension", required=True, type=str, help="Dimension to query values from")
-@click.option("--metric", required=True, type=str, help="Metric that is associated with the dimension")
+@click.option("--metrics", required=True, type=click_custom.SequenceParamType(min_length=1), help="Metrics that are associated with the dimension")
 @start_end_time_options
 @pass_config
 @exception_handler
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
 def dimension_values(
     cfg: CLIContext,
-    metric: str,
+    metrics: List[str],
     dimension: str,
     start_time: Optional[dt.datetime] = None,
     end_time: Optional[dt.datetime] = None,
 ) -> None:
     """List all dimension values with the corresponding metric."""
     spinner = Halo(
-        text=f"🔍 Retrieving dimension values for dimension '{dimension}' of metric '{metric}'...",
+        text=f"🔍 Retrieving dimension values for dimension '{dimension}' of metrics '{', '.join(metrics)}'...",
         spinner="dots",
     )
     spinner.start()
@@ -544,7 +544,7 @@ def dimension_values(
 
     try:
         dim_vals = cfg.mf.get_dimension_values(
-            metric_names=[metric],
+            metric_names=metrics,
             get_group_by_values=dimension,
             time_constraint_start=start_time,
             time_constraint_end=end_time,
@@ -554,7 +554,7 @@ def dimension_values(
         click.echo(
             textwrap.dedent(
                 f"""\
-                ❌ Failed to query dimension values for dimension {dimension} of metric {metric}.
+                ❌ Failed to query dimension values for dimension {dimension} of metrics {', '.join(metrics)}.
                     ERROR: {str(e)}
                 """
             )
@@ -562,7 +562,7 @@ def dimension_values(
         exit(1)
 
     assert dim_vals
-    spinner.succeed(f"🌱 We've found {len(dim_vals)} dimension values for dimension {dimension} of metric {metric}.")
+    spinner.succeed(f"🌱 We've found {len(dim_vals)} dimension values for dimension {dimension} of metrics {', '.join(metrics)}.")
     for dim_val in dim_vals:
         click.echo(f"• {click.style(dim_val, bold=True, fg='green')}")
 

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -544,7 +544,7 @@ def dimension_values(
 
     try:
         dim_vals = cfg.mf.get_dimension_values(
-            metric_name=metric,
+            metric_names=[metric],
             get_group_by_values=dimension,
             time_constraint_start=start_time,
             time_constraint_end=end_time,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -269,8 +269,8 @@ class AbstractMetricFlowEngine(ABC):
     @abstractmethod
     def explain_get_dimension_values(  # noqa: D
         self,
-        metric_name: str,
-        get_group_by_values: str,
+        metric_names: List[str],
+        get_group_by_values: List[str],
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
@@ -616,15 +616,15 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def explain_get_dimension_values(  # noqa: D
         self,
-        metric_name: str,
-        get_group_by_values: str,
+        metric_names: List[str],
+        get_group_by_values: List[str],
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
         return self._create_execution_plan(
             MetricFlowQueryRequest.create_with_random_request_id(
-                metric_names=[metric_name],
-                group_by_names=[get_group_by_values],
+                metric_names=metric_names,
+                group_by_names=get_group_by_values,
                 time_constraint_start=time_constraint_start,
                 time_constraint_end=time_constraint_end,
                 query_type=MetricFlowQueryType.DIMENSION_VALUES,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -270,7 +270,7 @@ class AbstractMetricFlowEngine(ABC):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: List[str],
-        get_group_by_values: List[str],
+        get_group_by_value: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
@@ -617,14 +617,14 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: List[str],
-        get_group_by_values: List[str],
+        get_group_by_value: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
         return self._create_execution_plan(
             MetricFlowQueryRequest.create_with_random_request_id(
                 metric_names=metric_names,
-                group_by_names=get_group_by_values,
+                group_by_names=[get_group_by_value],
                 time_constraint_start=time_constraint_start,
                 time_constraint_end=time_constraint_end,
                 query_type=MetricFlowQueryType.DIMENSION_VALUES,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -256,7 +256,7 @@ class AbstractMetricFlowEngine(ABC):
         """Retrieves a list of dimension values given a [metric_name, get_group_by_values].
 
         Args:
-            metric_name: Names of metric that contain the group_by.
+            metric_name: Names of metrics that contain the group_by.
             get_group_by_values: Name of group_by to get values from.
             time_constraint_start: Get data for the start of this time range.
             time_constraint_end: Get data for the end of this time range.

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -248,7 +248,7 @@ class AbstractMetricFlowEngine(ABC):
     @abstractmethod
     def get_dimension_values(
         self,
-        metric_name: str,
+        metric_names: List[str],
         get_group_by_values: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
@@ -256,7 +256,7 @@ class AbstractMetricFlowEngine(ABC):
         """Retrieves a list of dimension values given a [metric_name, get_group_by_values].
 
         Args:
-            metric_name: Name of metric that contains the group_by.
+            metric_name: Names of metric that contain the group_by.
             get_group_by_values: Name of group_by to get values from.
             time_constraint_start: Get data for the start of this time range.
             time_constraint_end: Get data for the end of this time range.
@@ -270,14 +270,14 @@ class AbstractMetricFlowEngine(ABC):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: List[str],
-        get_group_by_value: str,
+        get_group_by_values: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
         """Returns the SQL query for get_dimension_values.
 
         Args:
-            metric_name: Name of metric that contains the group_by.
+            metric_name: Names of metrics that contain the group_by.
             get_group_by_values: Name of group_by to get values from.
             time_constraint_start: Get data for the start of this time range.
             time_constraint_end: Get data for the end of this time range.
@@ -593,7 +593,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def get_dimension_values(  # noqa: D
         self,
-        metric_name: str,
+        metric_names: List[str],
         get_group_by_values: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
@@ -601,7 +601,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         # Run query
         query_result = self.query(
             MetricFlowQueryRequest.create_with_random_request_id(
-                metric_names=[metric_name],
+                metric_names=metric_names,
                 group_by_names=[get_group_by_values],
                 time_constraint_start=time_constraint_start,
                 time_constraint_end=time_constraint_end,
@@ -617,14 +617,14 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: List[str],
-        get_group_by_value: str,
+        get_group_by_values: str,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
         return self._create_execution_plan(
             MetricFlowQueryRequest.create_with_random_request_id(
                 metric_names=metric_names,
-                group_by_names=[get_group_by_value],
+                group_by_names=[get_group_by_values],
                 time_constraint_start=time_constraint_start,
                 time_constraint_end=time_constraint_end,
                 query_type=MetricFlowQueryType.DIMENSION_VALUES,

--- a/metricflow/test/api/test_metricflow_client.py
+++ b/metricflow/test/api/test_metricflow_client.py
@@ -82,7 +82,7 @@ def test_list_dimensions(mf_client: MetricFlowClient) -> None:  # noqa: D
 
 
 def test_get_dimension_values(mf_client: MetricFlowClient) -> None:  # noqa: D
-    dim_vals = mf_client.get_dimension_values("bookings", "ds", start_time="2020-01-01", end_time="2024-01-01")
+    dim_vals = mf_client.get_dimension_values(["bookings"], "ds", start_time="2020-01-01", end_time="2024-01-01")
     assert dim_vals
 
 

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -57,7 +57,7 @@ def test_list_metrics(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 
 
 def test_get_dimension_values(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
-    resp = cli_runner.run(dimension_values, args=["--metric", "bookings", "--dimension", "is_instant"])
+    resp = cli_runner.run(dimension_values, args=["--metrics", "bookings", "--dimension", "is_instant"])
 
     actual_output_lines = sorted(resp.output.split("\n"))
     assert ["", "• False", "• True"] == actual_output_lines


### PR DESCRIPTION
### Description

Fixes SLA-116 (private to dbt Labs)

This change allows `explain_get_dimension_values` & `get_dimension_values` to take a list of metrics parameters to allow for more flexible integrations, specifically in the Jinja interface.