### PR TITLE
Raise `UnknownMetricLinkingError` if a Metric isn't found during linking

### DIFF
--- a/.changes/unreleased/Under the Hood-20230705-141555.yaml
+++ b/.changes/unreleased/Under the Hood-20230705-141555.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Raise a more specific exception when a Metric isn't found during linking.
+time: 2023-07-05T14:15:55.013987-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -90,5 +90,6 @@ class UnsupportedEngineFeatureError(RuntimeError):
 class SqlBindParametersNotSupportedError(Exception):
     """Raised when a SqlClient that does not have support for bind parameters receives a non-empty set of params."""
 
+
 class UnknownMetricLinkingError(ValueError):
     """Raised during linking when a user attempts to use a metric that isn't specified."""

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -89,3 +89,6 @@ class UnsupportedEngineFeatureError(RuntimeError):
 
 class SqlBindParametersNotSupportedError(Exception):
     """Raised when a SqlClient that does not have support for bind parameters receives a non-empty set of params."""
+
+class UnknownMetricLinkingError(ValueError):
+    """Raised during linking when a user attempts to use a metric that isn't specified."""

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -13,8 +13,8 @@ from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference, SemanticModelReference
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
-from metricflow.errors.errors import UnknownMetricLinkingError
 
+from metricflow.errors.errors import UnknownMetricLinkingError
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
 from metricflow.protocols.semantics import SemanticModelAccessor

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference, SemanticModelReference
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from metricflow.errors.errors import UnknownMetricLinkingError
 
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
@@ -610,7 +611,7 @@ class ValidLinkableSpecResolver:
         for metric_reference in metric_references:
             element_sets = self._metric_to_linkable_element_sets.get(metric_reference.element_name)
             if not element_sets:
-                raise ValueError(f"Unknown metric: {metric_reference} in element set")
+                raise UnknownMetricLinkingError(f"Unknown metric: {metric_reference} in element set")
 
             # Using .only_unique_path_keys to exclude ambiguous elements where there are multiple join paths to get
             # a dimension / entity.


### PR DESCRIPTION
### Description

Fixes SLA-158 (internal to dbt Labs)

Raise a more specific exception when a Metric isn't found during linking. This will help with surfacing errors in the Jinja syntax. I only found one other instance of `Unknown metric` [here](https://github.com/dbt-labs/metricflow/blob/5a9e917434b1dbcbd1017ffa2e6635b84dc1c24e/metricflow/query/query_parser.py#L589), but that didn't seem related, so I didn't reuse or change that exception. This change shouldn't cause any breaking changes because `UnknownMetricLinkingError` inherits from `ValueError`
