### PR TITLE
URL for dbt-metricflow for PyPI

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
   "metricflow==0.200.0.dev13"
 ]
 
+[project.urls]
+"Source Code" = "https://github.com/dbt-labs/metricflow/tree/main/dbt-metricflow"
+
 [project.optional-dependencies]
 postgres = [
   "dbt-postgres>=1.6.0b6"


### PR DESCRIPTION
Resolves Issue #665

### Description

See details in #665.

We can optionally change the URL as desired. I did not also add a link to a documentation website like [here](https://github.com/dbt-labs/metricflow/blob/10c8feeb8f0666c9d847098aaa248e752f3ed173/pyproject.toml#L66), but can do so if asked to.

I did not include a changelog entry, but can add one if desired.