### PR TITLE
Fix snapshot generation for postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,3 @@ postgresql postgres:
 .PHONY: regenerate-test-snapshots
 regenerate-test-snapshots:
 	hatch -v run dev-env:python metricflow/test/generate_snapshots.py
-	hatch -v run postgres-env:pytest -vv -n ${PARALLELISM} --overwrite-snapshots metricflow/test

--- a/metricflow/test/generate_snapshots.py
+++ b/metricflow/test/generate_snapshots.py
@@ -23,7 +23,11 @@ export MF_TEST_ENGINE_CREDENTIALS=$(cat <<EOF
     "databricks": {
         "engine_url": "databricks://...",
         "engine_password": "..."
-    }
+    },
+    "postgres": {
+        "engine_url": postgres://...",
+        "engine_password": "..."
+    },
 }
 EOF
 )
@@ -140,10 +144,9 @@ def run_tests(test_configuration: MetricFlowTestConfiguration, test_file_paths: 
         or test_configuration.engine is SqlEngine.SNOWFLAKE
         or test_configuration.engine is SqlEngine.BIGQUERY
         or test_configuration.engine is SqlEngine.DATABRICKS
+        or test_configuration.engine is SqlEngine.POSTGRES
     ):
         run_command(f"pytest -x -vv -n 4 --overwrite-snapshots --use-persistent-source-schema {combined_paths}")
-    elif test_configuration.engine is SqlEngine.POSTGRES:
-        raise NotImplementedError(f"{test_configuration.engine} is not yet supported in this script.")
     else:
         assert_values_exhausted(test_configuration.engine)
 


### PR DESCRIPTION
With the recent change back to URL-based credential management
for postgres tests, the batch snapshot generation script can
once again be used with postgres, while a direct invocation
within the makefile would fail due to the improper environment
configuration.

This consolidates the engine-specific snapshot generation back
into the script.