### PR TITLE
Remove layer of indirection from CLI error messages

### DIFF
--- a/.changes/unreleased/Fixes-20230705-182137.yaml
+++ b/.changes/unreleased/Fixes-20230705-182137.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve error message rendering in MetricFlow CLI
+time: 2023-07-05T18:21:37.717453-04:00
+custom:
+  Author: tlento
+  Issue: "646"

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -51,24 +51,6 @@ class ExecutionException(Exception):
     pass
 
 
-class SqlClientCreationException(Exception):
-    """Exception to represent errors related to the SqlClient."""
-
-    def __init__(self) -> None:  # noqa: D
-        super().__init__(
-            "An error occurred when attempting to create the SqlClient",
-        )
-
-
-class MetricFlowInitException(Exception):
-    """Exception to represent errors related to the MetricFlow creation."""
-
-    def __init__(self) -> None:  # noqa: D
-        super().__init__(
-            "An error occurred when attempting to create the MetricFlow engine",
-        )
-
-
 class ModelCreationException(Exception):
     """Exception to represent errors related to the building a model."""
 


### PR DESCRIPTION
Currently, error messages in the CLI that result from failing
warehouse health checks or any problem with the model throw a
wrapped exception. In practice, this means a user with a misconfigured
model will see an error of the form:

`ERROR: An error occurred when attempting to create the MetricFlow engine`

along with a pointer to the log file, which will contain a much more
helpful error describing the root cause of the problem.

This change removes the wrapper so that the direct cause of the
exception will be surfaced in the CLI output itself, so users
will instead see exceptions that read something more like:

```
ERROR: Metric `east_coast_order_amount` references measure `MeasureReference(element_name='orderss')` which has not been registered
```