### PR TITLE
Remove DDL and other test-only methods from SqlClient protocol

### DIFF
--- a/.changes/unreleased/Under the Hood-20230724-152228.yaml
+++ b/.changes/unreleased/Under the Hood-20230724-152228.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove DDL and other unused methods from SqlClient protocol
+time: 2023-07-24T15:22:28.930711-07:00
+custom:
+  Author: tlento
+  Issue: None

--- a/metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import enum
 import logging
-import textwrap
 import time
-from typing import Optional, Sequence
+from typing import Optional
 
 import pandas as pd
 from dbt.adapters.base.impl import BaseAdapter
@@ -275,30 +274,6 @@ class AdapterBackedSqlClient:
             return self._sql_query_plan_renderer.expr_renderer.timestamp_data_type
         else:
             raise ValueError(f"Encountered unexpected Pandas dtype ({dtype})!")
-
-    def list_tables(self, schema_name: str) -> Sequence[str]:
-        """Get a list of the table names in a given schema. Only used in tutorials and tests."""
-        # TODO: Short term, make this work with as many engines as possible. Medium term, remove this altogether.
-        if self.sql_engine_type is SqlEngine.SNOWFLAKE:
-            # Snowflake likes capitalizing things, except when it doesn't. We can get away with this due to its
-            # limited scope of usage.
-            schema_name = schema_name.upper()
-
-        df = self.query(
-            textwrap.dedent(
-                f"""\
-                SELECT table_name FROM information_schema.tables
-                WHERE table_schema = '{schema_name}'
-                """
-            ),
-        )
-        if df.empty:
-            return []
-
-        # Lower casing table names and data frame names for consistency between Snowflake and other clients.
-        # As above, we can do this because it isn't used in any consequential situations.
-        df.columns = df.columns.str.lower()
-        return [t.lower() for t in df["table_name"]]
 
     def create_schema(self, schema_name: str) -> None:
         """Create the given schema in a data warehouse. Only used in tutorials and tests."""

--- a/metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -283,10 +283,6 @@ class AdapterBackedSqlClient:
         """Drop the given schema from the data warehouse. Only used in tests."""
         self.execute(f"DROP SCHEMA IF EXISTS {schema_name}{' CASCADE' if cascade else ''}")
 
-    def drop_table(self, sql_table: SqlTable) -> None:
-        """Drop the given table from the data warehouse. Only used in tutorials and tests."""
-        self.execute(f"DROP TABLE IF EXISTS {sql_table.sql}")
-
     def close(self) -> None:  # noqa: D
         self._adapter.cancel_open_connections()
 

--- a/metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -300,10 +300,6 @@ class AdapterBackedSqlClient:
         df.columns = df.columns.str.lower()
         return [t.lower() for t in df["table_name"]]
 
-    def table_exists(self, sql_table: SqlTable) -> bool:
-        """Check if a given table exists. Only used in tutorials and tests."""
-        return sql_table.table_name in self.list_tables(sql_table.schema_name)
-
     def create_schema(self, schema_name: str) -> None:
         """Create the given schema in a data warehouse. Only used in tutorials and tests."""
         self.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")

--- a/metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import enum
 import logging
 import time
-from typing import Optional
 
 import pandas as pd
 from dbt.adapters.base.impl import BaseAdapter
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 
-from metricflow.dataflow.sql_table import SqlTable
 from metricflow.errors.errors import SqlBindParametersNotSupportedError
 from metricflow.logging.formatting import indent_log_line
 from metricflow.protocols.sql_client import SqlEngine
@@ -187,101 +185,6 @@ class AdapterBackedSqlClient:
         stop = time.time()
         logger.info(f"Finished running the dry_run in {stop - start:.2f}s")
         return
