### PR TITLE
mf CLI throws an error if not in a working dbt root directory

### DIFF
--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -147,8 +147,8 @@ def error_if_not_in_dbt_project(func: Callable) -> Callable:
         if not dbt_project_file_exists():
             click.echo(
                 "❌ Unable to locate 'dbt_project.yml' in the current directory\n"
-                "In order to run the MetricFlow CLI, you must be running in the root directory of a complete dbt project.\n"
-                "Please run `mf tutorial` if you want to get started on building a dbt project."
+                "In order to run the MetricFlow CLI, you must be running in the root directory of a working dbt project.\n"
+                "Please check out `https://docs.getdbt.com/reference/commands/init` if you want to get started on building a dbt project."
             )
             exit(1)
         return ctx.invoke(func, *args, **kwargs)

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.test_utils import as_datetime
 from typing_extensions import override
 
 from metricflow.cli.cli_context import CLIContext
-from metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts
+from metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts, dbtProjectMetadata
 from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
@@ -44,6 +44,11 @@ class FakeCLIContext(CLIContext):
     @property
     @override
     def dbt_artifacts(self) -> dbtArtifacts:
+        raise NotImplementedError("FakeCLIContext does not load full dbt artifacts!")
+
+    @property
+    @override
+    def dbt_project_metadata(self) -> dbtProjectMetadata:
         raise NotImplementedError("FakeCLIContext does not load full dbt artifacts!")
 
     @property


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->



### Description
We initially allowed running some commands (only `mf tutorial`) without needing to be in a dbt project root directory. But because setting up the log file requires knowledge of the dbt log path, we must be in a dbt project when running the MF CLI. Refactored `mf tutorial` to expect being in a dbt project and also updated error message on how to build a new dbt project.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)