### PR TITLE
change group-bys to group-by in the CLI

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230630-135934.yaml
+++ b/.changes/unreleased/Breaking Changes-20230630-135934.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Changed the --group-bys option in mf query to be --group-by
+time: 2023-06-30T13:59:34.521502-04:00
+custom:
+  Author: WilliamDee
+  Issue: None

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -253,7 +253,7 @@ def tutorial(ctx: click.core.Context, cfg: CLIContext, msg: bool, clean: bool) -
 def query(
     cfg: CLIContext,
     metrics: List[str],
-    group_bys: List[str] = [],
+    group_by: List[str] = [],
     where: Optional[str] = None,
     start_time: Optional[dt.datetime] = None,
     end_time: Optional[dt.datetime] = None,
@@ -272,7 +272,7 @@ def query(
     spinner.start()
     mf_request = MetricFlowQueryRequest.create_with_random_request_id(
         metric_names=metrics,
-        group_by_names=group_bys,
+        group_by_names=group_by,
         limit=limit,
         time_constraint_start=start_time,
         time_constraint_end=end_time,

--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -39,10 +39,10 @@ def query_options(function: Callable) -> Callable:
     )(function)
     function = start_end_time_options(function)
     function = click.option(
-        "--group-bys",
+        "--group-by",
         type=click_custom.SequenceParamType(),
         default="",
-        help="Dimensions and/or entities to group by: syntax is --group-bys ds or for multiple group bys --group-bys ds,org",
+        help="Dimensions and/or entities to group by: syntax is --group-by ds or for multiple group bys --group-by ds,org",
     )(function)
     function = click.option(
         "--metrics",

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -38,7 +38,7 @@ from metricflow.test.fixtures.cli_fixtures import MetricFlowCliRunner
 
 
 def test_query(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
-    resp = cli_runner.run(query, args=["--metrics", "bookings", "--group-bys", "ds"])
+    resp = cli_runner.run(query, args=["--metrics", "bookings", "--group-by", "ds"])
     # case insensitive matches are needed for snowflake due to the capitalization thing
     engine_is_snowflake = cli_runner.cli_context.sql_client.sql_engine_type is SqlEngine.SNOWFLAKE
     assert "bookings" in resp.output or ("bookings" in resp.output.lower() and engine_is_snowflake)


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
It is a little inconsistent to use `--group-bys` when `--group-by` is used in cases of grouping by single or multiple elements.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)