### PR TITLE
Use Persistent Source Schema for CI Tests

### DIFF
--- a/.github/actions/run-mf-tests/action.yaml
+++ b/.github/actions/run-mf-tests/action.yaml
@@ -21,6 +21,10 @@ inputs:
     description: "The target to use for the make command."
     required: false
     default: "test"
+  additional-pytest-options:
+    description: "Additional options to pass into pytest."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -30,7 +34,11 @@ runs:
       python-version: "${{ inputs.python-version }}"
   - name: Run Tests
     shell: bash
-    run: make -e PARALLELISM=${{ inputs.parallelism }} ${{ inputs.make-target }}
+    run: >
+      make -e
+      PARALLELISM=${{ inputs.parallelism }}
+      ADDITIONAL_PYTEST_OPTIONS="${{ inputs.additional-pytest-options }}"
+      ${{ inputs.make-target }}
     env:
       MF_SQL_ENGINE_URL: ${{ inputs.mf_sql_engine_url }}
       MF_SQL_ENGINE_PASSWORD: ${{ inputs.mf_sql_engine_password }}

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -33,11 +33,12 @@ runs:
         ~/.cache/hatch
         ~/.cache/pre-commit
       # >- means combine all lines to a single line
+      # The cache key can be any string. The format used here is just for readability.
       key: >-
-        python_location="${{ env.pythonLocation }}"/
-        pyproject_hash="${{ hashFiles('pyproject.toml') }}"/
-        precommit_config_hash="${{ hashFiles('.pre-commit-config.yaml') }}"/
-        linux_release="${{ env.LINUX_RELEASE }}"}
+        python_location: "${{ env.pythonLocation }}" AND
+        pyproject_hash: "${{ hashFiles('pyproject.toml') }}" AND
+        precommit_config_hash: "${{ hashFiles('.pre-commit-config.yaml') }}" AND
+        linux_release: "${{ env.LINUX_RELEASE }}"
 
   - name: Install Hatch
     shell: bash

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -12,6 +12,7 @@ on:
 env:
   PYTHON_VERSION: "3.8"
   EXTERNAL_ENGINE_TEST_PARALLELISM: 8
+  ADDITIONAL_PYTEST_OPTIONS: "--use-persistent-source-schema"
 
 jobs:
   snowflake-tests:
@@ -31,6 +32,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_SNOWFLAKE_URL }}
           mf_sql_engine_password: ${{ secrets.MF_SNOWFLAKE_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
 
   redshift-tests:
     environment: DW_INTEGRATION_TESTS
@@ -49,6 +51,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_REDSHIFT_URL }}
           mf_sql_engine_password: ${{ secrets.MF_REDSHIFT_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
 
   bigquery-tests:
     environment: DW_INTEGRATION_TESTS
@@ -67,6 +70,7 @@ jobs:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
 
   databricks-cluster-tests:
     environment: DW_INTEGRATION_TESTS
@@ -85,6 +89,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_DATABRICKS_CLUSTER_URL }}
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
 
   databricks-sql-warehouse-tests:
     environment: DW_INTEGRATION_TESTS
@@ -103,6 +108,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_DATABRICKS_SQL_WAREHOUSE_URL }}
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
 
   slack-failure:
     environment: DW_INTEGRATION_TESTS

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 
 # Controls the number of parallel workers running tests. Try "make -e PARALLELISM=4 test".
 PARALLELISM = "auto"
+# Additional command line options to pass to pytest.
+ADDITIONAL_PYTEST_OPTIONS = ""
 
 # Install Hatch package / project manager
 .PHONY: install-hatch
@@ -13,20 +15,20 @@ install-hatch:
 # Testing and linting
 .PHONY: test-core
 test-core:
-	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) metricflow/test --ignore metricflow/test/model/dbt_cloud_parsing/
+	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test --ignore metricflow/test/model/dbt_cloud_parsing/
 
 # Test that depend on dbt-related packages.
 .PHONY: test-dbt-associated
 test-dbt-associated:
-	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) metricflow/test/model/dbt_cloud_parsing/
+	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/model/dbt_cloud_parsing/
 
 .PHONY: test
 test:
-	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) metricflow/test/
+	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
 
 .PHONY: test-postgresql
 test-postgresql:
-	hatch -v run postgres-env:pytest -vv -n $(PARALLELISM) metricflow/test/
+	hatch -v run postgres-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
 
 .PHONY: lint
 lint:

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -72,6 +72,13 @@ def create_source_tables(
 
     If a table with a given name already exists in the source schema, it's assumed to have the expected schema / data.
     """
+    if mf_test_session_state.use_persistent_source_schema:
+        logger.info(
+            "This session was configured to use a persistent source schema, so this fixture won't create new tables. "
+            "See populate_source_schema() for more details."
+        )
+        return
+
     create_tables_listed_in_table_snapshot_repository(
         sql_client=sql_client,
         schema_name=mf_test_session_state.mf_source_schema,

--- a/metricflow/test/table_snapshot/table_snapshots.py
+++ b/metricflow/test/table_snapshot/table_snapshots.py
@@ -140,6 +140,8 @@ class SqlTableSnapshotRestorer:
         self._sql_client.create_table_from_dataframe(
             sql_table=sql_table,
             df=table_snapshot.as_df,
+            # Without this set, the insert queries may be too long.
+            chunk_size=500,
         )
 
 


### PR DESCRIPTION
### Description

Since the race condition with the previous setup for `--use-persistent-source-schema` has been resolved, enabling the flag for CI runs. With this change, SQL engine tests can finish in <4 mins:

https://github.com/dbt-labs/metricflow/actions/runs/5360383668/jobs/9725634762

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)