### PR TITLE
Use a keyword that will link a pull request to an issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
   PRs for code changes without an associated issue *will not be merged*.
   See CONTRIBUTING.md for more information.
 -->
-Resolves Issue #
+Resolves #
 
 
 ### Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@ Resolves #
   1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
   2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
   3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
+-->


### PR DESCRIPTION
Resolves #668

### Description

This PR does two things:
- uses a [keyword that will link a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- adds a closing tag for the final comment

See #668 for more context.

I didn't include a changelog entry, but can do so if desired.