-
-    def create_table_from_dataframe(
-        self,
-        sql_table: SqlTable,
-        df: pd.DataFrame,
-        chunk_size: Optional[int] = None,
-    ) -> None:
-        """Create a table in the data warehouse containing the contents of the dataframe.
-
-        Only used in tutorials and tests.
-
-        Args:
-            sql_table: The SqlTable object representing the table location to use
-            df: The Pandas DataFrame object containing the column schema and data to load
-            chunk_size: The number of rows to insert per transaction
-        """
-        logger.info(f"Creating table '{sql_table.sql}' from a DataFrame with {df.shape[0]} row(s)")
-        start_time = time.time()
-        with self._adapter.connection_named("MetricFlow_create_from_dataframe"):
-            # Create table
-            # update dtypes to convert None to NA in boolean columns.
-            # This mirrors the SQLAlchemy schema detection logic in pandas.io.sql
-            df = df.convert_dtypes()
-            columns = df.columns
-            columns_to_insert = []
-            for i in range(len(df.columns)):
-                # Format as "column_name column_type"
-                columns_to_insert.append(
-                    f"{columns[i]} {self._get_type_from_pandas_dtype(str(df[columns[i]].dtype).lower())}"
-                )
-            self._adapter.execute(
-                f"CREATE TABLE IF NOT EXISTS {sql_table.sql} ({', '.join(columns_to_insert)})",
-                auto_begin=True,
-                fetch=False,
-            )
-            self._adapter.commit_if_has_connection()
-
-            # Insert rows
-            values = []
-            for row in df.itertuples(index=False, name=None):
-                cells = []
-                for cell in row:
-                    if pd.isnull(cell):
-                        # use null keyword instead of isNA/None/etc.
-                        cells.append("null")
-                    elif type(cell) in [str, pd.Timestamp]:
-                        # Wrap cell in quotes & escape existing single quotes
-                        escaped_cell = str(cell).replace("'", "''")
-                        cells.append(f"'{escaped_cell}'")
-                    else:
-                        cells.append(str(cell))
-
-                values.append(f"({', '.join(cells)})")
-                if chunk_size and len(values) == chunk_size:
-                    value_string = ",\n".join(values)
-                    self._adapter.execute(
-                        f"INSERT INTO {sql_table.sql} VALUES {value_string}", auto_begin=True, fetch=False
-                    )
-                    values = []
-            if values:
-                value_string = ",\n".join(values)
-                self._adapter.execute(
-                    f"INSERT INTO {sql_table.sql} VALUES {value_string}", auto_begin=True, fetch=False
-                )
-            # Commit all insert transaction at once
-            self._adapter.commit_if_has_connection()
-
-        logger.info(f"Created table '{sql_table.sql}' from a DataFrame in {time.time() - start_time:.2f}s")
-
-    def _get_type_from_pandas_dtype(self, dtype: str) -> str:
-        """Helper method to get the engine-specific type value.
-
-        The dtype dict here is non-exhaustive but should be adequate for our needs.
-        """
-        # TODO: add type handling for string/bool/bigint types for all engines
-        if dtype == "string" or dtype == "object":
-            return "text"
-        elif dtype == "boolean" or dtype == "bool":
-            return "boolean"
-        elif dtype == "int64":
-            return "bigint"
-        elif dtype == "float64":
-            return self._sql_query_plan_renderer.expr_renderer.double_data_type
-        elif dtype == "datetime64[ns]":
-            return self._sql_query_plan_renderer.expr_renderer.timestamp_data_type
-        else:
-            raise ValueError(f"Encountered unexpected Pandas dtype ({dtype})!")
-
-    def create_schema(self, schema_name: str) -> None:
-        """Create the given schema in a data warehouse. Only used in tutorials and tests."""
-        self.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
-
-    def drop_schema(self, schema_name: str, cascade: bool = True) -> None:
-        """Drop the given schema from the data warehouse. Only used in tests."""
-        self.execute(f"DROP SCHEMA IF EXISTS {schema_name}{' CASCADE' if cascade else ''}")
 
     def close(self) -> None:  # noqa: D
         self._adapter.cancel_open_connections()

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -185,7 +185,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
     def execute(self) -> TaskExecutionResult:  # noqa: D
         start_time = time.time()
         logger.info(f"Dropping table {self._output_table} in case it already exists")
