### PR TITLE
bump dbt-metricflow python version

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -7,7 +7,7 @@ name = "dbt-metricflow"
 version = "0.0.3"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.8,<3.12"
 license = "BUSL-1.1"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },


### PR DESCRIPTION
### Description
Bump dbt-metricflow python version since we now support 3.10 and 3.11! 