### PR TITLE
Apply semantic manifest transformations to json parsed output

### DIFF
--- a/.changes/unreleased/Fixes-20230626-110103.yaml
+++ b/.changes/unreleased/Fixes-20230626-110103.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Apply transformations to dbt-generated serialized model to fix issue with query
+  generation
+time: 2023-06-26T11:01:03.898209-07:00
+custom:
+  Author: tlento
+  Issue: "624"

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -89,8 +89,9 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
         """
     )
     bad_semantic_model = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    # JSON-stored manifests from dbt are not transformed, so we run this test on that style of output
     manifest = parse_yaml_files_to_validation_ready_semantic_manifest(
-        [base_semantic_manifest_file(), bad_semantic_model]
+        [base_semantic_manifest_file(), bad_semantic_model], apply_transformations=False
     ).semantic_manifest
 
     target_directory = Path().absolute() / "target"


### PR DESCRIPTION
The dbt-generated semantic manifest is not transformed, and as such
it fails at query time with inscrutable errors about missing metrics
which clearly appear in all of the manifest artifacts and runtime
objects.

This change applies the semantic manifest transformations to all
dbt-sourced json-serialized semantic manifests, and embeds the call
inside of the dbt-specific function in order to prevent confusion.

Longer term, we should refine these APIs and unify them across
dbt-semantic-interfaces and MetricFlow so that we can always be
clear about whether or not transformations are needed for a given
serialized object. This change eschews the boolean parameter approach
because we only have one mode for json parsing at this time. If we
add a second approach, this would likely benefit from separate
methods rather than passing in an "apply_transformations" flag.