-        self._sql_client.drop_table(self._output_table)
+        self._sql_client.execute(f"DROP TABLE IF EXISTS {self._output_table.sql}")
         logger.info(f"Creating table {self._output_table} using a SELECT query")
         sql_query = self.sql_query
         assert sql_query

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -99,11 +99,6 @@ class SqlClient(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def table_exists(self, sql_table: SqlTable) -> bool:
-        """Determines whether or not the given table exists in the data warehouse."""
-        raise NotImplementedError
-
-    @abstractmethod
     def drop_table(self, sql_table: SqlTable) -> None:
         """Drop the given table from the data warehouse."""
         raise NotImplementedError

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from enum import Enum
-from typing import Optional, Protocol, Sequence
+from typing import Optional, Protocol
 
 from pandas import DataFrame
 
@@ -91,11 +91,6 @@ class SqlClient(Protocol):
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
     ) -> None:
         """Base dry_run method."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_tables(self, schema_name: str) -> Sequence[str]:
-        """List the tables in the given schema."""
         raise NotImplementedError
 
     @abstractmethod

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -94,11 +94,6 @@ class SqlClient(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def drop_table(self, sql_table: SqlTable) -> None:
-        """Drop the given table from the data warehouse."""
-        raise NotImplementedError
-
-    @abstractmethod
     def create_schema(self, schema_name: str) -> None:
         """Create the given schema if it doesn't already exist."""
         raise NotImplementedError

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from enum import Enum
-from typing import Optional, Protocol
+from typing import Protocol
 
 from pandas import DataFrame
 
