### PR TITLE
Update pyproject.toml for dbt-metricflow to support Python 3.10 and 3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Welcome to the MetricFlow developer community, we're thrilled to have you aboard
 
 ## Environment setup
 
-1. Ensure you have Python `3.8` or `3.9`.
+1. Ensure you have a relevant version of Python.
 2. Install the following required system dependencies:
     - MySqlClient:
         - Follow the [instructions from MySQL](https://dev.mysql.com/doc/mysql-getting-started/en/)

--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -7,7 +7,7 @@ name = "dbt-metricflow"
 version = "0.0.3"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.8,<3.12"
 license = "BUSL-1.1"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -18,6 +18,8 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
Resolves #664

### Description

This PR handles the `dbt-metricflow` package and complements https://github.com/dbt-labs/metricflow/commit/7cd3fce84f85e6152a75875ff01cfacf0805964e that handles the `metricflow` package 

It removes explicit Python version numbers from CONTRIBUTING.md to avoid needing to keep that piece up-to-date in the future.

I did not include a changelog entry, but can add one if desired.