### PR TITLE
Clean up project metadata for contact and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ MetricFlow is distributed under a Business Source License (BUSL-1.1). For detail
 MetricFlow can be installed from PyPi for use as a Python library with the following command:
 
 ```
-pip install metricflow
+pip install dbt-metricflow
 ```
 
 Once installed, MetricFlow can be setup and connected to a data warehouse by following the instructions after issuing the command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8,<3.12"
 license = "BUSL-1.1"
 keywords = []
 authors = [
-    {name = "Transform", email = "hello@transformdata.io"}
+    {name = "dbt Labs"}
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR makes two adjustments to the project metadata:

1. Updates the MetricFlow install instructions in the README to point to the bundled dbt-metricflow package, since an independent install of MetricFlow will not be functionally useful without a dbt project. Note this file will need a broader overhaul once we finish our work on making MetricFlow a stand-alone library without explicit dependencies on either dbt or data warehouse packages.
2. Update the contact information we publish with our releases from Transform to dbt Labs.