### PR TITLE
Bump dbt-metricflow to 0.0.2

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.0.1"
+version = "0.0.2"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
 requires-python = ">=3.8,<3.10"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "dbt-core==1.6.0b6",
-  "metricflow==0.200.0.dev9"
+  "metricflow==0.200.0.dev10"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pulls in the fixes deployed in MetricFlow 0.200.0.dev10.