### PR TITLE
Update to Support `dbt-semantic-interfaces==0.1.0rc1`

### DIFF
--- a/metricflow/model/dbt_manifest_parser.py
+++ b/metricflow/model/dbt_manifest_parser.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.agg_time_dimension import (
-    SetMeasureAggregationTimeDimensionRule,
-)
 from dbt_semantic_interfaces.transformations.boolean_measure import (
     BooleanMeasureAggregationRule,
 )
@@ -28,10 +25,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
     # TODO: remove this transform call once the upstream changes are integrated into our dependency tree
     rules = (
         # Primary
-        (
-            LowerCaseNamesRule(),
-            SetMeasureAggregationTimeDimensionRule(),
-        ),
+        (LowerCaseNamesRule(),),
         # Secondary
         (
             CreateProxyMeasureRule(),

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -190,7 +190,9 @@ class SemanticModelLookup(SemanticModelAccessor):
         for measure in semantic_model.measures:
             self._measure_aggs[measure.reference] = measure.agg
             self._measure_index[measure.reference].append(semantic_model)
-            agg_time_dimension = measure.checked_agg_time_dimension
+            agg_time_dimension = semantic_model.checked_agg_time_dimension_for_measure(
+                measure_reference=measure.reference
+            )
             self._semantic_model_to_aggregation_time_dimensions[semantic_model.reference].add_value(
                 key=agg_time_dimension,
                 value=MeasureConverter.convert_to_measure_spec(measure=measure),

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1095,8 +1095,17 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         # Only these measures will be in the output data set.
         output_measure_instances = []
         for measure_instance in input_data_set.instance_set.measure_instances:
-            measure = self._semantic_model_lookup.get_measure(measure_instance.spec.as_reference)
-            if measure.checked_agg_time_dimension == node.aggregation_time_dimension_reference:
+            semantic_model = self._semantic_model_lookup.get_by_reference(
+                semantic_model_reference=measure_instance.origin_semantic_model_reference.semantic_model_reference
+            )
+            assert semantic_model is not None, (
+                f"{measure_instance} was defined from {measure_instance.origin_semantic_model_reference}, but that"
+                f"can't be found"
+            )
+            aggregation_time_dimension_for_measure = semantic_model.checked_agg_time_dimension_for_measure(
+                measure_reference=measure_instance.spec.as_reference
+            )
+            if aggregation_time_dimension_for_measure == node.aggregation_time_dimension_reference:
                 output_measure_instances.append(measure_instance)
 
         if len(output_measure_instances) == 0:

--- a/metricflow/specs/where_filter_transform.py
+++ b/metricflow/specs/where_filter_transform.py
@@ -4,7 +4,7 @@ import logging
 from typing import Sequence
 
 import jinja2
-from dbt_semantic_interfaces.implementations.filters.call_parameter_sets import (
+from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
     TimeDimensionCallParameterSet,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow"
-version = "0.200.0.dev12"
+version = "0.200.0.dev13"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
 requires-python = ">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "SQLAlchemy~=1.4.42",
   "click>=7.1.2, <8.1.4",
   "databricks-sql-connector~=2.0",
-  "dbt-core==1.6.0b8",
+  "dbt-core~=1.6.0rc1",
   "dbt-semantic-interfaces~=0.1.0rc1",
   "duckdb-engine~=0.9",
   "duckdb~=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "click>=7.1.2, <8.1.4",
   "databricks-sql-connector~=2.0",
   "dbt-core==1.6.0b8",
-  "dbt-semantic-interfaces==0.1.0.dev8",
+  "dbt-semantic-interfaces~=0.1.0rc1",
   "duckdb-engine~=0.9",
   "duckdb~=0.8",
   "google-auth~=2.13.0",


### PR DESCRIPTION
### Description

This PR makes updates as required to support `dbt-semantic-interfaces==0.1.0rc1`. This shouldn't be merged until there is a version of `dbt-core` that support the same version of `dbt-semantic-interfaces` as there is currently dependency conflict.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)