### PR TITLE
Update MetricFlow to depend on dbt-core 1.6.0.b6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow"
-version = "0.200.0.dev5"
+version = "0.200.0.dev6"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
 requires-python = ">=3.8,<3.10"
@@ -29,7 +29,7 @@ dependencies = [
   "SQLAlchemy~=1.4.42",
   "click>=7.1.2",
   "databricks-sql-connector==2.0.3",
-  "dbt-core==1.6.0b5",
+  "dbt-core==1.6.0b6",
   "dbt-semantic-interfaces==0.1.0.dev7",
   "duckdb-engine~=0.1.8",
   "duckdb==0.3.4",


### PR DESCRIPTION
The dbt <-> MetricFlow integration was broken in core 1.6.0.b5,
so we update our package to the beta release with the relevant fix.

This also updates the MF version for a deploy since we need the update
to propagate to our bundle package.