-from metricflow.dataflow.sql_table import SqlTable
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_request.sql_request_attributes import SqlJsonTag
@@ -49,22 +48,6 @@ class SqlClient(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def create_table_from_dataframe(
-        self,
-        sql_table: SqlTable,
-        df: DataFrame,
-        chunk_size: Optional[int] = None,
-    ) -> None:
-        """Creates a table and populates it with the contents of the dataframe.
-
-        Args:
-            sql_table: The SqlTable metadata of the table to create
-            df: The Pandas DataFrame with the contents of the target table
-            chunk_size: The number of rows to write per query
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def query(
         self,
         stmt: str,
@@ -91,16 +74,6 @@ class SqlClient(Protocol):
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
     ) -> None:
         """Base dry_run method."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_schema(self, schema_name: str) -> None:
-        """Create the given schema if it doesn't already exist."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def drop_schema(self, schema_name: str, cascade: bool) -> None:  # noqa: D
-        """Drop the given schema if it exists. If cascade is set, drop the tables in the schema first."""
         raise NotImplementedError
 
     @abstractmethod

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -58,4 +58,4 @@ def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql
         ),
         compare_names_using_lowercase=sql_client.sql_engine_type is SqlEngine.SNOWFLAKE,
     )
-    sql_client.drop_table(output_table)
+    sql_client.execute(f"DROP TABLE IF EXISTS {output_table.sql}")

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -49,7 +49,6 @@ def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql
     results = SequentialPlanExecutor().execute_plan(execution_plan)
 
     assert not results.contains_task_errors
-    assert sql_client.table_exists(output_table)
 
     assert_dataframes_equal(
         actual=sql_client.query(f"SELECT * FROM {output_table.sql}"),

--- a/metricflow/test/fixtures/sql_client_fixtures.py
+++ b/metricflow/test/fixtures/sql_client_fixtures.py
@@ -9,9 +9,9 @@ import sqlalchemy
 from dbt.adapters.factory import get_adapter_by_type
 from dbt.cli.main import dbtRunner
 
-from metricflow.cli.dbt_connectors.adapter_backed_client import AdapterBackedSqlClient
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState, dialect_from_url
+from metricflow.test.fixtures.sql_clients.adapter_backed_ddl_client import AdapterBackedDDLSqlClient
 from metricflow.test.fixtures.sql_clients.big_query import BigQuerySqlClient
 from metricflow.test.fixtures.sql_clients.common_client import SqlDialect
 from metricflow.test.fixtures.sql_clients.databricks import DatabricksSqlClient
@@ -81,13 +81,13 @@ def make_test_sql_client(url: str, password: str, schema: str) -> SqlClientWithD
         assert len(warehouses) == 1, f"Found more than 1 warehouse in Snowflake URL: `{warehouses}`"
         os.environ[MF_SQL_ENGINE_WAREHOUSE] = warehouses[0]
         __initialize_dbt()
-        return AdapterBackedSqlClient(adapter=get_adapter_by_type("snowflake"))
+        return AdapterBackedDDLSqlClient(adapter=get_adapter_by_type("snowflake"))
     elif dialect == SqlDialect.BIGQUERY:
         return BigQuerySqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.POSTGRESQL:
         configure_test_env_from_url(url, schema)
         __initialize_dbt()
-        return AdapterBackedSqlClient(adapter=get_adapter_by_type("postgres"))
+        return AdapterBackedDDLSqlClient(adapter=get_adapter_by_type("postgres"))
     elif dialect == SqlDialect.DUCKDB:
         return DuckDbSqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.DATABRICKS:

--- a/metricflow/test/fixtures/sql_clients/adapter_backed_ddl_client.py
+++ b/metricflow/test/fixtures/sql_clients/adapter_backed_ddl_client.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+import pandas as pd
+
+from metricflow.cli.dbt_connectors.adapter_backed_client import AdapterBackedSqlClient
+from metricflow.dataflow.sql_table import SqlTable
+
+logger = logging.getLogger(__name__)
+
+
+class AdapterBackedDDLSqlClient(AdapterBackedSqlClient):
+    """Extends the AdapterBackedSqlClient with the DDL methods necessary for test configuration and execution."""
+
+    def create_table_from_dataframe(
+        self,
+        sql_table: SqlTable,
+        df: pd.DataFrame,
+        chunk_size: Optional[int] = None,
+    ) -> None:
+        """Create a table in the data warehouse containing the contents of the dataframe.
+
+        Only used in tutorials and tests.
+
+        Args:
+            sql_table: The SqlTable object representing the table location to use
+            df: The Pandas DataFrame object containing the column schema and data to load
+            chunk_size: The number of rows to insert per transaction
+        """
+        logger.info(f"Creating table '{sql_table.sql}' from a DataFrame with {df.shape[0]} row(s)")
+        start_time = time.time()
+        with self._adapter.connection_named("MetricFlow_create_from_dataframe"):
+            # Create table
+            # update dtypes to convert None to NA in boolean columns.
+            # This mirrors the SQLAlchemy schema detection logic in pandas.io.sql
+            df = df.convert_dtypes()
+            columns = df.columns
+            columns_to_insert = []
+            for i in range(len(df.columns)):
+                # Format as "column_name column_type"
+                columns_to_insert.append(
+                    f"{columns[i]} {self._get_type_from_pandas_dtype(str(df[columns[i]].dtype).lower())}"
+                )
+            self._adapter.execute(
+                f"CREATE TABLE IF NOT EXISTS {sql_table.sql} ({', '.join(columns_to_insert)})",
+                auto_begin=True,
+                fetch=False,
+            )
+            self._adapter.commit_if_has_connection()
+
+            # Insert rows
+            values = []
+            for row in df.itertuples(index=False, name=None):
+                cells = []
+                for cell in row:
+                    if pd.isnull(cell):
+                        # use null keyword instead of isNA/None/etc.
+                        cells.append("null")
+                    elif type(cell) in [str, pd.Timestamp]:
+                        # Wrap cell in quotes & escape existing single quotes
+                        escaped_cell = str(cell).replace("'", "''")
+                        cells.append(f"'{escaped_cell}'")
+                    else:
+                        cells.append(str(cell))
+
+                values.append(f"({', '.join(cells)})")
+                if chunk_size and len(values) == chunk_size:
+                    value_string = ",\n".join(values)
+                    self._adapter.execute(
+                        f"INSERT INTO {sql_table.sql} VALUES {value_string}", auto_begin=True, fetch=False
+                    )
+                    values = []
+            if values:
+                value_string = ",\n".join(values)
+                self._adapter.execute(
+                    f"INSERT INTO {sql_table.sql} VALUES {value_string}", auto_begin=True, fetch=False
+                )
+            # Commit all insert transaction at once
+            self._adapter.commit_if_has_connection()
+
+        logger.info(f"Created table '{sql_table.sql}' from a DataFrame in {time.time() - start_time:.2f}s")
+
+    def _get_type_from_pandas_dtype(self, dtype: str) -> str:
+        """Helper method to get the engine-specific type value.
+
+        The dtype dict here is non-exhaustive but should be adequate for our needs.
+        """
+        # TODO: add type handling for string/bool/bigint types for all engines
+        if dtype == "string" or dtype == "object":
+            return "text"
+        elif dtype == "boolean" or dtype == "bool":
+            return "boolean"
+        elif dtype == "int64":
+            return "bigint"
+        elif dtype == "float64":
+            return self._sql_query_plan_renderer.expr_renderer.double_data_type
+        elif dtype == "datetime64[ns]":
+            return self._sql_query_plan_renderer.expr_renderer.timestamp_data_type
+        else:
+            raise ValueError(f"Encountered unexpected Pandas dtype ({dtype})!")
+
+    def create_schema(self, schema_name: str) -> None:
+        """Create the given schema in a data warehouse. Only used in tutorials and tests."""
+        self.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
+
+    def drop_schema(self, schema_name: str, cascade: bool = True) -> None:
+        """Drop the given schema from the data warehouse. Only used in tests."""
+        self.execute(f"DROP SCHEMA IF EXISTS {schema_name}{' CASCADE' if cascade else ''}")

--- a/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
@@ -163,9 +163,6 @@ class BaseSqlClientImplementation(ABC, SqlClient):
     def drop_schema(self, schema_name: str, cascade: bool = True) -> None:  # noqa: D
         self.execute(f"DROP SCHEMA IF EXISTS {schema_name}{' CASCADE' if cascade else ''}")
 
-    def drop_table(self, sql_table: SqlTable) -> None:  # noqa: D
-        self.execute(f"DROP TABLE IF EXISTS {sql_table.sql}")
-
     def close(self) -> None:  # noqa: D
         pass
 

--- a/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
@@ -157,9 +157,6 @@ class BaseSqlClientImplementation(ABC, SqlClient):
     ) -> None:
         pass
 
-    def table_exists(self, sql_table: SqlTable) -> bool:  # noqa: D
-        return sql_table.table_name in self.list_tables(sql_table.schema_name)
-
     def create_schema(self, schema_name: str) -> None:  # noqa: D
         self.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
 

--- a/metricflow/test/fixtures/sql_clients/big_query.py
+++ b/metricflow/test/fixtures/sql_clients/big_query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional
 
 import google.oauth2.service_account
 import sqlalchemy
@@ -100,9 +100,3 @@ class BigQuerySqlClient(SqlAlchemySqlClient):
     @override
     def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
         return BigQuerySqlQueryPlanRenderer()
-
-    def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
-        with self._engine_connection(engine=self._engine) as conn:
-            insp = sqlalchemy.inspection.inspect(conn)
-            schema_dot_tables = insp.get_table_names(schema=schema_name)
-            return [x.replace(schema_name + ".", "") for x in schema_dot_tables]

--- a/metricflow/test/fixtures/sql_clients/databricks.py
+++ b/metricflow/test/fixtures/sql_clients/databricks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional
 
 import pandas as pd
 import sqlalchemy
@@ -228,12 +228,6 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
                     self._execute_stmt(cursor=cursor, stmt=f"INSERT INTO {sql_table.sql} VALUES {values}")
 
         logger.info(f"Created table '{sql_table.sql}' from a DataFrame in {time.time() - start_time:.2f}s")
-
-    def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
-        with self.get_connection() as connection:
-            with connection.cursor() as cursor:
-                cursor.tables(schema_name=schema_name)
-                return [table.TABLE_NAME for table in cursor.fetchall()]
 
     def render_bind_parameter_key(self, bind_parameter_key: str) -> str:
         """Wrap execution parameter key with syntax accepted by engine."""

--- a/metricflow/test/fixtures/sql_clients/ddl_sql_client.py
+++ b/metricflow/test/fixtures/sql_clients/ddl_sql_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Optional, Protocol
+
+from pandas import DataFrame
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.sql_client import SqlClient
+
+
+class SqlClientWithDDLMethods(SqlClient, Protocol):
+    """SqlClient protocol with DDL methods enabled.
+
+    The core MetricFlow SqlClient is effectively a read-only construct, as MetricFlow is meant to compile and run SQL
+    for metric queries, not manage downstream database state.
+
+    However, it can be useful to have a SqlClient that can do DDL. In this case, we use these methods in our warehouse
+    engine integration tests for setup and teardown. All of the SqlClients we use in our tests must implement this
+    protocol, or else the integration tests cannot be run.
+    """
+
+    @abstractmethod
+    def create_table_from_dataframe(
+        self,
+        sql_table: SqlTable,
+        df: DataFrame,
+        chunk_size: Optional[int] = None,
+    ) -> None:
+        """Creates a table and populates it with the contents of the dataframe.
+
+        Args:
+            sql_table: The SqlTable metadata of the table to create
+            df: The Pandas DataFrame with the contents of the target table
+            chunk_size: The number of rows to write per query
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_schema(self, schema_name: str) -> None:
+        """Create the given schema if it doesn't already exist."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def drop_schema(self, schema_name: str, cascade: bool) -> None:  # noqa: D
+        """Drop the given schema if it exists. If cascade is set, drop the tables in the schema first."""
+        raise NotImplementedError

--- a/metricflow/test/fixtures/sql_clients/duckdb.py
+++ b/metricflow/test/fixtures/sql_clients/duckdb.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Optional, Sequence
+from typing import Optional
 
 import pandas as pd
 import sqlalchemy
-from sqlalchemy import inspect
 from sqlalchemy.pool import StaticPool
 from typing_extensions import override
 
@@ -91,8 +90,3 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
                 df=df,
                 chunk_size=chunk_size,
             )
-
-    def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
-        with self._concurrency_lock:
-            insp = inspect(self._engine)
-            return insp.get_table_names(schema=schema_name)

--- a/metricflow/test/fixtures/sql_clients/sqlalchemy_dialect.py
+++ b/metricflow/test/fixtures/sql_clients/sqlalchemy_dialect.py
@@ -8,7 +8,6 @@ from typing import Iterator, Mapping, Optional, Sequence, Set, Union
 
 import pandas as pd
 import sqlalchemy
-from sqlalchemy import inspect
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -75,10 +74,6 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
             max_overflow=10,
             pool_pre_ping=True,
         )
-
-    def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
-        insp = inspect(self._engine)
-        return insp.get_table_names(schema=schema_name)
 
     @contextmanager
     def _engine_connection(

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.source_schema_tools import create_tables_listed_in_table_snapshot_repository
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotRepository,
@@ -66,7 +66,7 @@ def check_time_spine_source(
 @pytest.fixture(scope="session")
 def create_source_tables(
     mf_test_session_state: MetricFlowTestSessionState,
-    sql_client: SqlClient,
+    ddl_sql_client: SqlClientWithDDLMethods,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> None:
     """Creates all tables that should be in the source schema.
@@ -81,7 +81,7 @@ def create_source_tables(
         return
 
     create_tables_listed_in_table_snapshot_repository(
-        sql_client=sql_client,
+        ddl_sql_client=ddl_sql_client,
         schema_name=mf_test_session_state.mf_source_schema,
         table_snapshot_repository=source_table_snapshot_repository,
     )

--- a/metricflow/test/integration/test_write_to_table.py
+++ b/metricflow/test/integration/test_write_to_table.py
@@ -45,4 +45,4 @@ def test_write_to_table(it_helpers: IntegrationTestHelpers) -> None:  # noqa: D
             compare_names_using_lowercase=it_helpers.sql_client.sql_engine_type is SqlEngine.SNOWFLAKE,
         )
     finally:
-        it_helpers.sql_client.drop_table(output_table)
+        it_helpers.sql_client.execute(f"DROP TABLE IF EXISTS {output_table.sql}")

--- a/metricflow/test/source_schema_tools.py
+++ b/metricflow/test/source_schema_tools.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 
-from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotLoader,
     SqlTableSnapshotRepository,
@@ -13,12 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 def create_tables_listed_in_table_snapshot_repository(
-    sql_client: SqlClient,
+    ddl_sql_client: SqlClientWithDDLMethods,
     schema_name: str,
     table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> None:
     """Creates all tables in the table snapshot repository in the given schema."""
-    snapshot_loader = SqlTableSnapshotLoader(sql_client=sql_client, schema_name=schema_name)
+    snapshot_loader = SqlTableSnapshotLoader(ddl_sql_client=ddl_sql_client, schema_name=schema_name)
     for table_snapshot in table_snapshot_repository.table_snapshots:
         logger.info(f"Loading: {table_snapshot.table_name}")
         snapshot_loader.load(table_snapshot)
@@ -35,7 +35,7 @@ POPULATE_SOURCE_SCHEMA_SHELL_COMMAND = (
 
 def populate_source_schema(
     mf_test_session_state: MetricFlowTestSessionState,
-    sql_client: SqlClient,
+    ddl_sql_client: SqlClientWithDDLMethods,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> None:
     """Populate the source schema with the tables listed in table_snapshots.
@@ -50,11 +50,11 @@ def populate_source_schema(
     schema_name = mf_test_session_state.mf_source_schema
 
     logger.info(f"Dropping schema {schema_name}")
-    sql_client.drop_schema(schema_name=schema_name, cascade=True)
+    ddl_sql_client.drop_schema(schema_name=schema_name, cascade=True)
     logger.info(f"Creating schema {schema_name}")
-    sql_client.create_schema(schema_name=schema_name)
+    ddl_sql_client.create_schema(schema_name=schema_name)
     create_tables_listed_in_table_snapshot_repository(
-        sql_client=sql_client,
+        ddl_sql_client=ddl_sql_client,
         schema_name=schema_name,
         table_snapshot_repository=source_table_snapshot_repository,
     )

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -14,6 +14,7 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_column_type import SqlColumnType
 from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ def test_failed_query_with_execution_params(sql_client: SqlClient) -> None:  # n
 
 
 def test_create_table_from_dataframe(  # noqa: D
-    mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient
+    mf_test_session_state: MetricFlowTestSessionState, ddl_sql_client: SqlClientWithDDLMethods
 ) -> None:
     expected_df = pd.DataFrame(
         columns=["int_col", "str_col", "float_col", "bool_col", "time_col"],
@@ -119,13 +120,13 @@ def test_create_table_from_dataframe(  # noqa: D
         ],
     )
     sql_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
-    sql_client.create_table_from_dataframe(sql_table=sql_table, df=expected_df)
+    ddl_sql_client.create_table_from_dataframe(sql_table=sql_table, df=expected_df)
 
-    actual_df = sql_client.query(f"SELECT * FROM {sql_table.sql}")
+    actual_df = ddl_sql_client.query(f"SELECT * FROM {sql_table.sql}")
     assert_dataframes_equal(
         actual=actual_df,
         expected=expected_df,
-        compare_names_using_lowercase=sql_client.sql_engine_type is SqlEngine.SNOWFLAKE,
+        compare_names_using_lowercase=ddl_sql_client.sql_engine_type is SqlEngine.SNOWFLAKE,
     )
 
 

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -189,14 +189,3 @@ def test_update_params_with_same_key_different_values() -> None:  # noqa: D
 
     with pytest.raises(RuntimeError):
         bind_params0.combine(bind_params1)
-
-
-def test_list_tables(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    schema = mf_test_session_state.mf_system_schema
-    sql_table = SqlTable(schema_name=schema, table_name=_random_table())
-    table_count_before_create = len(sql_client.list_tables(schema))
-    sql_client.execute(f"CREATE TABLE {sql_table.sql} AS {_select_x_as_y()}")
-    table_list = sql_client.list_tables(schema)
-    table_count_after_create = len(table_list)
-    assert table_count_after_create == table_count_before_create + 1
-    assert len([x for x in table_list if x == sql_table.table_name]) == 1

--- a/metricflow/test/table_snapshot/table_snapshots.py
+++ b/metricflow/test/table_snapshot/table_snapshots.py
@@ -16,8 +16,8 @@ from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.specs import hash_items
+from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 
 logger = logging.getLogger(__name__)
 
@@ -125,14 +125,14 @@ class SqlTableSnapshot(FrozenBaseModel):
 class SqlTableSnapshotLoader:
     """Loads a snapshot of a table into the SQL engine."""
 
-    def __init__(self, sql_client: SqlClient, schema_name: str) -> None:  # noqa: D
-        self._sql_client = sql_client
+    def __init__(self, ddl_sql_client: SqlClientWithDDLMethods, schema_name: str) -> None:  # noqa: D
+        self._ddl_sql_client = ddl_sql_client
         self._schema_name = schema_name
 
     def load(self, table_snapshot: SqlTableSnapshot) -> None:  # noqa: D
         sql_table = SqlTable(schema_name=self._schema_name, table_name=table_snapshot.table_name)
 
-        self._sql_client.create_table_from_dataframe(
+        self._ddl_sql_client.create_table_from_dataframe(
             sql_table=sql_table,
             df=table_snapshot.as_df,
             # Without this set, the insert queries may be too long.


### PR DESCRIPTION
MetricFlow is moving to a model where it serves as a library for
compiling and executing metric queries. This core functionality
does not require any DDL or other write operations, and so having
highly specific DDL and write query interfaces, such as the
create_table_from_dataframe method, is not warranted as part of the
core SqlClient protocol.

This PR removes those methods, and moves them to a test package
protocol in order to continue to support their only extant usage,
which is for test case setup, teardown, and verification around
certain operations.

This also moves the implementations of these methods out of the production
AdapterBackedSqlClient and into a test package extension.

This provides us with a bit more flexibility to take temporary short cuts
in order to quickly enable support for new adapter types without exposing
that silliness in any of our production code.