### PR TITLE
Separate engine-specific tests to dedicated hatch envs

### DIFF
--- a/.changes/unreleased/Under the Hood-20230721-131915.yaml
+++ b/.changes/unreleased/Under the Hood-20230721-131915.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update test environment configuration to allow for more streamlined dependencies
+time: 2023-07-21T13:19:15.88025-04:00
+custom:
+  Author: tlento
+  Issue: None

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -51,7 +51,7 @@ jobs:
           mf_sql_engine_password: ${{ secrets.MF_REDSHIFT_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
-
+          make-target: "test-redshift"
   bigquery-tests:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery Tests
@@ -69,6 +69,7 @@ jobs:
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
+          make-target: "test-bigquery"
 
   databricks-cluster-tests:
     environment: DW_INTEGRATION_TESTS
@@ -87,6 +88,7 @@ jobs:
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
+          make-target: "test-databricks"
 
   databricks-sql-warehouse-tests:
     environment: DW_INTEGRATION_TESTS
@@ -105,18 +107,4 @@ jobs:
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
-
-  slack-failure:
-    environment: DW_INTEGRATION_TESTS
-    needs: [snowflake-tests, redshift-tests, bigquery-tests]
-    if: ${{ github.event_name != 'pull_request' && failure() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Slack Failure
-        uses: kpritam/slack-job-status-action@v1
-        with:
-          job-status: Failure
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ secrets.MF_BUG_SINK }}
+          make-target: "test-databricks"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ dependencies.
 You're ready to start! Note all `make` and `hatch` commands should be run from your repository root unless otherwise indicated.
 
 `pyproject.yaml` includes a definition for a Hatch environment named `dev-env` that is similar to a virtual environment
-and allows packages to be installed in isolation.
+and allows packages to be installed in isolation. The `Makefile` includes a number of other useful commands as well, such as `make test`, which handle the environment switching. For engine-specific testing refer to the `<engine>-env` environments defined in `pyproject.yaml` and the `test-<engine>` commands in the `Makefile` - for example, postgres tests are most easily run through the `postgres-env` instead of `dev-env`, or via `make test-postgresql`.
 
 When running any one of the hatch commands, the environment is automatically set up for you.
 
@@ -41,10 +41,10 @@ When running any one of the hatch commands, the environment is automatically set
     - Working with integration tests
         - These tests are driven by a set of test configs in [metricflow/test/integration/test_cases](metricflow/test/integration/test_cases/). They compare the output of a MetricFlow query against the output of a similar SQL query.
         - These tests all run on consistent input data, which is [created in the target warehouse via setup fixtures](metricflow/test/fixtures/table_fixtures.py).
-            - Modify this file if you are looking to test boundary cases involving things like repeated rows of data.
+            - Modify the test inputs if you are looking to test boundary cases involving things like repeated rows of data.
         - Let's break a test!
             - Change a SQL query inside of [metricflow/test/integration/test_cases/itest_simple.yaml](metricflow/test/integration/test_cases/itest_simple.yaml)
-            - Run the test case: `hatch run dev-env:pytest -k "itest_simple.yaml" metricflow/test/integration`. Did it fail?
+            - Run the test case: `hatch run dev-env:pytest -k "itest_simple" metricflow/test/integration`. Did it fail?
     - Working with module and component tests
         - These are generally laid out in a similar hierarchy to the main package.
         - Let's try them out:
@@ -57,8 +57,8 @@ When running any one of the hatch commands, the environment is automatically set
     - Run the following commands in your shell, replacing the tags with the appropriate values:
         - `export MF_SQL_ENGINE_URL=<YOUR_WAREHOUSE_CONNECTION_URL>`
         - `export MF_SQL_ENGINE_PASSWORD=<YOUR_WAREHOUSE_PASSWORD>`
-    - Run `make test` to execute the entire test suite against the target engine.
-    - By default, without `MF_SQL_ENGINE_URL` and `MF_SQL_ENGINE_PASSWORD` set, your tests will run against SQLite.
+    - Run `make test-<engine>` to execute the entire test suite against the target engine. This will also set the `MF_TEST_ADAPTER_TYPE` to the proper engine identifier and pull in and configure the necessary dbt adapter dependencies for query execution. For example, to run tests against BigQuery, run `make test-bigquery`
+    - By default, without `MF_SQL_ENGINE_URL` and `MF_SQL_ENGINE_PASSWORD` set, your tests will run against DuckDB.
 4. Run the linters with `make lint` at any time, but especially before submitting a PR. We use:
     - `Black` for formatting
     - `Ruff` for general Python linting
@@ -66,7 +66,9 @@ When running any one of the hatch commands, the environment is automatically set
 5. To see how your changes work with more interactive queries, use your repo-local CLI.
     - Run `hatch run dev-env:mf --help`
     - Follow the CLI help from there, just remember your local CLI is always `hatch run dev-env:run mf <COMMAND>`!
+    - Note this will only work if you invoke the command from within a properly configured dbt project, so it may be simpler to clone the [jaffle-sl-template repo](https://github.com/dbt-labs/jaffle-sl-template) and do an editable install (via `pip install -e /path/to/metricflow/repo`) in a separate Python virtual environment.
 6. Some tests generate snapshots in the test directory. Separate snapshots may be generated for each SQL engine. You can regenerate these snapshots by running `make regenerate-test-snapshots`.
+
 ## Adding or modifying a CHANGELOG Entry!
 
 We use [changie](https://changie.dev) to generate `CHANGELOG` entries. **Note:** Do not edit the `CHANGELOG.md` directly. Your modifications will be lost.

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,6 @@ install-hatch:
 	pip3 install hatch
 
 # Testing and linting
-.PHONY: test-core
-test-core:
-	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test --ignore metricflow/test/model/dbt_cloud_parsing/
-
-# Test that depend on dbt-related packages.
-.PHONY: test-dbt-associated
-test-dbt-associated:
-	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/model/dbt_cloud_parsing/
-
 .PHONY: test
 test:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,20 @@ test:
 test-postgresql:
 	hatch -v run postgres-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
 
+# Engine-specific test environments. In most cases you should run these with
+# `make -e ADDITIONAL_PYTEST_OPTIONS="--use-persistent-source-schema" test-<engine_type>`
+.PHONY: test-bigquery
+test-bigquery:
+	hatch -v run bigquery-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
+
+.PHONY: test-databricks
+test-databricks:
+	hatch -v run databricks-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
+
+.PHONY: test-redshift
+test-redshift:
+	hatch -v run redshift-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/
+
 .PHONY: test-snowflake
 test-snowflake:
 	hatch -v run snowflake-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) metricflow/test/

--- a/metricflow/test/fixtures/sql_client_fixtures.py
+++ b/metricflow/test/fixtures/sql_client_fixtures.py
@@ -84,7 +84,7 @@ def make_test_sql_client(url: str, password: str, schema: str) -> SqlClient:
     elif dialect == SqlDialect.BIGQUERY:
         return BigQuerySqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.POSTGRESQL:
-        configure_test_env_from_url(url, "mf_demo")
+        configure_test_env_from_url(url, schema)
         __initialize_dbt()
         return AdapterBackedSqlClient(adapter=get_adapter_by_type("postgres"))
     elif dialect == SqlDialect.DUCKDB:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "PyYAML~=6.0",
   "SQLAlchemy~=1.4.42",
   "click>=7.1.2, <8.1.4",
-  "databricks-sql-connector~=2.0",
+  "databricks-sql-connector==2.7.0",
   "dbt-core~=1.6.0rc1",
   "dbt-semantic-interfaces~=0.1.0rc1",
   "duckdb-engine~=0.9",
@@ -48,7 +48,6 @@ dependencies = [
   "pydantic~=1.10.0",
   "python-dateutil==2.8.2",
   "rapidfuzz==3.0.0",
-  "requests~=2.27.1",
   "ruamel.yaml~=0.17.21",
   "rudder-sdk-python~=1.0.3",
   "sqlalchemy-bigquery~=1.6.1",
@@ -82,11 +81,23 @@ dev-packages = [
 ]
 
 dbt-postgres = [
-  "dbt-postgres>=1.6.0.b6",
+  "dbt-postgres~=1.6.0rc1",
+]
+
+dbt-bigquery = [
+  "dbt-bigquery~=1.6.0rc1",
+]
+
+dbt-databricks = [
+  "dbt-databricks==1.6.0rc2",
+]
+
+dbt-redshift = [
+  "dbt-redshift~=1.6.0rc1",
 ]
 
 dbt-snowflake = [
-  "dbt-snowflake>=1.6.0b3",
+  "dbt-snowflake~=1.6.0rc1",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -102,7 +113,7 @@ exclude = [
 ]
 
 [tool.hatch.envs.dev-env]
-description = "Environment for development."
+description = "Environment for development. Includes a DuckDB-backed client."
 features = [
   "dev-packages",
 ]
@@ -119,14 +130,44 @@ features = [
   "dbt-postgres",
 ]
 
+# NOTE: All of the below should have their authentication credentials
+# configured independently of the hatch env construction
+
+[tool.hatch.envs.bigquery-env.env-vars]
+	MF_TEST_ADAPTER_TYPE="bigquery"
+
+[tool.hatch.envs.bigquery-env]
+description = "Dev environment for working with the BigQuery adapter"
+features = [
+  "dev-packages",
+  "dbt-bigquery",
+]
+
+[tool.hatch.envs.databricks-env.env-vars]
+	MF_TEST_ADAPTER_TYPE="databricks"
+
+[tool.hatch.envs.databricks-env]
+description = "Dev environment for working with the Databricks adapter"
+features = [
+  "dev-packages",
+  "dbt-databricks",
+]
+
+[tool.hatch.envs.redshift-env.env-vars]
+	MF_TEST_ADAPTER_TYPE="redshift"
+
+[tool.hatch.envs.redshift-env]
+description = "Dev environment for working with the Redshift adapter"
+features = [
+  "dev-packages",
+  "dbt-redshift",
+]
+
 [tool.hatch.envs.snowflake-env.env-vars]
 	MF_TEST_ADAPTER_TYPE="snowflake"
-  # Note - the snowflake URL and password should be set via environment secrets
-  # in the calling process
 
 [tool.hatch.envs.snowflake-env]
 description = "Dev environment for working with Snowflake adapter"
-# Install the dbt snowflake package as a pre-install extra, just as with postgres
 features = [
   "dev-packages",
   "dbt-snowflake",


### PR DESCRIPTION
As we move towards making MetricFlow proper a lean, more
standalone library we will eventually want to only build targets
that pull in a minimal set of dependencies. As a first step towards
this goal we split all packaging of engine dependencies into
separate hatch environments for testing.

This change anticipates future pushes towards integration with
dbt adapters for various engines, and subsequent updates will
move all engine dependencies out of MetricFlow proper and into
either the dev-env or the relevant engine-specific env as appropriate.