### PR TITLE
Use ValidLinkableSpecResolver for TimeGranularitySolver Implementation

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -512,7 +512,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                             name=metric_time_name,
                             qualified_name=StructuredLinkableSpecName(
                                 element_name=metric_time_name,
-                                entity_link_names=linkable_dimension.entity_links,
+                                entity_link_names=tuple(
+                                    entity_reference.element_name
+                                    for entity_reference in linkable_dimension.entity_links
+                                ),
                                 time_granularity=linkable_dimension.time_granularity,
                             ).qualified_name,
                             description="Event time for metrics.",

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -19,7 +19,7 @@ from dbt_semantic_interfaces.transformations.add_input_metric_measures import Ad
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
 from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
-from metricflow.specs.specs import DimensionSpec, EntityReference
+from metricflow.specs.specs import DimensionSpec
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class Dimension:
         """Build from pydantic Dimension and entity_key."""
         qualified_name = DimensionSpec(
             element_name=path_key.element_name,
-            entity_links=tuple(EntityReference(element_name=x) for x in path_key.entity_links),
+            entity_links=path_key.entity_links,
         ).qualified_name
         return cls(
             name=pydantic_dimension.name,

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -219,7 +219,7 @@ def test_linkable_set(metric_lookup: MetricLookup) -> None:  # noqa: D
         tuple(
             (
                 # Checking a limited set of fields as the result is large due to the paths in the object.
-                linkable_dimension.entity_links,
+                tuple(entity_link.element_name for entity_link in linkable_dimension.entity_links),
                 linkable_dimension.element_name,
                 linkable_dimension.semantic_model_origin.semantic_model_name,
             )
@@ -274,7 +274,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(metric_lookup: M
         tuple(
             (
                 # Checking a limited set of fields as the result is large due to the paths in the object.
-                linkable_dimension.entity_links,
+                tuple(entity_link.element_name for entity_link in linkable_dimension.entity_links),
                 linkable_dimension.element_name,
                 linkable_dimension.semantic_model_origin.semantic_model_name,
                 # Abbreviated version of the join path.

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -1,30 +1,22 @@
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import pandas as pd
-from dbt_semantic_interfaces.protocols.metric import MetricType
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 from dbt_semantic_interfaces.references import (
     EntityReference,
     MeasureReference,
-    MetricModelReference,
     MetricReference,
     TimeDimensionReference,
 )
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
-from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
-from metricflow.dataflow.dataflow_plan import BaseOutput
-from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.specs.specs import (
-    DEFAULT_TIME_GRANULARITY,
     TimeDimensionSpec,
 )
 from metricflow.time.time_granularity import (
@@ -70,79 +62,8 @@ class TimeGranularitySolver:
     def __init__(  # noqa: D
         self,
         semantic_manifest_lookup: SemanticManifestLookup,
-        source_nodes: Sequence[BaseOutput[SemanticModelDataSet]],
-        node_output_resolver: DataflowPlanNodeOutputDataSetResolver[SemanticModelDataSet],
     ) -> None:
         self._semantic_manifest_lookup = semantic_manifest_lookup
-        self._metric_reference_to_measure_reference = TimeGranularitySolver._measures_for_metric(
-            self._semantic_manifest_lookup.semantic_manifest
-        )
-
-        self._local_time_dimension_granularities: Dict[
-            LocalTimeDimensionGranularityKey, Set[TimeGranularity]
-        ] = defaultdict(set)
-
-        for source_node in source_nodes:
-            output_data_set = node_output_resolver.get_output_data_set(source_node)
-            for time_dimension_instance in output_data_set.instance_set.time_dimension_instances:
-                time_dimension_spec = time_dimension_instance.spec
-                if len(time_dimension_spec.entity_links) == 0:
-                    for measure_instance in output_data_set.instance_set.measure_instances:
-                        self._local_time_dimension_granularities[
-                            LocalTimeDimensionGranularityKey(
-                                measure_reference=measure_instance.spec.as_reference,
-                                local_time_dimension_reference=time_dimension_spec.reference,
-                            )
-                        ].add(time_dimension_spec.time_granularity)
-
-    @staticmethod
-    def _measures_for_metric(model: SemanticManifest) -> Dict[MetricModelReference, List[MeasureReference]]:
-        """Given a model, return a dict that maps the name of the metric to the names of the measures used."""
-        metric_reference_to_measure_references: Dict[MetricModelReference, List[MeasureReference]] = {}
-        for metric in model.metrics:
-            metric_reference_to_measure_references[MetricModelReference(metric_name=metric.name)] = [
-                MeasureReference(element_name=measure.element_name) for measure in metric.measure_references
-            ]
-
-        return metric_reference_to_measure_references
-
-    def local_dimension_granularity_range(
-        self, metric_references: Sequence[MetricReference], local_time_dimension_reference: TimeDimensionReference
-    ) -> Tuple[TimeGranularity, TimeGranularity]:
-        """Return the ranges of time granularities for a local dimension associated with the measures in metrics.
-
-        For example, let's say we're querying for two metrics that are based on 'bookings' and 'bookings_monthly'
-        respectively.
-
-        The 'bookings' measure defined is in the 'fct_bookings' semantic model. 'fct_bookings' has a local time dimension
-        named 'ds' with granularity DAY.
-
-        The 'monthly_bookings' measure is in defined in the 'fct_bookings_monthly' semantic model. 'fct_bookings_monthly'
-        has a local time dimension named 'ds' with granularity MONTH.
-
-        Then this would return [DAY, MONTH].
-        """
-        all_time_granularities = set()
-
-        for metric_reference in metric_references:
-            for measure_reference in self._metric_reference_to_measure_reference[
-                MetricModelReference(metric_name=metric_reference.element_name)
-            ]:
-                key = LocalTimeDimensionGranularityKey(
-                    measure_reference=measure_reference,
-                    local_time_dimension_reference=local_time_dimension_reference,
-                )
-                valid_time_granularities_for_measure = self._local_time_dimension_granularities[key]
-
-                if len(valid_time_granularities_for_measure) == 0:
-                    raise InvalidQueryException(
-                        f"Local dimension {local_time_dimension_reference} does not exist for measure "
-                        f"'{measure_reference}' of metric '{metric_reference}"
-                    )
-
-                all_time_granularities.add(min(valid_time_granularities_for_measure))
-
-        return min(all_time_granularities), max(all_time_granularities)
 
     def validate_time_granularity(
         self, metric_references: Sequence[MetricReference], time_dimension_specs: Sequence[TimeDimensionSpec]
@@ -151,87 +72,65 @@ class TimeGranularitySolver:
 
         e.g. throw an error if "ds__week" is specified for a metric with a time granularity of MONTH.
         """
+        valid_group_by_elements = self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
+            metric_references=metric_references,
+        )
+
         for time_dimension_spec in time_dimension_specs:
-            # Validate local time dimensions.
-            if time_dimension_spec.entity_links == ():
-                _, min_granularity_for_querying = self.local_dimension_granularity_range(
-                    metric_references=metric_references,
-                    local_time_dimension_reference=time_dimension_spec.reference,
+            match_found = False
+            for path_key in valid_group_by_elements.path_key_to_linkable_dimensions:
+                if (
+                    path_key.element_name == time_dimension_spec.element_name
+                    and (path_key.entity_links == time_dimension_spec.entity_links)
+                    and path_key.time_granularity == time_dimension_spec.time_granularity
+                ):
+                    match_found = True
+                    break
+            if not match_found:
+                raise RequestTimeGranularityException(
+                    f"{time_dimension_spec} is not valid for querying {metric_references}"
                 )
-                if time_dimension_spec.time_granularity < min_granularity_for_querying:
-                    raise RequestTimeGranularityException(
-                        f"The minimum time granularity for querying metrics {metric_references} is "
-                        f"{min_granularity_for_querying}. Got {time_dimension_spec}"
-                    )
-
-                # If there is a cumulative metric, granularity changes aren't supported. We need to check the granularity
-                # specified in the configs for the cumulative metric alone, since `min_granularity_for_querying` may not be supported.
-                for metric_reference in metric_references:
-                    metric = self._semantic_manifest_lookup.metric_lookup.get_metric(metric_reference)
-                    if metric.type == MetricType.CUMULATIVE:
-                        _, only_queryable_granularity = self.local_dimension_granularity_range(
-                            metric_references=[metric_reference],
-                            local_time_dimension_reference=time_dimension_spec.reference,
-                        )
-                        if time_dimension_spec.time_granularity != only_queryable_granularity:
-                            raise RequestTimeGranularityException(
-                                f"For querying cumulative metric '{metric_reference.element_name}', the granularity of "
-                                f"'{time_dimension_spec.qualified_name}' must be {only_queryable_granularity.name}"
-                            )
-
-        # TODO: Validate non-local time dimension granularities here instead of during plan building.
 
     def resolve_granularity_for_partial_time_dimension_specs(
         self,
         metric_references: Sequence[MetricReference],
         partial_time_dimension_specs: Sequence[PartialTimeDimensionSpec],
-        metric_time_dimension_reference: TimeDimensionReference,
-        time_granularity: Optional[TimeGranularity] = None,
     ) -> Dict[PartialTimeDimensionSpec, TimeDimensionSpec]:
         """Figure out the lowest granularity possible for the partially specified time dimension specs.
 
         Returns a dictionary that maps how the partial time dimension spec should be turned into a time dimension spec.
         """
-        replacement_dict: OrderedDict[PartialTimeDimensionSpec, TimeDimensionSpec] = OrderedDict()
+        valid_group_by_elements = self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
+            metric_references=metric_references,
+        )
+        result: Dict[PartialTimeDimensionSpec, TimeDimensionSpec] = {}
         for partial_time_dimension_spec in partial_time_dimension_specs:
-            # Handle local time dimensions
-            if partial_time_dimension_spec.entity_links == ():
-                _, min_time_granularity_for_querying = self.local_dimension_granularity_range(
-                    metric_references=metric_references,
-                    local_time_dimension_reference=TimeDimensionReference(
-                        element_name=partial_time_dimension_spec.element_name
-                    ),
-                )
-
+            minimum_time_granularity: Optional[TimeGranularity] = None
+            for path_key in valid_group_by_elements.path_key_to_linkable_dimensions:
                 if (
-                    partial_time_dimension_spec.element_name == metric_time_dimension_reference.element_name
-                    and time_granularity
+                    path_key.element_name == partial_time_dimension_spec.element_name
+                    and path_key.entity_links == partial_time_dimension_spec.entity_links
+                    and path_key.time_granularity is not None
                 ):
-                    if time_granularity < min_time_granularity_for_querying:
-                        raise RequestTimeGranularityException(
-                            f"Can't use time granularity for time dimension '{metric_time_dimension_reference} since "
-                            f"the minimum granularity is {min_time_granularity_for_querying}"
-                        )
-                    replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
-                        element_name=partial_time_dimension_spec.element_name,
-                        entity_links=(),
-                        time_granularity=time_granularity,
+                    minimum_time_granularity = (
+                        path_key.time_granularity
+                        if minimum_time_granularity is None
+                        else min(minimum_time_granularity, path_key.time_granularity)
                     )
-                else:
-                    replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
-                        element_name=partial_time_dimension_spec.element_name,
-                        entity_links=(),
-                        time_granularity=min_time_granularity_for_querying,
-                    )
-            # Handle joined time dimensions.
-            else:
-                # TODO: For joined time dimensions, also compute the minimum granularity for querying.
-                replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
+
+            if minimum_time_granularity is not None:
+                result[partial_time_dimension_spec] = TimeDimensionSpec(
                     element_name=partial_time_dimension_spec.element_name,
                     entity_links=partial_time_dimension_spec.entity_links,
-                    time_granularity=DEFAULT_TIME_GRANULARITY,
+                    time_granularity=minimum_time_granularity,
                 )
-        return replacement_dict
+            else:
+                raise RequestTimeGranularityException(
+                    f"Unable to resolve the time dimension spec for {partial_time_dimension_spec}. "
+                    f"Valid group by elements are:\n"
+                    f"{pformat_big_objects([spec.qualified_name for spec in valid_group_by_elements.as_spec_set.as_tuple])}"
+                )
+        return result
 
     def adjust_time_range_to_granularity(
         self, time_range_constraint: TimeRangeConstraint, time_granularity: TimeGranularity


### PR DESCRIPTION
### Description

With https://github.com/dbt-labs/metricflow/pull/676, it's possible to remove some redundant logic in the `TimeGranularitySolver`. There are plans for additional simplification that will allow us to consolidate `MetricFlowQueryParser`, `ValidLinkableSpecResolver`, and `TimeGranularitySolver`.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
