### PR TITLE
Fix tutorial loading with dbt project

### DIFF
--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -147,8 +147,8 @@ def error_if_not_in_dbt_project(func: Callable) -> Callable:
         if not dbt_project_file_exists():
             click.echo(
                 "❌ Unable to locate 'dbt_project.yml' in the current directory\n"
-                "In order to run the MetricFlow CLI, you must be running in the root directory of a complete dbt project.\n"
-                "Please run `mf tutorial` if you want to get started on building a dbt project."
+                "In order to run the MetricFlow CLI, you must be running in the root directory of a working dbt project.\n"
+                "Please check out `https://docs.getdbt.com/reference/commands/init` if you want to get started on building a dbt project."
             )
             exit(1)
         return ctx.invoke(func, *args, **kwargs)

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.test_utils import as_datetime
 from typing_extensions import override
 
 from metricflow.cli.cli_context import CLIContext
-from metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts
+from metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts, dbtProjectMetadata
 from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
@@ -45,6 +45,11 @@ class FakeCLIContext(CLIContext):
     @override
     def dbt_artifacts(self) -> dbtArtifacts:
         raise NotImplementedError("FakeCLIContext does not load full dbt artifacts!")
+
+    @property
+    @override
+    def dbt_project_metadata(self) -> dbtProjectMetadata:
+        raise NotImplementedError("FakeCLIContext does not load dbt project metadata!")
 
     @property
     @override


### PR DESCRIPTION
During some live testing of the tutorial we discovered two seemingly
separate but closely connected issues. First, running the tutorial
from outside of a dbt project root filled the terminal with error
trace output, and second the dreaded ResourceWarning was appearing
after certain commands.

The base of the issue was due to us having to initialize the dbt project
at the very start of the CLI invocation, before any of our handlers
were active, and then accidentally initializing it a second time
as part of the tutorial operations.

This PR fixes both issues by first ensuring that we will simply not
run the CLI at all if we are not in a dbt project root, and along
the way restructuring our dbt artifact loading stack such that
we only invoke the dbtRunner one time per process.