### PR TITLE
Update databricks-sql-connector and click dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "MarkupSafe==2.0.1",
   "PyYAML~=6.0",
   "SQLAlchemy~=1.4.42",
-  "click>=7.1.2",
+  "click>=7.1.2, <8.1.4",
   "databricks-sql-connector==2.0.3",
   "dbt-core==1.6.0b8",
   "dbt-semantic-interfaces==0.1.0.dev8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "PyYAML~=6.0",
   "SQLAlchemy~=1.4.42",
   "click>=7.1.2, <8.1.4",
-  "databricks-sql-connector==2.0.3",
+  "databricks-sql-connector~=2.0",
   "dbt-core==1.6.0b8",
   "dbt-semantic-interfaces==0.1.0.dev8",
   "duckdb-engine~=0.1.8",


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Loosen the `databricks-sql-connector` version requirement and the latest click version `8.1.4` that was just released broke the mypy tests. So restrict that to use versions before `8.1.4`

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)