### PR TITLE
Remove `create_a_cycle_in_the_join_graph` Identifier in Test Manifest

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -512,7 +512,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                             name=metric_time_name,
                             qualified_name=StructuredLinkableSpecName(
                                 element_name=metric_time_name,
-                                entity_link_names=linkable_dimension.entity_links,
+                                entity_link_names=tuple(
+                                    entity_reference.element_name
+                                    for entity_reference in linkable_dimension.entity_links
+                                ),
                                 time_granularity=linkable_dimension.time_granularity,
                             ).qualified_name,
                             description="Event time for metrics.",

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -19,7 +19,7 @@ from dbt_semantic_interfaces.transformations.add_input_metric_measures import Ad
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
 from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
-from metricflow.specs.specs import DimensionSpec, EntityReference
+from metricflow.specs.specs import DimensionSpec
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class Dimension:
         """Build from pydantic Dimension and entity_key."""
         qualified_name = DimensionSpec(
             element_name=path_key.element_name,
-            entity_links=tuple(EntityReference(element_name=x) for x in path_key.entity_links),
+            entity_links=path_key.entity_links,
         ).qualified_name
         return cls(
             name=pydantic_dimension.name,

--- a/metricflow/test/dataflow/builder/test_cyclic_join.py
+++ b/metricflow/test/dataflow/builder/test_cyclic_join.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.references import EntityReference
+
+from metricflow.dataflow.builder.costing import DefaultCostFunction
+from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.dataflow.dataflow_plan_to_text import dataflow_plan_as_text
+from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
+from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow.specs.specs import (
+    DimensionSpec,
+    MetricFlowQuerySpec,
+    MetricSpec,
+)
+from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
+from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.sql_client_fixtures import sql_client  # noqa: F401, F403
+from metricflow.test.plan_utils import assert_plan_snapshot_text_equal
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def cyclic_join_manifest_dataflow_plan_builder(  # noqa: D
+    cyclic_join_semantic_manifest_lookup: SemanticManifestLookup,
+    consistent_id_object_repository: ConsistentIdObjectRepository,
+) -> DataflowPlanBuilder[SemanticModelDataSet]:
+    for source_node in consistent_id_object_repository.cyclic_join_source_nodes:
+        logger.error(f"Source node is: {source_node}")
+
+    return DataflowPlanBuilder(
+        source_nodes=consistent_id_object_repository.cyclic_join_source_nodes,
+        semantic_manifest_lookup=cyclic_join_semantic_manifest_lookup,
+        cost_function=DefaultCostFunction[SemanticModelDataSet](),
+    )
+
+
+def test_cyclic_join(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    cyclic_join_manifest_dataflow_plan_builder: DataflowPlanBuilder[SemanticModelDataSet],
+) -> None:
+    """Tests that sources with the same joinable keys don't cause cycle issues."""
+    dataflow_plan = cyclic_join_manifest_dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="listings"),),
+            dimension_specs=(
+                DimensionSpec(
+                    element_name="capacity_latest",
+                    entity_links=(EntityReference(element_name="cyclic_entity"),),
+                ),
+            ),
+        )
+    )
+
+    assert_plan_snapshot_text_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        plan=dataflow_plan,
+        plan_snapshot_text=dataflow_plan_as_text(dataflow_plan),
+    )
+
+    display_graph_if_requested(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dag_graph=dataflow_plan,
+    )

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -88,12 +88,15 @@ class ConsistentIdObjectRepository:
     scd_model_read_nodes: OrderedDict[str, ReadSqlSourceNode[SemanticModelDataSet]]
     scd_model_source_nodes: Sequence[BaseOutput[SemanticModelDataSet]]
 
+    cyclic_join_source_nodes: Sequence[BaseOutput[SemanticModelDataSet]]
+
 
 @pytest.fixture(scope="session")
 def consistent_id_object_repository(
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
     scd_semantic_manifest_lookup: SemanticManifestLookup,
+    cyclic_join_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> ConsistentIdObjectRepository:  # noqa: D
     """Create objects that have incremental numeric IDs with a consistent value.
 
@@ -104,6 +107,7 @@ def consistent_id_object_repository(
         sm_data_sets = create_data_sets(simple_semantic_manifest_lookup)
         multihop_data_sets = create_data_sets(multi_hop_join_semantic_manifest_lookup)
         scd_data_sets = create_data_sets(scd_semantic_manifest_lookup)
+        cyclic_join_data_sets = create_data_sets(cyclic_join_semantic_manifest_lookup)
 
         return ConsistentIdObjectRepository(
             simple_model_data_sets=sm_data_sets,
@@ -117,6 +121,9 @@ def consistent_id_object_repository(
             scd_model_read_nodes=_data_set_to_read_nodes(scd_data_sets),
             scd_model_source_nodes=_data_set_to_source_nodes(
                 semantic_manifest_lookup=scd_semantic_manifest_lookup, data_sets=scd_data_sets
+            ),
+            cyclic_join_source_nodes=_data_set_to_source_nodes(
+                semantic_manifest_lookup=cyclic_join_semantic_manifest_lookup, data_sets=cyclic_join_data_sets
             ),
         )
 

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -243,3 +243,13 @@ def data_warehouse_validation_model(template_mapping: Dict[str, str]) -> Semanti
         template_mapping=template_mapping,
     )
     return build_result.semantic_manifest
+
+
+@pytest.fixture(scope="session")
+def cyclic_join_semantic_manifest_lookup(template_mapping: Dict[str, str]) -> SemanticManifestLookup:
+    """Manifest that contains a potential cycle in the join graph (if not handled properly)."""
+    build_result = parse_directory_of_yaml_files_to_semantic_manifest(
+        os.path.join(os.path.dirname(__file__), "semantic_manifest_yamls/cyclic_join_manifest"),
+        template_mapping=template_mapping,
+    )
+    return SemanticManifestLookup(build_result.semantic_manifest)

--- a/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/listings_latest.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/listings_latest.yaml
@@ -1,0 +1,35 @@
+---
+semantic_model:
+  name: listings_latest
+  description: listings_latest
+
+  node_relation:
+    schema_name: $source_schema
+    alias: dim_listings_latest
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: listings
+      expr: 1
+      agg: sum
+      create_metric: true
+
+  dimensions:
+    - name: ds
+      type: time
+      expr: created_at
+      type_params:
+        time_granularity: day
+    - name: country_latest
+      type: categorical
+      expr: country
+
+  entities:
+    - name: listing
+      type: primary
+      expr: listing_id
+    - name: cyclic_entity
+      type: unique
+      expr: listing_id

--- a/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/listings_latest_cyclic.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/listings_latest_cyclic.yaml
@@ -1,0 +1,21 @@
+---
+semantic_model:
+  name: listings_latest_cyclic
+  description: This can create a join cycle with listings_latest since they share primary / unique keys.
+
+  node_relation:
+    schema_name: $source_schema
+    alias: dim_listings_latest
+
+  dimensions:
+    - name: capacity_latest
+      type: categorical
+      expr: capacity
+
+  entities:
+    - name: listing
+      type: primary
+      expr: listing_id
+    - name: cyclic_entity
+      type: unique
+      expr: listing_id

--- a/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/project_configuration.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/cyclic_join_manifest/project_configuration.yaml
@@ -1,0 +1,1 @@
+../shared/project_configuration.yaml

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/semantic_models/bookings_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/semantic_models/bookings_source.yaml
@@ -94,6 +94,3 @@ semantic_model:
     - name: host
       type: foreign
       expr: host_id
-    - name: create_a_cycle_in_the_join_graph
-      type: primary
-      expr: guest_id

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/semantic_models/views_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/semantic_models/views_source.yaml
@@ -33,6 +33,3 @@ semantic_model:
     - name: user
       type: foreign
       expr: user_id
-    - name: create_a_cycle_in_the_join_graph
-      type: primary
-      expr: user_id

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -39,10 +39,6 @@ def test_linkable_spec_resolver(simple_model_spec_resolver: ValidLinkableSpecRes
     ).as_spec_set
 
     assert [
-        "create_a_cycle_in_the_join_graph__is_instant",
-        "create_a_cycle_in_the_join_graph__listing__capacity_latest",
-        "create_a_cycle_in_the_join_graph__listing__country_latest",
-        "create_a_cycle_in_the_join_graph__listing__is_lux_latest",
         "listing__capacity_latest",
         "listing__country_latest",
         "listing__is_lux_latest",
@@ -51,9 +47,6 @@ def test_linkable_spec_resolver(simple_model_spec_resolver: ValidLinkableSpecRes
         "listing__user__home_state_latest",
     ] == sorted(tuple(x.qualified_name for x in result.dimension_specs))
     assert [
-        "create_a_cycle_in_the_join_graph__booking_paid_at",
-        "create_a_cycle_in_the_join_graph__listing__created_at",
-        "create_a_cycle_in_the_join_graph__listing__ds",
         "ds",
         "ds_partitioned",
         "listing__created_at",
@@ -63,10 +56,6 @@ def test_linkable_spec_resolver(simple_model_spec_resolver: ValidLinkableSpecRes
         "metric_time",
     ] == sorted(tuple(x.qualified_name for x in result.time_dimension_specs))
     assert [
-        "create_a_cycle_in_the_join_graph",
-        "create_a_cycle_in_the_join_graph__listing",
-        "create_a_cycle_in_the_join_graph__listing__lux_listing",
-        "create_a_cycle_in_the_join_graph__listing__user",
         "listing",
         "listing__lux_listing",
         "listing__user",

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -74,7 +74,6 @@ def test_get_names(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa:
 
     expected = [
         "company",
-        "create_a_cycle_in_the_join_graph",
         "guest",
         "host",
         "listing",
@@ -125,19 +124,6 @@ def test_elements_for_metric(metric_lookup: MetricLookup) -> None:  # noqa: D
             )
         ]
     ) == {
-        "create_a_cycle_in_the_join_graph",
-        "create_a_cycle_in_the_join_graph__booking_paid_at",
-        "create_a_cycle_in_the_join_graph__guest",
-        "create_a_cycle_in_the_join_graph__host",
-        "create_a_cycle_in_the_join_graph__is_instant",
-        "create_a_cycle_in_the_join_graph__listing",
-        "create_a_cycle_in_the_join_graph__listing__ds",
-        "create_a_cycle_in_the_join_graph__listing__capacity_latest",
-        "create_a_cycle_in_the_join_graph__listing__country_latest",
-        "create_a_cycle_in_the_join_graph__listing__created_at",
-        "create_a_cycle_in_the_join_graph__listing__is_lux_latest",
-        "create_a_cycle_in_the_join_graph__listing__user",
-        "create_a_cycle_in_the_join_graph__listing__lux_listing",
         "ds",
         "ds_partitioned",
         "listing",
@@ -169,7 +155,6 @@ def test_elements_for_metric(metric_lookup: MetricLookup) -> None:  # noqa: D
         without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
     )
     assert set([x.qualified_name for x in local_specs]) == {
-        "create_a_cycle_in_the_join_graph",
         "ds",
         "ds_partitioned",
         "listing",
@@ -231,13 +216,6 @@ def test_linkable_set(metric_lookup: MetricLookup) -> None:  # noqa: D
     assert result_to_compare == [
         ((), "ds", "views_source"),
         ((), "ds_partitioned", "views_source"),
-        (("create_a_cycle_in_the_join_graph",), "booking_paid_at", "bookings_source"),
-        (("create_a_cycle_in_the_join_graph",), "is_instant", "bookings_source"),
-        (("create_a_cycle_in_the_join_graph", "listing"), "capacity_latest", "listings_latest"),
-        (("create_a_cycle_in_the_join_graph", "listing"), "country_latest", "listings_latest"),
-        (("create_a_cycle_in_the_join_graph", "listing"), "created_at", "listings_latest"),
-        (("create_a_cycle_in_the_join_graph", "listing"), "ds", "listings_latest"),
-        (("create_a_cycle_in_the_join_graph", "listing"), "is_lux_latest", "listings_latest"),
         (("listing",), "capacity_latest", "listings_latest"),
         (("listing",), "country_latest", "listings_latest"),
         (("listing",), "created_at", "listings_latest"),
@@ -295,48 +273,6 @@ def test_linkable_set_for_common_dimensions_in_different_models(metric_lookup: M
         ((), "ds_partitioned", "views_source", ()),
         ((), "metric_time", "bookings_source", ()),
         ((), "metric_time", "views_source", ()),
-        (("create_a_cycle_in_the_join_graph",), "booking_paid_at", "bookings_source", ()),
-        (("create_a_cycle_in_the_join_graph",), "booking_paid_at", "bookings_source", ()),
-        (("create_a_cycle_in_the_join_graph",), "is_instant", "bookings_source", ()),
-        (("create_a_cycle_in_the_join_graph",), "is_instant", "bookings_source", ("bookings_source",)),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "capacity_latest",
-            "listings_latest",
-            ("bookings_source", "listings_latest"),
-        ),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "capacity_latest",
-            "listings_latest",
-            ("views_source", "listings_latest"),
-        ),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "country_latest",
-            "listings_latest",
-            ("bookings_source", "listings_latest"),
-        ),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "country_latest",
-            "listings_latest",
-            ("views_source", "listings_latest"),
-        ),
-        (("create_a_cycle_in_the_join_graph", "listing"), "created_at", "listings_latest", ()),
-        (("create_a_cycle_in_the_join_graph", "listing"), "ds", "listings_latest", ()),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "is_lux_latest",
-            "listings_latest",
-            ("bookings_source", "listings_latest"),
-        ),
-        (
-            ("create_a_cycle_in_the_join_graph", "listing"),
-            "is_lux_latest",
-            "listings_latest",
-            ("views_source", "listings_latest"),
-        ),
         (("listing",), "capacity_latest", "listings_latest", ("listings_latest",)),
         (("listing",), "country_latest", "listings_latest", ("listings_latest",)),
         (("listing",), "created_at", "listings_latest", ()),

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -219,7 +219,7 @@ def test_linkable_set(metric_lookup: MetricLookup) -> None:  # noqa: D
         tuple(
             (
                 # Checking a limited set of fields as the result is large due to the paths in the object.
-                linkable_dimension.entity_links,
+                tuple(entity_link.element_name for entity_link in linkable_dimension.entity_links),
                 linkable_dimension.element_name,
                 linkable_dimension.semantic_model_origin.semantic_model_name,
             )
@@ -274,7 +274,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(metric_lookup: M
         tuple(
             (
                 # Checking a limited set of fields as the result is large due to the paths in the object.
-                linkable_dimension.entity_links,
+                tuple(entity_link.element_name for entity_link in linkable_dimension.entity_links),
                 linkable_dimension.element_name,
                 linkable_dimension.semantic_model_origin.semantic_model_name,
                 # Abbreviated version of the join path.

--- a/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
+++ b/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
@@ -1,0 +1,96 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = Write to Dataframe -->
+        <!-- node_id = wrd_0 -->
+        <ComputeMetricsNode>
+            <!-- description = Compute Metrics via Expressions -->
+            <!-- node_id = cm_0 -->
+            <!-- metric_spec =                   -->
+            <!--   {'class': 'MetricSpec',       -->
+            <!--    'element_name': 'listings',  -->
+            <!--    'constraint': None,          -->
+            <!--    'alias': None,               -->
+            <!--    'offset_window': None,       -->
+            <!--    'offset_to_grain': None}     -->
+            <AggregateMeasuresNode>
+                <!-- description = Aggregate Measures -->
+                <!-- node_id = am_0 -->
+                <FilterElementsNode>
+                    <!-- description =                                       -->
+                    <!--   Pass Only Elements:                               -->
+                    <!--     ['listings', 'cyclic_entity__capacity_latest']  -->
+                    <!-- node_id = pfe_2 -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'listings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
+                    <!-- include_spec =                                            -->
+                    <!--   {'class': 'DimensionSpec',                              -->
+                    <!--    'element_name': 'capacity_latest',                     -->
+                    <!--    'entity_links': ({'class': 'EntityReference',          -->
+                    <!--                      'element_name': 'cyclic_entity'},)}  -->
+                    <JoinToBaseOutputNode>
+                        <!-- description = Join Standard Outputs -->
+                        <!-- node_id = jso_0 -->
+                        <!-- join0_for_node_id_pfe_1 =                               -->
+                        <!--   {'class': 'JoinDescription',                          -->
+                        <!--    'join_node': FilterElementsNode(node_id=pfe_1),      -->
+                        <!--    'join_on_entity': {'class': 'LinklessEntitySpec',    -->
+                        <!--                       'element_name': 'cyclic_entity',  -->
+                        <!--                       'entity_links': ()},              -->
+                        <!--    'join_on_partition_dimensions': (),                  -->
+                        <!--    'join_on_partition_time_dimensions': (),             -->
+                        <!--    'validity_window': None}                             -->
+                        <FilterElementsNode>
+                            <!-- description =                      -->
+                            <!--   Pass Only Elements:              -->
+                            <!--     ['listings', 'cyclic_entity']  -->
+                            <!-- node_id = pfe_0 -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'listings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
+                            <!-- include_spec =                       -->
+                            <!--   {'class': 'LinklessEntitySpec',    -->
+                            <!--    'element_name': 'cyclic_entity',  -->
+                            <!--    'entity_links': ()}               -->
+                            <MetricTimeDimensionTransformNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = sma_10010 -->
+                                <!-- aggregation_time_dimension = ds -->
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                                    -->
+                                    <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                    <!-- node_id = rss_10044 -->
+                                    <!-- data_set =                                                                             -->
+                                    <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->
+                                </ReadSqlSourceNode>
+                            </MetricTimeDimensionTransformNode>
+                        </FilterElementsNode>
+                        <FilterElementsNode>
+                            <!-- description =                             -->
+                            <!--   Pass Only Elements:                     -->
+                            <!--     ['capacity_latest', 'cyclic_entity']  -->
+                            <!-- node_id = pfe_1 -->
+                            <!-- include_spec =                         -->
+                            <!--   {'class': 'DimensionSpec',           -->
+                            <!--    'element_name': 'capacity_latest',  -->
+                            <!--    'entity_links': ()}                 -->
+                            <!-- include_spec =                       -->
+                            <!--   {'class': 'LinklessEntitySpec',    -->
+                            <!--    'element_name': 'cyclic_entity',  -->
+                            <!--    'entity_links': ()}               -->
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                                           -->
+                                <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest_cyclic'))  -->
+                                <!-- node_id = rss_10045 -->
+                                <!-- data_set =                                                                                    -->
+                                <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest_cyclic'))  -->
+                            </ReadSqlSourceNode>
+                        </FilterElementsNode>
+                    </JoinToBaseOutputNode>
+                </FilterElementsNode>
+            </AggregateMeasuresNode>
+        </ComputeMetricsNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS ds_partitioned__quarter
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(views_source_src_10009.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(views_source_src_10009.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
         , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
         , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                 , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
                   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
               , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
           , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
       , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
   , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC(booking_paid_at, month) AS booking_paid_at__month
   , DATE_TRUNC(booking_paid_at, quarter) AS booking_paid_at__quarter
   , DATE_TRUNC(booking_paid_at, isoyear) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC(ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC(ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC(ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC(ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC(ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC(ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC(booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC(booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC(booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC(booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
                   , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
         , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
                   , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
         , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
                   , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
         , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
                   , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
         , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.ds AS metric_time
           , subq_5.ds__week AS metric_time__week
           , subq_5.ds__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.bookings
           , subq_5.instant_bookings
           , subq_5.booking_value
@@ -252,29 +192,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -61,21 +61,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -84,12 +69,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -136,29 +116,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -303,16 +263,6 @@ FROM (
                 , subq_10.ds_partitioned__month
                 , subq_10.ds_partitioned__quarter
                 , subq_10.ds_partitioned__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds
-                , subq_10.create_a_cycle_in_the_join_graph__ds__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds__year
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_10.create_a_cycle_in_the_join_graph__ds_partitioned__year
                 , subq_10.ds AS metric_time
                 , subq_10.ds__week AS metric_time__week
                 , subq_10.ds__month AS metric_time__month
@@ -320,9 +270,6 @@ FROM (
                 , subq_10.ds__year AS metric_time__year
                 , subq_10.listing
                 , subq_10.user
-                , subq_10.create_a_cycle_in_the_join_graph
-                , subq_10.create_a_cycle_in_the_join_graph__listing
-                , subq_10.create_a_cycle_in_the_join_graph__user
                 , subq_10.views
               FROM (
                 -- Read Elements From Semantic Model 'views_source'
@@ -338,21 +285,8 @@ FROM (
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
                   , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
                 FROM ***************************.fct_views views_source_src_10009
               ) subq_10
             ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -57,29 +57,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
@@ -54,29 +54,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
@@ -48,29 +48,9 @@ FROM (
         , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
         , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_0
   ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -182,21 +142,6 @@ FROM (
             , subq_5.booking_paid_at__month
             , subq_5.booking_paid_at__quarter
             , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_5.ds AS metric_time
             , subq_5.ds__week AS metric_time__week
             , subq_5.ds__month AS metric_time__month
@@ -205,12 +150,7 @@ FROM (
             , subq_5.listing
             , subq_5.guest
             , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
             , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
             , subq_5.bookings
             , subq_5.instant_bookings
             , subq_5.booking_value
@@ -257,29 +197,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_5
         ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -42,21 +42,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -65,12 +50,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -117,29 +97,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
@@ -193,21 +153,6 @@ FROM (
               , subq_5.booking_paid_at__month
               , subq_5.booking_paid_at__quarter
               , subq_5.booking_paid_at__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds
-              , subq_5.create_a_cycle_in_the_join_graph__ds__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds__year
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_5.ds AS metric_time
               , subq_5.ds__week AS metric_time__week
               , subq_5.ds__month AS metric_time__month
@@ -216,12 +161,7 @@ FROM (
               , subq_5.listing
               , subq_5.guest
               , subq_5.host
-              , subq_5.create_a_cycle_in_the_join_graph
-              , subq_5.create_a_cycle_in_the_join_graph__listing
-              , subq_5.create_a_cycle_in_the_join_graph__guest
-              , subq_5.create_a_cycle_in_the_join_graph__host
               , subq_5.is_instant
-              , subq_5.create_a_cycle_in_the_join_graph__is_instant
               , subq_5.bookings
               , subq_5.instant_bookings
               , subq_5.booking_value
@@ -268,29 +208,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_5
           ) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -53,21 +53,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -76,12 +61,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -128,29 +108,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1
@@ -207,21 +167,6 @@ FROM (
               , subq_8.booking_paid_at__month
               , subq_8.booking_paid_at__quarter
               , subq_8.booking_paid_at__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds
-              , subq_8.create_a_cycle_in_the_join_graph__ds__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds__year
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_8.ds AS metric_time
               , subq_8.ds__week AS metric_time__week
               , subq_8.ds__month AS metric_time__month
@@ -230,12 +175,7 @@ FROM (
               , subq_8.listing
               , subq_8.guest
               , subq_8.host
-              , subq_8.create_a_cycle_in_the_join_graph
-              , subq_8.create_a_cycle_in_the_join_graph__listing
-              , subq_8.create_a_cycle_in_the_join_graph__guest
-              , subq_8.create_a_cycle_in_the_join_graph__host
               , subq_8.is_instant
-              , subq_8.create_a_cycle_in_the_join_graph__is_instant
               , subq_8.bookings
               , subq_8.instant_bookings
               , subq_8.booking_value
@@ -282,29 +222,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_8
           ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_one_input_metric__plan0.sql
@@ -47,21 +47,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -122,29 +102,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0.sql
@@ -52,21 +52,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -75,12 +60,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -127,29 +107,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_node__plan0.sql
@@ -35,28 +35,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0.sql
@@ -41,29 +41,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -58,21 +58,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -81,12 +66,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -133,29 +113,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -47,21 +47,6 @@ INNER JOIN (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -70,12 +55,7 @@ INNER JOIN (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -122,29 +102,9 @@ INNER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0.sql
@@ -36,21 +36,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -59,12 +44,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -111,29 +91,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_aggregation_node__plan0.sql
@@ -45,29 +45,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
@@ -70,21 +70,6 @@ FROM (
                     , subq_0.booking_paid_at__month
                     , subq_0.booking_paid_at__quarter
                     , subq_0.booking_paid_at__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_0.ds AS metric_time
                     , subq_0.ds__week AS metric_time__week
                     , subq_0.ds__month AS metric_time__month
@@ -93,12 +78,7 @@ FROM (
                     , subq_0.listing
                     , subq_0.guest
                     , subq_0.host
-                    , subq_0.create_a_cycle_in_the_join_graph
-                    , subq_0.create_a_cycle_in_the_join_graph__listing
-                    , subq_0.create_a_cycle_in_the_join_graph__guest
-                    , subq_0.create_a_cycle_in_the_join_graph__host
                     , subq_0.is_instant
-                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
                     , subq_0.bookings
                     , subq_0.instant_bookings
                     , subq_0.booking_value
@@ -145,29 +125,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_0
                 ) subq_1
@@ -329,21 +289,6 @@ FROM (
                     , subq_12.booking_paid_at__month
                     , subq_12.booking_paid_at__quarter
                     , subq_12.booking_paid_at__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
                     , subq_12.ds AS metric_time
                     , subq_12.ds__week AS metric_time__week
                     , subq_12.ds__month AS metric_time__month
@@ -352,12 +297,7 @@ FROM (
                     , subq_12.listing
                     , subq_12.guest
                     , subq_12.host
-                    , subq_12.create_a_cycle_in_the_join_graph
-                    , subq_12.create_a_cycle_in_the_join_graph__listing
-                    , subq_12.create_a_cycle_in_the_join_graph__guest
-                    , subq_12.create_a_cycle_in_the_join_graph__host
                     , subq_12.is_instant
-                    , subq_12.create_a_cycle_in_the_join_graph__is_instant
                     , subq_12.bookings
                     , subq_12.instant_bookings
                     , subq_12.booking_value
@@ -404,29 +344,9 @@ FROM (
                       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM ***************************.fct_bookings bookings_source_src_10001
                   ) subq_12
                 ) subq_13
@@ -567,21 +487,6 @@ FROM (
             , subq_24.booking_paid_at__month
             , subq_24.booking_paid_at__quarter
             , subq_24.booking_paid_at__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds
-            , subq_24.create_a_cycle_in_the_join_graph__ds__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds__year
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_24.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_24.ds AS metric_time
             , subq_24.ds__week AS metric_time__week
             , subq_24.ds__month AS metric_time__month
@@ -590,12 +495,7 @@ FROM (
             , subq_24.listing
             , subq_24.guest
             , subq_24.host
-            , subq_24.create_a_cycle_in_the_join_graph
-            , subq_24.create_a_cycle_in_the_join_graph__listing
-            , subq_24.create_a_cycle_in_the_join_graph__guest
-            , subq_24.create_a_cycle_in_the_join_graph__host
             , subq_24.is_instant
-            , subq_24.create_a_cycle_in_the_join_graph__is_instant
             , subq_24.bookings
             , subq_24.instant_bookings
             , subq_24.booking_value
@@ -642,29 +542,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_24
         ) subq_25

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
@@ -55,21 +55,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -78,12 +63,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -130,29 +110,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -198,21 +158,6 @@ FROM (
             , subq_7.booking_paid_at__month
             , subq_7.booking_paid_at__quarter
             , subq_7.booking_paid_at__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds
-            , subq_7.create_a_cycle_in_the_join_graph__ds__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds__year
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_7.ds AS metric_time
             , subq_7.ds__week AS metric_time__week
             , subq_7.ds__month AS metric_time__month
@@ -221,12 +166,7 @@ FROM (
             , subq_7.listing
             , subq_7.guest
             , subq_7.host
-            , subq_7.create_a_cycle_in_the_join_graph
-            , subq_7.create_a_cycle_in_the_join_graph__listing
-            , subq_7.create_a_cycle_in_the_join_graph__guest
-            , subq_7.create_a_cycle_in_the_join_graph__host
             , subq_7.is_instant
-            , subq_7.create_a_cycle_in_the_join_graph__is_instant
             , subq_7.bookings
             , subq_7.instant_bookings
             , subq_7.booking_value
@@ -273,29 +213,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_7
         ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -49,21 +49,6 @@ FROM (
               , subq_0.booking_paid_at__month
               , subq_0.booking_paid_at__quarter
               , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
               , subq_0.ds AS metric_time
               , subq_0.ds__week AS metric_time__week
               , subq_0.ds__month AS metric_time__month
@@ -72,12 +57,7 @@ FROM (
               , subq_0.listing
               , subq_0.guest
               , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
               , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
               , subq_0.bookings
               , subq_0.instant_bookings
               , subq_0.booking_value
@@ -124,29 +104,9 @@ FROM (
                 , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                 , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
               FROM ***************************.fct_bookings bookings_source_src_10001
             ) subq_0
           ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -37,21 +37,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
@@ -43,29 +43,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
@@ -33,21 +33,6 @@ FROM (
           , subq_1.booking_paid_at__month
           , subq_1.booking_paid_at__quarter
           , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_1.metric_time
           , subq_1.metric_time__week
           , subq_1.metric_time__month
@@ -56,12 +41,7 @@ FROM (
           , subq_1.listing
           , subq_1.guest
           , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
           , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
           , subq_1.bookings
           , subq_1.instant_bookings
           , subq_1.booking_value
@@ -93,21 +73,6 @@ FROM (
             , subq_0.booking_paid_at__month
             , subq_0.booking_paid_at__quarter
             , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_0.ds AS metric_time
             , subq_0.ds__week AS metric_time__week
             , subq_0.ds__month AS metric_time__month
@@ -116,12 +81,7 @@ FROM (
             , subq_0.listing
             , subq_0.guest
             , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
             , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
             , subq_0.bookings
             , subq_0.instant_bookings
             , subq_0.booking_value
@@ -168,29 +128,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0.sql
@@ -54,21 +54,6 @@ FROM (
                 , subq_0.booking_paid_at__month
                 , subq_0.booking_paid_at__quarter
                 , subq_0.booking_paid_at__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds
-                , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_0.ds AS metric_time
                 , subq_0.ds__week AS metric_time__week
                 , subq_0.ds__month AS metric_time__month
@@ -77,12 +62,7 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.create_a_cycle_in_the_join_graph
-                , subq_0.create_a_cycle_in_the_join_graph__listing
-                , subq_0.create_a_cycle_in_the_join_graph__guest
-                , subq_0.create_a_cycle_in_the_join_graph__host
                 , subq_0.is_instant
-                , subq_0.create_a_cycle_in_the_join_graph__is_instant
                 , subq_0.bookings
                 , subq_0.instant_bookings
                 , subq_0.booking_value
@@ -129,29 +109,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_0
             ) subq_1
@@ -194,21 +154,6 @@ FROM (
                 , subq_5.booking_paid_at__month
                 , subq_5.booking_paid_at__quarter
                 , subq_5.booking_paid_at__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds
-                , subq_5.create_a_cycle_in_the_join_graph__ds__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds__year
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
                 , subq_5.ds AS metric_time
                 , subq_5.ds__week AS metric_time__week
                 , subq_5.ds__month AS metric_time__month
@@ -217,12 +162,7 @@ FROM (
                 , subq_5.listing
                 , subq_5.guest
                 , subq_5.host
-                , subq_5.create_a_cycle_in_the_join_graph
-                , subq_5.create_a_cycle_in_the_join_graph__listing
-                , subq_5.create_a_cycle_in_the_join_graph__guest
-                , subq_5.create_a_cycle_in_the_join_graph__host
                 , subq_5.is_instant
-                , subq_5.create_a_cycle_in_the_join_graph__is_instant
                 , subq_5.bookings
                 , subq_5.instant_bookings
                 , subq_5.booking_value
@@ -269,29 +209,9 @@ FROM (
                   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
                   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM ***************************.fct_bookings bookings_source_src_10001
               ) subq_5
             ) subq_6
@@ -342,21 +262,6 @@ FROM (
             , subq_12.booking_paid_at__month
             , subq_12.booking_paid_at__quarter
             , subq_12.booking_paid_at__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds
-            , subq_12.create_a_cycle_in_the_join_graph__ds__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds__year
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_12.ds AS metric_time
             , subq_12.ds__week AS metric_time__week
             , subq_12.ds__month AS metric_time__month
@@ -365,12 +270,7 @@ FROM (
             , subq_12.listing
             , subq_12.guest
             , subq_12.host
-            , subq_12.create_a_cycle_in_the_join_graph
-            , subq_12.create_a_cycle_in_the_join_graph__listing
-            , subq_12.create_a_cycle_in_the_join_graph__guest
-            , subq_12.create_a_cycle_in_the_join_graph__host
             , subq_12.is_instant
-            , subq_12.create_a_cycle_in_the_join_graph__is_instant
             , subq_12.bookings
             , subq_12.instant_bookings
             , subq_12.booking_value
@@ -417,29 +317,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_12
         ) subq_13
@@ -488,21 +368,6 @@ FROM (
             , subq_17.booking_paid_at__month
             , subq_17.booking_paid_at__quarter
             , subq_17.booking_paid_at__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds
-            , subq_17.create_a_cycle_in_the_join_graph__ds__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds__year
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
             , subq_17.ds AS metric_time
             , subq_17.ds__week AS metric_time__week
             , subq_17.ds__month AS metric_time__month
@@ -511,12 +376,7 @@ FROM (
             , subq_17.listing
             , subq_17.guest
             , subq_17.host
-            , subq_17.create_a_cycle_in_the_join_graph
-            , subq_17.create_a_cycle_in_the_join_graph__listing
-            , subq_17.create_a_cycle_in_the_join_graph__guest
-            , subq_17.create_a_cycle_in_the_join_graph__host
             , subq_17.is_instant
-            , subq_17.create_a_cycle_in_the_join_graph__is_instant
             , subq_17.bookings
             , subq_17.instant_bookings
             , subq_17.booking_value
@@ -563,29 +423,9 @@ FROM (
               , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
               , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_17
         ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0.sql
@@ -55,29 +55,9 @@ FROM (
           , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
           , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-          , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-          , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-          , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-          , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-          , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-          , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-          , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-          , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-          , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
         FROM ***************************.fct_bookings bookings_source_src_10001
       ) subq_0
     ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_single_join_node__plan0.sql
@@ -42,29 +42,9 @@ FROM (
       , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
       , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_0
 ) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0_optimized.sql
@@ -30,27 +30,7 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_semantic_model__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_semantic_model__plan0.xml
@@ -31,11 +31,11 @@
             <!-- node_id = ss_10 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- where = None -->
@@ -44,7 +44,7 @@
                 <!-- node_id = ss_9 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -53,7 +53,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -63,11 +63,11 @@
                     <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                     <!-- where = None -->
@@ -76,231 +76,151 @@
                         <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                        <!-- col15 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col16 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!-- col17 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!-- col18 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!-- col19 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                        <!--    'column_alias': 'metric_time__year'}                   -->
+                        <!-- col20 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                        <!--    'column_alias': 'listing'}                             -->
+                        <!-- col21 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                        <!--    'column_alias': 'guest'}                               -->
+                        <!-- col22 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                        <!--    'column_alias': 'host'}                                -->
+                        <!-- col23 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                        <!--    'column_alias': 'is_instant'}                          -->
+                        <!-- col24 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- col25 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                        <!--    'column_alias': 'instant_bookings'}                    -->
+                        <!-- col26 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                        <!--    'column_alias': 'booking_value'}                       -->
+                        <!-- col27 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                        <!--    'column_alias': 'max_booking_value'}                   -->
+                        <!-- col28 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                        <!--    'column_alias': 'min_booking_value'}                   -->
+                        <!-- col29 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                        <!--    'column_alias': 'bookers'}                             -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                        <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                        <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                        <!--    'column_alias': 'median_booking_value'}                -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                        <!--    'column_alias': 'booking_value_p99'}                   -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                        <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                        <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                        <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                        <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                        <!--    'column_alias': 'bookings'}                            -->
-                        <!-- col45 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                        <!--    'column_alias': 'instant_bookings'}                    -->
-                        <!-- col46 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                        <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- col47 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                        <!--    'column_alias': 'max_booking_value'}                   -->
-                        <!-- col48 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                        <!--    'column_alias': 'min_booking_value'}                   -->
-                        <!-- col49 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                        <!--    'column_alias': 'bookers'}                             -->
-                        <!-- col50 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                        <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- col51 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                        <!--    'column_alias': 'referred_bookings'}                   -->
-                        <!-- col52 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                        <!--    'column_alias': 'median_booking_value'}                -->
-                        <!-- col53 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                        <!--    'column_alias': 'booking_value_p99'}                   -->
-                        <!-- col54 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
@@ -427,98 +347,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>
@@ -536,11 +376,11 @@
             <!-- node_id = ss_14 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
             <!--    'column_alias': 'booking_value'}                       -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
             <!-- where = None -->
@@ -549,7 +389,7 @@
                 <!-- node_id = ss_13 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -558,7 +398,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -568,11 +408,11 @@
                     <!-- node_id = ss_12 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                     <!--    'column_alias': 'booking_value'}                       -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
@@ -581,231 +421,151 @@
                         <!-- node_id = ss_11 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                        <!-- col15 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col16 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!-- col17 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!-- col18 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!-- col19 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                        <!--    'column_alias': 'metric_time__year'}                   -->
+                        <!-- col20 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                        <!--    'column_alias': 'listing'}                             -->
+                        <!-- col21 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'column_alias': 'guest'}                               -->
+                        <!-- col22 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'column_alias': 'host'}                                -->
+                        <!-- col23 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                        <!--    'column_alias': 'is_instant'}                          -->
+                        <!-- col24 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- col25 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
+                        <!--    'column_alias': 'instant_bookings'}                    -->
+                        <!-- col26 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
+                        <!--    'column_alias': 'booking_value'}                       -->
+                        <!-- col27 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
+                        <!--    'column_alias': 'max_booking_value'}                   -->
+                        <!-- col28 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
+                        <!--    'column_alias': 'min_booking_value'}                   -->
+                        <!-- col29 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                        <!--    'column_alias': 'bookers'}                             -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
-                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                        <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
-                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                        <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
-                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                        <!--    'column_alias': 'median_booking_value'}                -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
-                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                        <!--    'column_alias': 'booking_value_p99'}                   -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
-                        <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                        <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                        <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                        <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
-                        <!--    'column_alias': 'bookings'}                            -->
-                        <!-- col45 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
-                        <!--    'column_alias': 'instant_bookings'}                    -->
-                        <!-- col46 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
-                        <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- col47 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
-                        <!--    'column_alias': 'max_booking_value'}                   -->
-                        <!-- col48 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
-                        <!--    'column_alias': 'min_booking_value'}                   -->
-                        <!-- col49 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                        <!--    'column_alias': 'bookers'}                             -->
-                        <!-- col50 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                        <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- col51 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                        <!--    'column_alias': 'referred_bookings'}                   -->
-                        <!-- col52 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                        <!--    'column_alias': 'median_booking_value'}                -->
-                        <!-- col53 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                        <!--    'column_alias': 'booking_value_p99'}                   -->
-                        <!-- col54 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),        -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),      -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
@@ -932,98 +692,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -202,98 +202,18 @@
                         <!--   {'class': 'SqlSelectColumn',                        -->
                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                        <!-- col30 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                        <!-- col30 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                        <!--    'column_alias': 'listing'}                               -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col32 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col33 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col34 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col35 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col36 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col37 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col38 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col39 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col40 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col41 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col42 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col43 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col44 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col45 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col46 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'listing'}                               -->
-                        <!-- col47 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                         <!--    'column_alias': 'guest'}                                 -->
-                        <!-- col48 =                                                     -->
+                        <!-- col32 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                         <!--    'column_alias': 'host'}                                  -->
-                        <!-- col49 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                        <!-- col50 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col51 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col52 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
                         <SqlTableFromClauseNode>
@@ -327,127 +247,127 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col11 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col12 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col23 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col24 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col25 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_24 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
         <!--    'column_alias': 'ds'}                                  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_440),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
@@ -29,11 +29,11 @@
             <!--    'column_alias': 'listing__country_latest'}                                     -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
             <!--    'column_alias': 'views'}                               -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- join_0 =                                                   -->
@@ -48,15 +48,15 @@
                 <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
@@ -65,11 +65,11 @@
                     <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -78,11 +78,11 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- group_by1 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -92,15 +92,15 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
@@ -109,19 +109,19 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
@@ -138,15 +138,15 @@
                                 <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
@@ -155,231 +155,151 @@
                                     <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -506,98 +426,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -615,11 +455,11 @@
                                 <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
@@ -628,151 +468,151 @@
                                     <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
@@ -785,127 +625,127 @@
                                         <!--    'column_alias': 'listings'}                                 -->
                                         <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                         <!--    'column_alias': 'largest_listing'}                       -->
                                         <!-- col2 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
                                         <!-- col3 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                         <!--    'column_alias': 'created_at'}                            -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col12 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col13 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                         <!--    'column_alias': 'country_latest'}                        -->
                                         <!-- col14 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                         -->
                                         <!-- col15 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
                                         <!-- col16 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                         <!--    'column_alias': 'listing__ds'}                           -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col21 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                         <!--    'column_alias': 'listing__created_at'}                   -->
                                         <!-- col22 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col23 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col24 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col25 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col26 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                         <!--    'column_alias': 'listing__country_latest'}               -->
                                         <!-- col27 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                         <!-- col28 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                                         <!-- col29 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                         <!--    'column_alias': 'listing'}                               -->
                                         <!-- col30 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                         <!--    'column_alias': 'user'}                                  -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                         <!--    'column_alias': 'listing__user'}                         -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                         <!-- where = None -->
@@ -926,15 +766,15 @@
                 <!-- node_id = ss_22 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                 <!--    'column_alias': 'views'}                               -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
                 <!-- where = None -->
@@ -943,11 +783,11 @@
                     <!-- node_id = ss_21 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -956,11 +796,11 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- group_by1 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -970,15 +810,15 @@
                         <!-- node_id = ss_20 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                         <!--    'column_alias': 'views'}                               -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                         <!-- where = None -->
@@ -987,19 +827,19 @@
                             <!-- node_id = ss_19 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
                             <!--    'column_alias': 'views'}                               -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                             <!-- join_0 =                                                    -->
@@ -1016,15 +856,15 @@
                                 <!-- node_id = ss_16 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                 <!--    'column_alias': 'views'}                               -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                                 <!-- where = None -->
@@ -1033,127 +873,75 @@
                                     <!-- node_id = ss_15 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                    <!-- col10 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col11 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col12 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col13 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col14 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col15 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col16 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col17 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col18 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col19 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col20 =                                                   -->
+                                    <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
-                                    <!-- col21 =                                                   -->
+                                    <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
-                                    <!-- col22 =                                                   -->
+                                    <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
-                                    <!-- col23 =                                                   -->
+                                    <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
-                                    <!-- col24 =                                                   -->
+                                    <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col25 =                                                   -->
+                                    <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                                     <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col26 =                                                   -->
+                                    <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                     <!--    'column_alias': 'user'}                                -->
-                                    <!-- col27 =                                                   -->
+                                    <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col28 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col29 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
-                                    <!-- col30 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                     <!--    'column_alias': 'views'}                               -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10009) -->
                                     <!-- where = None -->
@@ -1166,104 +954,52 @@
                                         <!--    'column_alias': 'views'}                                    -->
                                         <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10179),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10159),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col2 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10096),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col3 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10097),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10098),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10099),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col6 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10184),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10164),  -->
                                         <!--    'column_alias': 'ds_partitioned'}                        -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10100),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col8 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10101),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10102),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10090),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10103),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10091),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col11 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10189),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col12 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col13 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col14 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col15 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col16 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10194),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col17 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col18 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col19 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col20 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col21 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10199),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10169),  -->
                                         <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col22 =                                                     -->
+                                        <!-- col12 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10200),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10170),  -->
                                         <!--    'column_alias': 'user'}                                  -->
-                                        <!-- col23 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10201),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col24 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10202),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col25 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10203),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10009) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -1281,11 +1017,11 @@
                                 <!-- node_id = ss_18 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_413),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                                 <!-- where = None -->
@@ -1294,151 +1030,151 @@
                                     <!-- node_id = ss_17 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_412),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
@@ -1451,127 +1187,127 @@
                                         <!--    'column_alias': 'listings'}                                 -->
                                         <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                         <!--    'column_alias': 'largest_listing'}                       -->
                                         <!-- col2 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
                                         <!-- col3 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                         <!--    'column_alias': 'created_at'}                            -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col12 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col13 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                         <!--    'column_alias': 'country_latest'}                        -->
                                         <!-- col14 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                         -->
                                         <!-- col15 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
                                         <!-- col16 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                         <!--    'column_alias': 'listing__ds'}                           -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col21 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                         <!--    'column_alias': 'listing__created_at'}                   -->
                                         <!-- col22 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col23 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col24 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col25 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col26 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                         <!--    'column_alias': 'listing__country_latest'}               -->
                                         <!-- col27 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                         <!-- col28 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                                         <!-- col29 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                         <!--    'column_alias': 'listing'}                               -->
                                         <!-- col30 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                         <!--    'column_alias': 'user'}                                  -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                         <!--    'column_alias': 'listing__user'}                         -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -214,98 +214,18 @@
                         <!--   {'class': 'SqlSelectColumn',                        -->
                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                        <!-- col30 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                        <!-- col30 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                        <!--    'column_alias': 'listing'}                               -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col32 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col33 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col34 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col35 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col36 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col37 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col38 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col39 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col40 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col41 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col42 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col43 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col44 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col45 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col46 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'listing'}                               -->
-                        <!-- col47 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                         <!--    'column_alias': 'guest'}                                 -->
-                        <!-- col48 =                                                     -->
+                        <!-- col32 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                         <!--    'column_alias': 'host'}                                  -->
-                        <!-- col49 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                        <!-- col50 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col51 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col52 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
                         <SqlTableFromClauseNode>
@@ -339,127 +259,127 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col11 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col12 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col23 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col24 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col25 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -202,98 +202,18 @@
                         <!--   {'class': 'SqlSelectColumn',                        -->
                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                        <!-- col30 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                        <!-- col30 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                        <!--    'column_alias': 'listing'}                               -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col32 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col33 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col34 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col35 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col36 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col37 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col38 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col39 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col40 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col41 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col42 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col43 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col44 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col45 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col46 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'listing'}                               -->
-                        <!-- col47 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                         <!--    'column_alias': 'guest'}                                 -->
-                        <!-- col48 =                                                     -->
+                        <!-- col32 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                         <!--    'column_alias': 'host'}                                  -->
-                        <!-- col49 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                        <!-- col50 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col51 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col52 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
                         <SqlTableFromClauseNode>
@@ -327,127 +247,127 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col11 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col12 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col23 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col24 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col25 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
@@ -172,98 +172,18 @@
                     <!--   {'class': 'SqlSelectColumn',                        -->
                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                    <!-- col30 =                                                             -->
-                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                    <!-- col30 =                                                     -->
+                    <!--   {'class': 'SqlSelectColumn',                              -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                    <!--    'column_alias': 'listing'}                               -->
                     <!-- col31 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                    <!-- col32 =                                                           -->
-                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                    <!-- col33 =                                                            -->
-                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                    <!-- col34 =                                                              -->
-                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                    <!-- col35 =                                                           -->
-                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                    <!-- col36 =                                                                 -->
-                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                    <!-- col37 =                                                                       -->
-                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                    <!-- col38 =                                                                        -->
-                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                    <!-- col39 =                                                                          -->
-                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                    <!-- col40 =                                                                       -->
-                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                    <!-- col41 =                                                                  -->
-                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                    <!-- col42 =                                                                        -->
-                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                    <!-- col43 =                                                                         -->
-                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                    <!-- col44 =                                                                           -->
-                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                    <!-- col45 =                                                                        -->
-                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                    <!-- col46 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                    <!--    'column_alias': 'listing'}                               -->
-                    <!-- col47 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                     <!--    'column_alias': 'guest'}                                 -->
-                    <!-- col48 =                                                     -->
+                    <!-- col32 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                     <!--    'column_alias': 'host'}                                  -->
-                    <!-- col49 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                    <!-- col50 =                                                          -->
-                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                    <!-- col51 =                                                        -->
-                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                    <!-- col52 =                                                       -->
-                    <!--   {'class': 'SqlSelectColumn',                                -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                     <!-- where = None -->
                     <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -49,51 +49,51 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
@@ -102,31 +102,31 @@
                         <!-- node_id = ss_10006 -->
                         <!-- col0 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
         <!--    'column_alias': 'revenue_mtd'}                         -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -49,51 +49,51 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
@@ -102,31 +102,31 @@
                         <!-- node_id = ss_10006 -->
                         <!-- col0 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -24,7 +24,7 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -33,51 +33,51 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
@@ -86,31 +86,31 @@
                         <!-- node_id = ss_10006 -->
                         <!-- col0 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
         <!--    'column_alias': 'revenue_all_time'}                    -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -49,51 +49,51 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
@@ -102,31 +102,31 @@
                         <!-- node_id = ss_10006 -->
                         <!-- col0 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
         <!--    'column_alias': 'revenue_all_time'}                    -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
@@ -50,51 +50,51 @@
                     <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = SqlBetweenExpression(node_id=betw_1) -->
@@ -103,51 +103,51 @@
                         <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                         <!--    'column_alias': 'txn_revenue'}                         -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                         <!-- where = None -->
@@ -156,31 +156,31 @@
                             <!-- node_id = ss_10006 -->
                             <!-- col0 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                             <!--    'column_alias': 'txn_revenue'}                           -->
                             <!-- col1 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                             <!--    'column_alias': 'ds'}                                    -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col5 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col6 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                             <!--    'column_alias': 'user'}                                  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
@@ -50,51 +50,51 @@
                     <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = SqlBetweenExpression(node_id=betw_1) -->
@@ -103,51 +103,51 @@
                         <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                         <!--    'column_alias': 'txn_revenue'}                         -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                         <!-- where = None -->
@@ -156,31 +156,31 @@
                             <!-- node_id = ss_10006 -->
                             <!-- col0 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
                             <!--    'column_alias': 'txn_revenue'}                           -->
                             <!-- col1 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                             <!--    'column_alias': 'ds'}                                    -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col5 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col6 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                             <!--    'column_alias': 'user'}                                  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_16 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                              -->
         <!--   {'class': 'SqlSelectColumn',                                                                      -->
@@ -21,11 +21,11 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
             <!--    'column_alias': 'ref_bookings'}                        -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- join_0 =                                                   -->
@@ -40,11 +40,11 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                 <!--    'column_alias': 'ref_bookings'}                        -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -53,7 +53,7 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -62,7 +62,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -72,11 +72,11 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                         <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -85,231 +85,151 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -436,98 +356,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -545,11 +385,11 @@
                 <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
@@ -558,7 +398,7 @@
                     <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -567,7 +407,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -577,11 +417,11 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
@@ -590,231 +430,151 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -941,98 +701,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_18 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                         -->
         <!--   {'class': 'SqlSelectColumn',                                                                 -->
@@ -21,11 +21,11 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
             <!--    'column_alias': 'bookings_at_start_of_month'}          -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- join_0 =                                                   -->
@@ -40,11 +40,11 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -53,7 +53,7 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -62,7 +62,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -72,11 +72,11 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -85,231 +85,151 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -436,98 +356,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -545,11 +385,11 @@
                 <!-- node_id = ss_16 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                 <!--    'column_alias': 'bookings_at_start_of_month'}          -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- join_0 =                                                    -->
@@ -564,7 +404,7 @@
                     <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
                     <!-- where = None -->
@@ -579,11 +419,11 @@
                     <!-- node_id = ss_14 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                     <!--    'column_alias': 'bookings_at_start_of_month'}          -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                     <!-- where = None -->
@@ -592,7 +432,7 @@
                         <!-- node_id = ss_13 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -601,7 +441,7 @@
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                         <!-- group_by0 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
@@ -611,11 +451,11 @@
                             <!-- node_id = ss_12 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                             <!-- where = None -->
@@ -624,231 +464,151 @@
                                 <!-- node_id = ss_11 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                 <!--    'column_alias': 'ds__week'}                            -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                 <!--    'column_alias': 'ds__month'}                           -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                 <!--    'column_alias': 'ds__quarter'}                         -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                 <!--    'column_alias': 'ds__year'}                            -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col8 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                     -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}               -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                 <!-- col14 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col15 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col16 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col17 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col18 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col19 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col20 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col21 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col22 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col23 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col24 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col25 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col26 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col27 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col28 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col29 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
                                 <!-- col30 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
-                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- col31 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
-                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- col32 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
-                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
                                 <!-- col33 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
-                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
                                 <!-- col34 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
-                                <!--    'column_alias': 'metric_time__year'}                   -->
-                                <!-- col35 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col36 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col38 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col39 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col40 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col41 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col43 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col46 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col47 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col48 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col49 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col50 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- col51 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                                <!--    'column_alias': 'referred_bookings'}                   -->
-                                <!-- col52 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                                <!--    'column_alias': 'median_booking_value'}                -->
-                                <!-- col53 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                                <!--    'column_alias': 'booking_value_p99'}                   -->
-                                <!-- col54 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                 <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                <!-- col55 =                                                         -->
+                                <!-- col35 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),        -->
                                 <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                <!-- col56 =                                                       -->
+                                <!-- col36 =                                                       -->
                                 <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),      -->
                                 <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                 <!-- where = None -->
@@ -975,98 +735,18 @@
                                     <!--   {'class': 'SqlSelectColumn',                        -->
                                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col30 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col30 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
                                     <!-- col31 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col32 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col33 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col34 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col35 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col36 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col37 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col38 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col39 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col40 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col41 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col42 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col43 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col44 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col45 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col46 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col47 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                     <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col48 =                                                     -->
+                                    <!-- col32 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                     <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col49 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col50 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col51 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col52 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_18 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                   -->
         <!--   {'class': 'SqlSelectColumn',                                                           -->
@@ -21,11 +21,11 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
             <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- join_0 =                                                   -->
@@ -40,11 +40,11 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -53,7 +53,7 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -62,7 +62,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -72,11 +72,11 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -85,231 +85,151 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -436,98 +356,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -545,11 +385,11 @@
                 <!-- node_id = ss_16 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                 <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- join_0 =                                                    -->
@@ -564,7 +404,7 @@
                     <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
                     <!-- where = None -->
@@ -579,11 +419,11 @@
                     <!-- node_id = ss_14 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                     <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                     <!-- where = None -->
@@ -592,7 +432,7 @@
                         <!-- node_id = ss_13 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -601,7 +441,7 @@
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                         <!-- group_by0 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
@@ -611,11 +451,11 @@
                             <!-- node_id = ss_12 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                             <!-- where = None -->
@@ -624,231 +464,151 @@
                                 <!-- node_id = ss_11 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                 <!--    'column_alias': 'ds__week'}                            -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                 <!--    'column_alias': 'ds__month'}                           -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                 <!--    'column_alias': 'ds__quarter'}                         -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                 <!--    'column_alias': 'ds__year'}                            -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col8 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                     -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}               -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                 <!-- col14 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col15 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col16 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col17 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col18 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col19 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col20 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col21 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col22 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col23 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col24 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col25 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col26 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col27 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col28 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col29 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
                                 <!-- col30 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
-                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- col31 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
-                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- col32 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
-                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
                                 <!-- col33 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
-                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
                                 <!-- col34 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
-                                <!--    'column_alias': 'metric_time__year'}                   -->
-                                <!-- col35 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col36 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col38 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col39 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col40 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col41 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col43 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col46 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col47 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col48 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col49 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col50 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- col51 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                                <!--    'column_alias': 'referred_bookings'}                   -->
-                                <!-- col52 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                                <!--    'column_alias': 'median_booking_value'}                -->
-                                <!-- col53 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                                <!--    'column_alias': 'booking_value_p99'}                   -->
-                                <!-- col54 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                 <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                <!-- col55 =                                                         -->
+                                <!-- col35 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),        -->
                                 <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                <!-- col56 =                                                       -->
+                                <!-- col36 =                                                       -->
                                 <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),      -->
                                 <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                 <!-- where = None -->
@@ -975,98 +735,18 @@
                                     <!--   {'class': 'SqlSelectColumn',                        -->
                                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col30 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col30 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
                                     <!-- col31 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col32 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col33 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col34 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col35 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col36 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col37 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col38 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col39 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col40 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col41 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col42 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col43 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col44 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col45 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col46 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col47 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                     <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col48 =                                                     -->
+                                    <!-- col32 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                     <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col49 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col50 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col51 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col52 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_20 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                               -->
         <!--   {'class': 'SqlSelectColumn',                                                                       -->
@@ -21,11 +21,11 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
             <!--    'column_alias': 'month_start_bookings'}                -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
             <!--    'column_alias': 'bookings_1_month_ago'}                -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
             <!-- join_0 =                                                   -->
@@ -40,11 +40,11 @@
                 <!-- node_id = ss_12 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                 <!--    'column_alias': 'month_start_bookings'}                -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                 <!-- join_0 =                                                    -->
@@ -59,7 +59,7 @@
                     <!-- node_id = ss_11 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
                     <!-- where = None -->
@@ -74,11 +74,11 @@
                     <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                     <!--    'column_alias': 'month_start_bookings'}                -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
@@ -87,7 +87,7 @@
                         <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -96,7 +96,7 @@
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                         <!-- group_by0 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
@@ -106,11 +106,11 @@
                             <!-- node_id = ss_8 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                             <!-- where = None -->
@@ -119,231 +119,151 @@
                                 <!-- node_id = ss_7 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                 <!--    'column_alias': 'ds__week'}                            -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                 <!--    'column_alias': 'ds__month'}                           -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                 <!--    'column_alias': 'ds__quarter'}                         -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                 <!--    'column_alias': 'ds__year'}                            -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col8 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                     -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}               -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                 <!-- col14 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col15 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col16 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col17 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col18 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col19 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col20 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col21 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col22 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col23 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col24 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col25 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col26 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col27 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col28 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col29 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
                                 <!-- col30 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- col31 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- col32 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
                                 <!-- col33 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
                                 <!-- col34 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                <!--    'column_alias': 'metric_time__year'}                   -->
-                                <!-- col35 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col36 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col38 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col39 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col40 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col41 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col43 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col46 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col47 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col48 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col49 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col50 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- col51 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                <!--    'column_alias': 'referred_bookings'}                   -->
-                                <!-- col52 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                <!--    'column_alias': 'median_booking_value'}                -->
-                                <!-- col53 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                <!--    'column_alias': 'booking_value_p99'}                   -->
-                                <!-- col54 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                 <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                <!-- col55 =                                                         -->
+                                <!-- col35 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                 <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                <!-- col56 =                                                       -->
+                                <!-- col36 =                                                       -->
                                 <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                 <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                 <!-- where = None -->
@@ -470,98 +390,18 @@
                                     <!--   {'class': 'SqlSelectColumn',                        -->
                                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col30 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col30 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
                                     <!-- col31 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col32 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col33 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col34 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col35 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col36 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col37 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col38 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col39 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col40 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col41 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col42 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col43 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col44 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col45 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col46 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col47 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                     <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col48 =                                                     -->
+                                    <!-- col32 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                     <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col49 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col50 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col51 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col52 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>
@@ -580,11 +420,11 @@
                 <!-- node_id = ss_18 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
                 <!--    'column_alias': 'bookings_1_month_ago'}                -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                 <!-- join_0 =                                                    -->
@@ -599,7 +439,7 @@
                     <!-- node_id = ss_17 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_1) -->
                     <!-- where = None -->
@@ -614,11 +454,11 @@
                     <!-- node_id = ss_16 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'bookings_1_month_ago'}                -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                     <!-- where = None -->
@@ -627,7 +467,7 @@
                         <!-- node_id = ss_15 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -636,7 +476,7 @@
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                         <!-- group_by0 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
@@ -646,11 +486,11 @@
                             <!-- node_id = ss_14 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- where = None -->
@@ -659,231 +499,151 @@
                                 <!-- node_id = ss_13 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                 <!--    'column_alias': 'ds__week'}                            -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                 <!--    'column_alias': 'ds__month'}                           -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                 <!--    'column_alias': 'ds__quarter'}                         -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                 <!--    'column_alias': 'ds__year'}                            -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col8 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                     -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}               -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                 <!-- col14 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col15 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col16 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col17 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col18 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col19 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col20 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col21 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col22 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col23 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col24 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col25 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col26 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col27 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col28 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col29 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
                                 <!-- col30 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- col31 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- col32 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
                                 <!-- col33 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
                                 <!-- col34 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
-                                <!--    'column_alias': 'metric_time__year'}                   -->
-                                <!-- col35 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col36 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col38 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col39 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col40 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col41 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col43 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col46 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col47 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col48 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col49 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col50 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- col51 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
-                                <!--    'column_alias': 'referred_bookings'}                   -->
-                                <!-- col52 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                                <!--    'column_alias': 'median_booking_value'}                -->
-                                <!-- col53 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
-                                <!--    'column_alias': 'booking_value_p99'}                   -->
-                                <!-- col54 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                 <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                <!-- col55 =                                                         -->
+                                <!-- col35 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),        -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),        -->
                                 <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                <!-- col56 =                                                       -->
+                                <!-- col36 =                                                       -->
                                 <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),      -->
                                 <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                 <!-- where = None -->
@@ -1010,98 +770,18 @@
                                     <!--   {'class': 'SqlSelectColumn',                        -->
                                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col30 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col30 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
                                     <!-- col31 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col32 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col33 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col34 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col35 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col36 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col37 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col38 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col39 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col40 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col41 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col42 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col43 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col44 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col45 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col46 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col47 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                     <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col48 =                                                     -->
+                                    <!-- col32 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                     <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col49 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col50 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col51 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col52 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_one_input_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_one_input_metric__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                       -->
         <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -17,11 +17,11 @@
             <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
             <!--    'column_alias': 'bookings_5_days_ago'}                 -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                    -->
@@ -36,7 +36,7 @@
                 <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
                 <!-- where = None -->
@@ -51,11 +51,11 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                 <!--    'column_alias': 'bookings_5_days_ago'}                 -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -64,7 +64,7 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -73,7 +73,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -83,11 +83,11 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -96,231 +96,151 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -447,98 +367,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
@@ -4,13 +4,13 @@
         <!-- node_id = ss_16 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
         <!-- order_by0 =                                               -->
         <!--   {'class': 'SqlOrderByDescription',                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
         <!--    'desc': False}                                         -->
         <SqlSelectStatementNode>
             <!-- description =                    -->
@@ -19,7 +19,7 @@
             <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- where = None -->
@@ -28,11 +28,11 @@
                 <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
@@ -41,7 +41,7 @@
                     <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -50,7 +50,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -60,11 +60,11 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
@@ -73,15 +73,15 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
@@ -98,11 +98,11 @@
                                 <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
@@ -111,231 +111,151 @@
                                     <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -462,98 +382,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -571,11 +411,11 @@
                                 <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
@@ -584,151 +424,151 @@
                                     <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
@@ -741,127 +581,127 @@
                                         <!--    'column_alias': 'listings'}                                 -->
                                         <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                         <!--    'column_alias': 'largest_listing'}                       -->
                                         <!-- col2 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
                                         <!-- col3 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                         <!--    'column_alias': 'created_at'}                            -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col12 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col13 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                         <!--    'column_alias': 'country_latest'}                        -->
                                         <!-- col14 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                         -->
                                         <!-- col15 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
                                         <!-- col16 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                         <!--    'column_alias': 'listing__ds'}                           -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col21 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                         <!--    'column_alias': 'listing__created_at'}                   -->
                                         <!-- col22 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col23 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col24 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col25 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col26 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                         <!--    'column_alias': 'listing__country_latest'}               -->
                                         <!-- col27 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                         <!-- col28 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                                         <!-- col29 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                         <!--    'column_alias': 'listing'}                               -->
                                         <!-- col30 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                         <!--    'column_alias': 'user'}                                  -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                         <!--    'column_alias': 'listing__user'}                         -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
@@ -133,98 +133,18 @@
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
             <!--    'column_alias': 'booking_paid_at__year'}           -->
-            <!-- col30 =                                                             -->
-            <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+            <!-- col30 =                                                     -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+            <!--    'column_alias': 'listing'}                               -->
             <!-- col31 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-            <!-- col32 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-            <!-- col33 =                                                            -->
-            <!--   {'class': 'SqlSelectColumn',                                     -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-            <!-- col34 =                                                              -->
-            <!--   {'class': 'SqlSelectColumn',                                       -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-            <!-- col35 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-            <!-- col36 =                                                                 -->
-            <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-            <!-- col37 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-            <!-- col38 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-            <!-- col39 =                                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                                   -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-            <!-- col40 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-            <!-- col41 =                                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-            <!-- col42 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-            <!-- col43 =                                                                         -->
-            <!--   {'class': 'SqlSelectColumn',                                                  -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-            <!-- col44 =                                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-            <!-- col45 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-            <!-- col46 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-            <!--    'column_alias': 'listing'}                               -->
-            <!-- col47 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
             <!--    'column_alias': 'guest'}                                 -->
-            <!-- col48 =                                                     -->
+            <!-- col32 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
             <!--    'column_alias': 'host'}                                  -->
-            <!-- col49 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-            <!-- col50 =                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-            <!-- col51 =                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-            <!-- col52 =                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->
             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -151,98 +151,18 @@
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                <!-- col30 =                                                             -->
-                <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                <!-- col30 =                                                     -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                <!--    'column_alias': 'listing'}                               -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                <!-- col32 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                <!-- col33 =                                                            -->
-                <!--   {'class': 'SqlSelectColumn',                                     -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                <!-- col34 =                                                              -->
-                <!--   {'class': 'SqlSelectColumn',                                       -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                <!-- col35 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                <!-- col36 =                                                                 -->
-                <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                <!-- col37 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                <!-- col38 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                <!-- col39 =                                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                <!-- col40 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                <!-- col41 =                                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                <!-- col42 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                <!-- col43 =                                                                         -->
-                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                <!-- col44 =                                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                <!-- col45 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                <!-- col46 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'listing'}                               -->
-                <!-- col47 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                 <!--    'column_alias': 'guest'}                                 -->
-                <!-- col48 =                                                     -->
+                <!-- col32 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                 <!--    'column_alias': 'host'}                                  -->
-                <!-- col49 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                <!-- col50 =                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                <!-- col51 =                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                <!-- col52 =                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_16 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
         <!--    'column_alias': 'is_instant'}                          -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
         <!--    'column_alias': 'bookings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
             <!--    'column_alias': 'is_instant'}                          -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
             <!--    'column_alias': 'is_instant'}                          -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                 <!--    'column_alias': 'is_instant'}                          -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
@@ -49,15 +49,15 @@
                     <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'is_instant'}                          -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- where =                                                                       -->
@@ -69,15 +69,15 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
@@ -86,19 +86,19 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
@@ -115,15 +115,15 @@
                                 <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                 <!--    'column_alias': 'is_instant'}                          -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
@@ -132,231 +132,151 @@
                                     <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -483,98 +403,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -592,11 +432,11 @@
                                 <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
@@ -605,151 +445,151 @@
                                     <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
@@ -762,127 +602,127 @@
                                         <!--    'column_alias': 'listings'}                                 -->
                                         <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                         <!--    'column_alias': 'largest_listing'}                       -->
                                         <!-- col2 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
                                         <!-- col3 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                         <!--    'column_alias': 'created_at'}                            -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col12 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col13 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                         <!--    'column_alias': 'country_latest'}                        -->
                                         <!-- col14 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                         -->
                                         <!-- col15 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
                                         <!-- col16 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                         <!--    'column_alias': 'listing__ds'}                           -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col21 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                         <!--    'column_alias': 'listing__created_at'}                   -->
                                         <!-- col22 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col23 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col24 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col25 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col26 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                         <!--    'column_alias': 'listing__country_latest'}               -->
                                         <!-- col27 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                         <!-- col28 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                                         <!-- col29 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                         <!--    'column_alias': 'listing'}                               -->
                                         <!-- col30 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                         <!--    'column_alias': 'user'}                                  -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                         <!--    'column_alias': 'listing__user'}                         -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
@@ -273,99 +273,99 @@
                                         <!--    'column_alias': 'instant_bookings'}                                                              -->
                                         <!-- col2 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
                                         <!--    'column_alias': 'booking_value'}                         -->
                                         <!-- col3 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10236),  -->
                                         <!--    'column_alias': 'bookers'}                               -->
                                         <!-- col4 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10270),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10237),  -->
                                         <!--    'column_alias': 'average_booking_value'}                 -->
                                         <!-- col5 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10271),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10238),  -->
                                         <!--    'column_alias': 'booking_payments'}                      -->
                                         <!-- col6 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10272),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10239),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
                                         <!-- col7 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10240),  -->
                                         <!--    'column_alias': 'ds'}                                    -->
                                         <!-- col8 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col12 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10245),  -->
                                         <!--    'column_alias': 'ds_partitioned'}                        -->
                                         <!-- col13 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10128),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col14 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10129),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col15 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col17 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10283),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10250),  -->
                                         <!--    'column_alias': 'booking_paid_at'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),  -->
                                         <!--    'column_alias': 'booking_paid_at__week'}           -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),  -->
                                         <!--    'column_alias': 'booking_paid_at__month'}          -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),  -->
                                         <!--    'column_alias': 'booking_paid_at__quarter'}        -->
                                         <!-- col21 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
                                         <!-- col22 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10288),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10255),  -->
                                         <!--    'column_alias': 'listing'}                               -->
                                         <!-- col23 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10256),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
                                         <!-- col24 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10290),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10257),  -->
                                         <!--    'column_alias': 'host'}                                  -->
                                         <!-- col25 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10291),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10258),  -->
                                         <!--    'column_alias': 'user'}                                  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10015) -->
                                         <!-- where = None -->
@@ -405,119 +405,119 @@
                                     <!-- node_id = ss_10017 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10299),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10266),  -->
                                     <!--    'column_alias': 'window_start'}                          -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10136),  -->
                                     <!--    'column_alias': 'window_start__week'}              -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10137),  -->
                                     <!--    'column_alias': 'window_start__month'}             -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10138),  -->
                                     <!--    'column_alias': 'window_start__quarter'}           -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10139),  -->
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10304),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10271),  -->
                                     <!--    'column_alias': 'window_end'}                            -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10140),  -->
                                     <!--    'column_alias': 'window_end__week'}                -->
                                     <!-- col7 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10141),  -->
                                     <!--    'column_alias': 'window_end__month'}               -->
                                     <!-- col8 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10142),  -->
                                     <!--    'column_alias': 'window_end__quarter'}             -->
                                     <!-- col9 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10143),  -->
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10309),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
                                     <!--    'column_alias': 'country'}                               -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10310),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
                                     <!--    'column_alias': 'is_lux'}                                -->
                                     <!-- col12 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10311),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
                                     <!--    'column_alias': 'capacity'}                              -->
                                     <!-- col13 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10312),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10279),  -->
                                     <!--    'column_alias': 'listing__window_start'}                 -->
                                     <!-- col14 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
                                     <!--    'column_alias': 'listing__window_start__week'}     -->
                                     <!-- col15 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
                                     <!--    'column_alias': 'listing__window_start__month'}    -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
                                     <!--    'column_alias': 'listing__window_start__quarter'}  -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
                                     <!--    'column_alias': 'listing__window_start__year'}     -->
                                     <!-- col18 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10317),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10284),  -->
                                     <!--    'column_alias': 'listing__window_end'}                   -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
                                     <!--    'column_alias': 'listing__window_end__week'}       -->
                                     <!-- col20 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
                                     <!--    'column_alias': 'listing__window_end__month'}      -->
                                     <!-- col21 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
                                     <!--    'column_alias': 'listing__window_end__quarter'}    -->
                                     <!-- col22 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
                                     <!--    'column_alias': 'listing__window_end__year'}       -->
                                     <!-- col23 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10322),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
                                     <!--    'column_alias': 'listing__country'}                      -->
                                     <!-- col24 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10323),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10290),  -->
                                     <!--    'column_alias': 'listing__is_lux'}                       -->
                                     <!-- col25 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10324),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10291),  -->
                                     <!--    'column_alias': 'listing__capacity'}                     -->
                                     <!-- col26 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10325),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10292),  -->
                                     <!--    'column_alias': 'listing'}                               -->
                                     <!-- col27 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10326),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10293),  -->
                                     <!--    'column_alias': 'user'}                                  -->
                                     <!-- col28 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10327),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10294),  -->
                                     <!--    'column_alias': 'listing__user'}                         -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10017) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -4,15 +4,15 @@
         <!-- node_id = ss_5 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
         <!--    'column_alias': 'metric_time'}                        -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
         <!--    'column_alias': 'listing'}                            -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
         <!--    'column_alias': 'booking_fees'}                       -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- join_0 =                                                    -->
@@ -27,7 +27,7 @@
             <!-- node_id = ss_4 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
@@ -42,11 +42,11 @@
             <!-- node_id = ss_3 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
             <!--    'column_alias': 'listing'}                            -->
             <!-- col2 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -59,11 +59,11 @@
                 <!-- node_id = ss_2 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- col2 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -72,11 +72,11 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- group_by1 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -86,15 +86,15 @@
                     <!-- node_id = ss_1 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                     <!--    'column_alias': 'metric_time'}                        -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                     <!--    'column_alias': 'listing'}                            -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                     <!--    'column_alias': 'booking_value'}                      -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
@@ -103,229 +103,149 @@
                         <!-- node_id = ss_0 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
                         <!--    'column_alias': 'ds'}                                 -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
                         <!--    'column_alias': 'ds__week'}                           -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
                         <!--    'column_alias': 'ds__month'}                          -->
                         <!-- col3 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
                         <!--    'column_alias': 'ds__quarter'}                        -->
                         <!-- col4 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
                         <!--    'column_alias': 'ds__year'}                           -->
                         <!-- col5 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
                         <!--    'column_alias': 'ds_partitioned'}                     -->
                         <!-- col6 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}               -->
                         <!-- col7 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}              -->
                         <!-- col8 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}            -->
                         <!-- col9 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}               -->
                         <!-- col10 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                         <!--    'column_alias': 'booking_paid_at'}                    -->
                         <!-- col11 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}              -->
                         <!-- col12 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}             -->
                         <!-- col13 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}           -->
                         <!-- col14 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}              -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),                  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col30 =                                                  -->
+                        <!-- col15 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                         <!--    'column_alias': 'metric_time'}                        -->
-                        <!-- col31 =                                                  -->
+                        <!-- col16 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                         <!--    'column_alias': 'metric_time__week'}                  -->
-                        <!-- col32 =                                                  -->
+                        <!-- col17 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                         <!--    'column_alias': 'metric_time__month'}                 -->
-                        <!-- col33 =                                                  -->
+                        <!-- col18 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                         <!--    'column_alias': 'metric_time__quarter'}               -->
-                        <!-- col34 =                                                  -->
+                        <!-- col19 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                         <!--    'column_alias': 'metric_time__year'}                  -->
-                        <!-- col35 =                                                  -->
+                        <!-- col20 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                         <!--    'column_alias': 'listing'}                            -->
-                        <!-- col36 =                                                  -->
+                        <!-- col21 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                         <!--    'column_alias': 'guest'}                              -->
-                        <!-- col37 =                                                  -->
+                        <!-- col22 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                         <!--    'column_alias': 'host'}                               -->
-                        <!-- col38 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}   -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                  -->
+                        <!-- col23 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
                         <!--    'column_alias': 'is_instant'}                         -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                 -->
+                        <!-- col24 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
                         <!--    'column_alias': 'bookings'}                          -->
-                        <!-- col45 =                                                 -->
+                        <!-- col25 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
                         <!--    'column_alias': 'instant_bookings'}                  -->
-                        <!-- col46 =                                                 -->
+                        <!-- col26 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
                         <!--    'column_alias': 'booking_value'}                     -->
-                        <!-- col47 =                                                 -->
+                        <!-- col27 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
                         <!--    'column_alias': 'max_booking_value'}                 -->
-                        <!-- col48 =                                                 -->
+                        <!-- col28 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
                         <!--    'column_alias': 'min_booking_value'}                 -->
-                        <!-- col49 =                                                 -->
+                        <!-- col29 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
                         <!--    'column_alias': 'bookers'}                           -->
-                        <!-- col50 =                                                 -->
+                        <!-- col30 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
                         <!--    'column_alias': 'average_booking_value'}             -->
-                        <!-- col51 =                                                 -->
+                        <!-- col31 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
                         <!--    'column_alias': 'referred_bookings'}                 -->
-                        <!-- col52 =                                                 -->
+                        <!-- col32 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
                         <!--    'column_alias': 'median_booking_value'}              -->
-                        <!-- col53 =                                                 -->
+                        <!-- col33 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
                         <!--    'column_alias': 'booking_value_p99'}                 -->
-                        <!-- col54 =                                                  -->
+                        <!-- col34 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}         -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),         -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),       -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
@@ -454,98 +374,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -4,15 +4,15 @@
         <!-- node_id = ss_5 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
         <!--    'column_alias': 'metric_time'}                        -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
         <!--    'column_alias': 'listing'}                            -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
         <!--    'column_alias': 'booking_fees'}                       -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- join_0 =                                                    -->
@@ -27,7 +27,7 @@
             <!-- node_id = ss_4 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
@@ -42,11 +42,11 @@
             <!-- node_id = ss_3 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
             <!--    'column_alias': 'listing'}                            -->
             <!-- col2 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -59,11 +59,11 @@
                 <!-- node_id = ss_2 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- col2 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -72,11 +72,11 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- group_by1 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -86,15 +86,15 @@
                     <!-- node_id = ss_1 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                     <!--    'column_alias': 'metric_time'}                        -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                     <!--    'column_alias': 'listing'}                            -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                     <!--    'column_alias': 'booking_value'}                      -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
@@ -103,229 +103,149 @@
                         <!-- node_id = ss_0 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
                         <!--    'column_alias': 'ds'}                                 -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
                         <!--    'column_alias': 'ds__week'}                           -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
                         <!--    'column_alias': 'ds__month'}                          -->
                         <!-- col3 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
                         <!--    'column_alias': 'ds__quarter'}                        -->
                         <!-- col4 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
                         <!--    'column_alias': 'ds__year'}                           -->
                         <!-- col5 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
                         <!--    'column_alias': 'ds_partitioned'}                     -->
                         <!-- col6 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}               -->
                         <!-- col7 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}              -->
                         <!-- col8 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}            -->
                         <!-- col9 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}               -->
                         <!-- col10 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                         <!--    'column_alias': 'booking_paid_at'}                    -->
                         <!-- col11 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}              -->
                         <!-- col12 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}             -->
                         <!-- col13 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}           -->
                         <!-- col14 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}              -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),                  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col30 =                                                  -->
+                        <!-- col15 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                         <!--    'column_alias': 'metric_time'}                        -->
-                        <!-- col31 =                                                  -->
+                        <!-- col16 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                         <!--    'column_alias': 'metric_time__week'}                  -->
-                        <!-- col32 =                                                  -->
+                        <!-- col17 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                         <!--    'column_alias': 'metric_time__month'}                 -->
-                        <!-- col33 =                                                  -->
+                        <!-- col18 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                         <!--    'column_alias': 'metric_time__quarter'}               -->
-                        <!-- col34 =                                                  -->
+                        <!-- col19 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                         <!--    'column_alias': 'metric_time__year'}                  -->
-                        <!-- col35 =                                                  -->
+                        <!-- col20 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                         <!--    'column_alias': 'listing'}                            -->
-                        <!-- col36 =                                                  -->
+                        <!-- col21 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                         <!--    'column_alias': 'guest'}                              -->
-                        <!-- col37 =                                                  -->
+                        <!-- col22 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                         <!--    'column_alias': 'host'}                               -->
-                        <!-- col38 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}   -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                  -->
+                        <!-- col23 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
                         <!--    'column_alias': 'is_instant'}                         -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                 -->
+                        <!-- col24 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
                         <!--    'column_alias': 'bookings'}                          -->
-                        <!-- col45 =                                                 -->
+                        <!-- col25 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
                         <!--    'column_alias': 'instant_bookings'}                  -->
-                        <!-- col46 =                                                 -->
+                        <!-- col26 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
                         <!--    'column_alias': 'booking_value'}                     -->
-                        <!-- col47 =                                                 -->
+                        <!-- col27 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
                         <!--    'column_alias': 'max_booking_value'}                 -->
-                        <!-- col48 =                                                 -->
+                        <!-- col28 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
                         <!--    'column_alias': 'min_booking_value'}                 -->
-                        <!-- col49 =                                                 -->
+                        <!-- col29 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
                         <!--    'column_alias': 'bookers'}                           -->
-                        <!-- col50 =                                                 -->
+                        <!-- col30 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
                         <!--    'column_alias': 'average_booking_value'}             -->
-                        <!-- col51 =                                                 -->
+                        <!-- col31 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
                         <!--    'column_alias': 'referred_bookings'}                 -->
-                        <!-- col52 =                                                 -->
+                        <!-- col32 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
                         <!--    'column_alias': 'median_booking_value'}              -->
-                        <!-- col53 =                                                 -->
+                        <!-- col33 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
                         <!--    'column_alias': 'booking_value_p99'}                 -->
-                        <!-- col54 =                                                  -->
+                        <!-- col34 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}         -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),         -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),       -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
@@ -454,98 +374,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -4,15 +4,15 @@
         <!-- node_id = ss_5 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
         <!--    'column_alias': 'metric_time'}                        -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
         <!--    'column_alias': 'listing'}                            -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
         <!--    'column_alias': 'booking_fees'}                       -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- join_0 =                                                    -->
@@ -27,7 +27,7 @@
             <!-- node_id = ss_4 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
@@ -42,11 +42,11 @@
             <!-- node_id = ss_3 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
             <!--    'column_alias': 'metric_time'}                        -->
             <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
             <!--    'column_alias': 'listing'}                            -->
             <!-- col2 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -59,11 +59,11 @@
                 <!-- node_id = ss_2 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- col2 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -72,11 +72,11 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                 <!--    'column_alias': 'metric_time'}                        -->
                 <!-- group_by1 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                 <!--    'column_alias': 'listing'}                            -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -86,15 +86,15 @@
                     <!-- node_id = ss_1 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                     <!--    'column_alias': 'metric_time'}                        -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                     <!--    'column_alias': 'listing'}                            -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                     <!--    'column_alias': 'booking_value'}                      -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
@@ -103,229 +103,149 @@
                         <!-- node_id = ss_0 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
                         <!--    'column_alias': 'ds'}                                 -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
                         <!--    'column_alias': 'ds__week'}                           -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
                         <!--    'column_alias': 'ds__month'}                          -->
                         <!-- col3 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
                         <!--    'column_alias': 'ds__quarter'}                        -->
                         <!-- col4 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
                         <!--    'column_alias': 'ds__year'}                           -->
                         <!-- col5 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
                         <!--    'column_alias': 'ds_partitioned'}                     -->
                         <!-- col6 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}               -->
                         <!-- col7 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}              -->
                         <!-- col8 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}            -->
                         <!-- col9 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}               -->
                         <!-- col10 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                         <!--    'column_alias': 'booking_paid_at'}                    -->
                         <!-- col11 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}              -->
                         <!-- col12 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}             -->
                         <!-- col13 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}           -->
                         <!-- col14 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}              -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),                  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col30 =                                                  -->
+                        <!-- col15 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                         <!--    'column_alias': 'metric_time'}                        -->
-                        <!-- col31 =                                                  -->
+                        <!-- col16 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                         <!--    'column_alias': 'metric_time__week'}                  -->
-                        <!-- col32 =                                                  -->
+                        <!-- col17 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                         <!--    'column_alias': 'metric_time__month'}                 -->
-                        <!-- col33 =                                                  -->
+                        <!-- col18 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                         <!--    'column_alias': 'metric_time__quarter'}               -->
-                        <!-- col34 =                                                  -->
+                        <!-- col19 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                         <!--    'column_alias': 'metric_time__year'}                  -->
-                        <!-- col35 =                                                  -->
+                        <!-- col20 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                         <!--    'column_alias': 'listing'}                            -->
-                        <!-- col36 =                                                  -->
+                        <!-- col21 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                         <!--    'column_alias': 'guest'}                              -->
-                        <!-- col37 =                                                  -->
+                        <!-- col22 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                         <!--    'column_alias': 'host'}                               -->
-                        <!-- col38 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}   -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                  -->
+                        <!-- col23 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
                         <!--    'column_alias': 'is_instant'}                         -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                 -->
+                        <!-- col24 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
                         <!--    'column_alias': 'bookings'}                          -->
-                        <!-- col45 =                                                 -->
+                        <!-- col25 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
                         <!--    'column_alias': 'instant_bookings'}                  -->
-                        <!-- col46 =                                                 -->
+                        <!-- col26 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
                         <!--    'column_alias': 'booking_value'}                     -->
-                        <!-- col47 =                                                 -->
+                        <!-- col27 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
                         <!--    'column_alias': 'max_booking_value'}                 -->
-                        <!-- col48 =                                                 -->
+                        <!-- col28 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
                         <!--    'column_alias': 'min_booking_value'}                 -->
-                        <!-- col49 =                                                 -->
+                        <!-- col29 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
                         <!--    'column_alias': 'bookers'}                           -->
-                        <!-- col50 =                                                 -->
+                        <!-- col30 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
                         <!--    'column_alias': 'average_booking_value'}             -->
-                        <!-- col51 =                                                 -->
+                        <!-- col31 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
                         <!--    'column_alias': 'referred_bookings'}                 -->
-                        <!-- col52 =                                                 -->
+                        <!-- col32 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
                         <!--    'column_alias': 'median_booking_value'}              -->
-                        <!-- col53 =                                                 -->
+                        <!-- col33 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
                         <!--    'column_alias': 'booking_value_p99'}                 -->
-                        <!-- col54 =                                                  -->
+                        <!-- col34 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}         -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),         -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),       -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
@@ -454,98 +374,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_11 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
         <!--    'column_alias': 'ds'}                                  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
         <!--    'column_alias': 'bookings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- where = None -->
@@ -17,11 +17,11 @@
             <!-- node_id = ss_10 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
             <!--    'column_alias': 'ds'}                                  -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- where = None -->
@@ -30,7 +30,7 @@
                 <!-- node_id = ss_9 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -39,7 +39,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -49,11 +49,11 @@
                     <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                     <!-- where = None -->
@@ -62,231 +62,151 @@
                         <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                        <!-- col15 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col16 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!-- col17 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!-- col18 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!-- col19 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                        <!--    'column_alias': 'metric_time__year'}                   -->
+                        <!-- col20 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                        <!--    'column_alias': 'listing'}                             -->
+                        <!-- col21 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                        <!--    'column_alias': 'guest'}                               -->
+                        <!-- col22 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                        <!--    'column_alias': 'host'}                                -->
+                        <!-- col23 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                        <!--    'column_alias': 'is_instant'}                          -->
+                        <!-- col24 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- col25 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                        <!--    'column_alias': 'instant_bookings'}                    -->
+                        <!-- col26 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                        <!--    'column_alias': 'booking_value'}                       -->
+                        <!-- col27 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                        <!--    'column_alias': 'max_booking_value'}                   -->
+                        <!-- col28 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                        <!--    'column_alias': 'min_booking_value'}                   -->
+                        <!-- col29 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                        <!--    'column_alias': 'bookers'}                             -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                        <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                        <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                        <!--    'column_alias': 'median_booking_value'}                -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                        <!--    'column_alias': 'booking_value_p99'}                   -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                        <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                        <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                        <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                        <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                        <!--    'column_alias': 'bookings'}                            -->
-                        <!-- col45 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                        <!--    'column_alias': 'instant_bookings'}                    -->
-                        <!-- col46 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                        <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- col47 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                        <!--    'column_alias': 'max_booking_value'}                   -->
-                        <!-- col48 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                        <!--    'column_alias': 'min_booking_value'}                   -->
-                        <!-- col49 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                        <!--    'column_alias': 'bookers'}                             -->
-                        <!-- col50 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                        <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- col51 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                        <!--    'column_alias': 'referred_bookings'}                   -->
-                        <!-- col52 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                        <!--    'column_alias': 'median_booking_value'}                -->
-                        <!-- col53 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                        <!--    'column_alias': 'booking_value_p99'}                   -->
-                        <!-- col54 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
@@ -413,98 +333,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_entity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_entity__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
         <!--    'column_alias': 'listings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                 <!--    'column_alias': 'listings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -49,151 +49,151 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                     <!--    'column_alias': 'created_at'}                          -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                     <!--    'column_alias': 'created_at__week'}                    -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                     <!--    'column_alias': 'created_at__month'}                   -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                     <!--    'column_alias': 'created_at__quarter'}                 -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                     <!--    'column_alias': 'created_at__year'}                    -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                     <!--    'column_alias': 'listing__ds'}                         -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                     <!--    'column_alias': 'listing__ds__week'}                   -->
                     <!-- col12 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                     <!--    'column_alias': 'listing__ds__month'}                  -->
                     <!-- col13 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                     <!-- col14 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                     <!--    'column_alias': 'listing__ds__year'}                   -->
                     <!-- col15 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                     <!--    'column_alias': 'listing__created_at'}                 -->
                     <!-- col16 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                     <!--    'column_alias': 'listing__created_at__week'}           -->
                     <!-- col17 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                     <!--    'column_alias': 'listing__created_at__month'}          -->
                     <!-- col18 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                     <!-- col19 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                     <!--    'column_alias': 'listing__created_at__year'}           -->
                     <!-- col20 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col21 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col22 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col23 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col24 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col25 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
                     <!--    'column_alias': 'listing'}                             -->
                     <!-- col26 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col27 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
                     <!--    'column_alias': 'listing__user'}                       -->
                     <!-- col28 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'country_latest'}                      -->
                     <!-- col29 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                     <!--    'column_alias': 'is_lux_latest'}                       -->
                     <!-- col30 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                     <!--    'column_alias': 'capacity_latest'}                     -->
                     <!-- col31 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col32 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                     <!-- col33 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                     <!-- col34 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'listings'}                            -->
                     <!-- col35 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                     <!--    'column_alias': 'largest_listing'}                     -->
                     <!-- col36 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'smallest_listing'}                    -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                     <!-- where = None -->
@@ -206,127 +206,127 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col11 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col12 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col23 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col24 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col25 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
@@ -166,98 +166,18 @@
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                <!-- col30 =                                                             -->
-                <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                <!-- col30 =                                                     -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                <!--    'column_alias': 'listing'}                               -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                <!-- col32 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                <!-- col33 =                                                            -->
-                <!--   {'class': 'SqlSelectColumn',                                     -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                <!-- col34 =                                                              -->
-                <!--   {'class': 'SqlSelectColumn',                                       -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                <!-- col35 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                <!-- col36 =                                                                 -->
-                <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                <!-- col37 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                <!-- col38 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                <!-- col39 =                                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                <!-- col40 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                <!-- col41 =                                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                <!-- col42 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                <!-- col43 =                                                                         -->
-                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                <!-- col44 =                                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                <!-- col45 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                <!-- col46 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'listing'}                               -->
-                <!-- col47 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                 <!--    'column_alias': 'guest'}                                 -->
-                <!-- col48 =                                                     -->
+                <!-- col32 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                 <!--    'column_alias': 'host'}                                  -->
-                <!-- col49 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                <!-- col50 =                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                <!-- col51 =                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                <!-- col52 =                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_32 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                                               -->
         <!--   {'class': 'SqlSelectColumn',                                                                                       -->
@@ -21,15 +21,15 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),  -->
             <!--    'column_alias': 'average_booking_value'}               -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
             <!--    'column_alias': 'booking_value'}                       -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
             <!-- join_0 =                                                   -->
@@ -50,11 +50,11 @@
                 <!-- node_id = ss_16 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
                 <!--    'column_alias': 'average_booking_value'}               -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- where = None -->
@@ -63,7 +63,7 @@
                     <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                           -->
                     <!--   {'class': 'SqlSelectColumn',                                                   -->
@@ -72,7 +72,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -82,11 +82,11 @@
                         <!-- node_id = ss_14 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                         <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
@@ -95,15 +95,15 @@
                             <!-- node_id = ss_13 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                             <!-- where =                                                               -->
@@ -115,15 +115,15 @@
                                 <!-- node_id = ss_12 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                 <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                                 <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                                 <!-- where = None -->
@@ -132,19 +132,19 @@
                                     <!-- node_id = ss_11 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                     <!-- join_0 =                                                    -->
@@ -161,15 +161,15 @@
                                         <!-- node_id = ss_8 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                         <!--    'column_alias': 'metric_time'}                         -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col2 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                         <!--    'column_alias': 'average_booking_value'}               -->
                                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                         <!-- where = None -->
@@ -178,231 +178,151 @@
                                             <!-- node_id = ss_7 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                             <!--    'column_alias': 'ds_partitioned'}                      -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                             <!--    'column_alias': 'booking_paid_at'}                     -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col16 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col17 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col18 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col19 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col20 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col21 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col22 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col23 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col24 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col25 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col26 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col27 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col28 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col29 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                            <!-- col15 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                            <!--    'column_alias': 'metric_time'}                         -->
+                                            <!-- col16 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                            <!--    'column_alias': 'metric_time__week'}                   -->
+                                            <!-- col17 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                            <!--    'column_alias': 'metric_time__month'}                  -->
+                                            <!-- col18 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                                            <!-- col19 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                            <!--    'column_alias': 'metric_time__year'}                   -->
+                                            <!-- col20 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                            <!--    'column_alias': 'listing'}                             -->
+                                            <!-- col21 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                            <!--    'column_alias': 'guest'}                               -->
+                                            <!-- col22 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                            <!--    'column_alias': 'host'}                                -->
+                                            <!-- col23 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                            <!--    'column_alias': 'is_instant'}                          -->
+                                            <!-- col24 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                            <!--    'column_alias': 'bookings'}                            -->
+                                            <!-- col25 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                            <!--    'column_alias': 'instant_bookings'}                    -->
+                                            <!-- col26 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                            <!--    'column_alias': 'booking_value'}                       -->
+                                            <!-- col27 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                            <!--    'column_alias': 'max_booking_value'}                   -->
+                                            <!-- col28 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                            <!--    'column_alias': 'min_booking_value'}                   -->
+                                            <!-- col29 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                            <!--    'column_alias': 'bookers'}                             -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                            <!--    'column_alias': 'metric_time'}                         -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                            <!--    'column_alias': 'average_booking_value'}               -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                            <!--    'column_alias': 'metric_time__week'}                   -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                            <!--    'column_alias': 'referred_bookings'}                   -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                            <!--    'column_alias': 'metric_time__month'}                  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                            <!--    'column_alias': 'median_booking_value'}                -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                            <!--    'column_alias': 'booking_value_p99'}                   -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                            <!--    'column_alias': 'metric_time__year'}                   -->
-                                            <!-- col35 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                            <!--    'column_alias': 'listing'}                             -->
-                                            <!-- col36 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                            <!--    'column_alias': 'guest'}                               -->
-                                            <!-- col37 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                            <!--    'column_alias': 'host'}                                -->
-                                            <!-- col38 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                            <!-- col39 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col40 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col41 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- col42 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                            <!--    'column_alias': 'is_instant'}                          -->
-                                            <!-- col43 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col44 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                            <!--    'column_alias': 'bookings'}                            -->
-                                            <!-- col45 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                    -->
-                                            <!-- col46 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                            <!--    'column_alias': 'booking_value'}                       -->
-                                            <!-- col47 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                   -->
-                                            <!-- col48 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                   -->
-                                            <!-- col49 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                            <!--    'column_alias': 'bookers'}                             -->
-                                            <!-- col50 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                            <!--    'column_alias': 'average_booking_value'}               -->
-                                            <!-- col51 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                            <!--    'column_alias': 'referred_bookings'}                   -->
-                                            <!-- col52 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                            <!--    'column_alias': 'median_booking_value'}                -->
-                                            <!-- col53 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                                            <!-- col54 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                            <!-- col55 =                                                         -->
+                                            <!-- col35 =                                                         -->
                                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                            <!-- col56 =                                                       -->
+                                            <!-- col36 =                                                       -->
                                             <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                             <!-- where = None -->
@@ -529,98 +449,18 @@
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                                <!-- col30 =                                                             -->
-                                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                                <!-- col30 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                                <!--    'column_alias': 'listing'}                               -->
                                                 <!-- col31 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                                <!-- col32 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                                <!-- col33 =                                                            -->
-                                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                                <!-- col34 =                                                              -->
-                                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                                <!-- col35 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                                <!-- col36 =                                                                 -->
-                                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                                <!-- col37 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                                <!-- col38 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                                <!-- col39 =                                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                                <!-- col40 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                                <!-- col41 =                                                                  -->
-                                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                                <!-- col42 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                                <!-- col43 =                                                                         -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                                <!-- col44 =                                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                                <!-- col45 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                                <!-- col46 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                                <!--    'column_alias': 'listing'}                               -->
-                                                <!-- col47 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                                 <!--    'column_alias': 'guest'}                                 -->
-                                                <!-- col48 =                                                     -->
+                                                <!-- col32 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                                 <!--    'column_alias': 'host'}                                  -->
-                                                <!-- col49 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                                <!-- col50 =                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                                <!-- col51 =                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                                <!-- col52 =                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                                 <!-- where = None -->
                                                 <SqlTableFromClauseNode>
@@ -638,11 +478,11 @@
                                         <!-- node_id = ss_10 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                       -->
                                         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                         <!-- where = None -->
@@ -651,151 +491,151 @@
                                             <!-- node_id = ss_9 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                             <!--    'column_alias': 'created_at'}                          -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                                             <!--    'column_alias': 'created_at__week'}                    -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                             <!--    'column_alias': 'created_at__month'}                   -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                             <!--    'column_alias': 'created_at__quarter'}                 -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                             <!--    'column_alias': 'created_at__year'}                    -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                             <!--    'column_alias': 'listing__ds'}                         -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                             <!--    'column_alias': 'listing__ds__week'}                   -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                             <!--    'column_alias': 'listing__ds__month'}                  -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                             <!--    'column_alias': 'listing__ds__year'}                   -->
                                             <!-- col15 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                             <!--    'column_alias': 'listing__created_at'}                 -->
                                             <!-- col16 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                             <!--    'column_alias': 'listing__created_at__week'}           -->
                                             <!-- col17 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                             <!--    'column_alias': 'listing__created_at__month'}          -->
                                             <!-- col18 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                             <!-- col19 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                             <!--    'column_alias': 'listing__created_at__year'}           -->
                                             <!-- col20 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                             <!--    'column_alias': 'metric_time'}                         -->
                                             <!-- col21 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                             <!--    'column_alias': 'metric_time__week'}                   -->
                                             <!-- col22 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                             <!--    'column_alias': 'metric_time__month'}                  -->
                                             <!-- col23 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                                             <!--    'column_alias': 'metric_time__quarter'}                -->
                                             <!-- col24 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                                             <!--    'column_alias': 'metric_time__year'}                   -->
                                             <!-- col25 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                                             <!--    'column_alias': 'listing'}                             -->
                                             <!-- col26 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                                             <!--    'column_alias': 'user'}                                -->
                                             <!-- col27 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                                             <!--    'column_alias': 'listing__user'}                       -->
                                             <!-- col28 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                                             <!--    'column_alias': 'country_latest'}                      -->
                                             <!-- col29 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                                             <!--    'column_alias': 'is_lux_latest'}                       -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                                             <!--    'column_alias': 'capacity_latest'}                     -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                                             <!--    'column_alias': 'listing__country_latest'}             -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                                             <!--    'column_alias': 'listings'}                            -->
                                             <!-- col35 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                                             <!--    'column_alias': 'largest_listing'}                     -->
                                             <!-- col36 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                                             <!--    'column_alias': 'smallest_listing'}                    -->
                                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                             <!-- where = None -->
@@ -808,127 +648,127 @@
                                                 <!--    'column_alias': 'listings'}                                 -->
                                                 <!-- col1 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                                 <!--    'column_alias': 'largest_listing'}                       -->
                                                 <!-- col2 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                                 <!--    'column_alias': 'smallest_listing'}                      -->
                                                 <!-- col3 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                                 <!--    'column_alias': 'ds'}                                    -->
                                                 <!-- col4 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col5 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col6 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col7 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col8 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                                 <!--    'column_alias': 'created_at'}                            -->
                                                 <!-- col9 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                                 <!--    'column_alias': 'created_at__week'}                -->
                                                 <!-- col10 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                                 <!--    'column_alias': 'created_at__month'}               -->
                                                 <!-- col11 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                                 <!-- col12 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                                 <!--    'column_alias': 'created_at__year'}                -->
                                                 <!-- col13 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                                 <!--    'column_alias': 'country_latest'}                        -->
                                                 <!-- col14 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                                 <!--    'column_alias': 'is_lux_latest'}                         -->
                                                 <!-- col15 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                                 <!--    'column_alias': 'capacity_latest'}                       -->
                                                 <!-- col16 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                                 <!--    'column_alias': 'listing__ds'}                           -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                                 <!-- col20 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                                 <!-- col21 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                                 <!--    'column_alias': 'listing__created_at'}                   -->
                                                 <!-- col22 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                                 <!-- col23 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                                 <!-- col24 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                                 <!-- col25 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                                 <!-- col26 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                                 <!--    'column_alias': 'listing__country_latest'}               -->
                                                 <!-- col27 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                                 <!-- col28 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                                                 <!-- col29 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                                 <!--    'column_alias': 'listing'}                               -->
                                                 <!-- col30 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                                 <!--    'column_alias': 'user'}                                  -->
                                                 <!-- col31 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                                 <!--    'column_alias': 'listing__user'}                         -->
                                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                                 <!-- where = None -->
@@ -951,11 +791,11 @@
                 <!-- node_id = ss_26 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_460),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_461),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
                 <!-- where = None -->
@@ -964,7 +804,7 @@
                     <!-- node_id = ss_25 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_459),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -973,7 +813,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_459),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -983,11 +823,11 @@
                         <!-- node_id = ss_24 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_457),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_456),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
                         <!-- where = None -->
@@ -996,15 +836,15 @@
                             <!-- node_id = ss_23 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_455),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_454),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_453),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
                             <!-- where =                                                               -->
@@ -1016,15 +856,15 @@
                                 <!-- node_id = ss_22 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_452),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_451),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
                                 <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_450),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
                                 <!-- where = None -->
@@ -1033,19 +873,19 @@
                                     <!-- node_id = ss_21 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_447),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_448),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_449),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_446),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                                     <!-- join_0 =                                                    -->
@@ -1062,15 +902,15 @@
                                         <!-- node_id = ss_18 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                         <!--    'column_alias': 'metric_time'}                         -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col2 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                         <!--    'column_alias': 'bookings'}                            -->
                                         <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                                         <!-- where = None -->
@@ -1079,231 +919,151 @@
                                             <!-- node_id = ss_17 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                             <!--    'column_alias': 'ds_partitioned'}                      -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                             <!--    'column_alias': 'booking_paid_at'}                     -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col16 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col17 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col18 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col19 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col20 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),                -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col21 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),                      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col22 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col23 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),                         -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col24 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),                      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col25 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col26 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col27 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),                        -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col28 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col29 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),                       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                            <!-- col15 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                            <!--    'column_alias': 'metric_time'}                         -->
+                                            <!-- col16 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                            <!--    'column_alias': 'metric_time__week'}                   -->
+                                            <!-- col17 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                            <!--    'column_alias': 'metric_time__month'}                  -->
+                                            <!-- col18 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                                            <!-- col19 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                            <!--    'column_alias': 'metric_time__year'}                   -->
+                                            <!-- col20 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                            <!--    'column_alias': 'listing'}                             -->
+                                            <!-- col21 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                            <!--    'column_alias': 'guest'}                               -->
+                                            <!-- col22 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                            <!--    'column_alias': 'host'}                                -->
+                                            <!-- col23 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                            <!--    'column_alias': 'is_instant'}                          -->
+                                            <!-- col24 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
+                                            <!--    'column_alias': 'bookings'}                            -->
+                                            <!-- col25 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                                            <!--    'column_alias': 'instant_bookings'}                    -->
+                                            <!-- col26 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                                            <!--    'column_alias': 'booking_value'}                       -->
+                                            <!-- col27 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                                            <!--    'column_alias': 'max_booking_value'}                   -->
+                                            <!-- col28 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                                            <!--    'column_alias': 'min_booking_value'}                   -->
+                                            <!-- col29 =                                                   -->
+                                            <!--   {'class': 'SqlSelectColumn',                            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                                            <!--    'column_alias': 'bookers'}                             -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
-                                            <!--    'column_alias': 'metric_time'}                         -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                                            <!--    'column_alias': 'average_booking_value'}               -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
-                                            <!--    'column_alias': 'metric_time__week'}                   -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                                            <!--    'column_alias': 'referred_bookings'}                   -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
-                                            <!--    'column_alias': 'metric_time__month'}                  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
+                                            <!--    'column_alias': 'median_booking_value'}                -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
-                                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                                            <!--    'column_alias': 'booking_value_p99'}                   -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
-                                            <!--    'column_alias': 'metric_time__year'}                   -->
-                                            <!-- col35 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
-                                            <!--    'column_alias': 'listing'}                             -->
-                                            <!-- col36 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
-                                            <!--    'column_alias': 'guest'}                               -->
-                                            <!-- col37 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
-                                            <!--    'column_alias': 'host'}                                -->
-                                            <!-- col38 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                            <!-- col39 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),         -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col40 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col41 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),      -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- col42 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
-                                            <!--    'column_alias': 'is_instant'}                          -->
-                                            <!-- col43 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col44 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
-                                            <!--    'column_alias': 'bookings'}                            -->
-                                            <!-- col45 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                    -->
-                                            <!-- col46 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
-                                            <!--    'column_alias': 'booking_value'}                       -->
-                                            <!-- col47 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                   -->
-                                            <!-- col48 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                   -->
-                                            <!-- col49 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
-                                            <!--    'column_alias': 'bookers'}                             -->
-                                            <!-- col50 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
-                                            <!--    'column_alias': 'average_booking_value'}               -->
-                                            <!-- col51 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
-                                            <!--    'column_alias': 'referred_bookings'}                   -->
-                                            <!-- col52 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
-                                            <!--    'column_alias': 'median_booking_value'}                -->
-                                            <!-- col53 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
-                                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                                            <!-- col54 =                                                   -->
-                                            <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                            <!-- col55 =                                                         -->
+                                            <!-- col35 =                                                         -->
                                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),        -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),        -->
                                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                            <!-- col56 =                                                       -->
+                                            <!-- col36 =                                                       -->
                                             <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),      -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
                                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                             <!-- where = None -->
@@ -1430,98 +1190,18 @@
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                                <!-- col30 =                                                             -->
-                                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                                <!-- col30 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                                <!--    'column_alias': 'listing'}                               -->
                                                 <!-- col31 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                                <!-- col32 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                                <!-- col33 =                                                            -->
-                                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                                <!-- col34 =                                                              -->
-                                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                                <!-- col35 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                                <!-- col36 =                                                                 -->
-                                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                                <!-- col37 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                                <!-- col38 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                                <!-- col39 =                                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                                <!-- col40 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                                <!-- col41 =                                                                  -->
-                                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                                <!-- col42 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                                <!-- col43 =                                                                         -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                                <!-- col44 =                                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                                <!-- col45 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                                <!-- col46 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                                <!--    'column_alias': 'listing'}                               -->
-                                                <!-- col47 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                                 <!--    'column_alias': 'guest'}                                 -->
-                                                <!-- col48 =                                                     -->
+                                                <!-- col32 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                                 <!--    'column_alias': 'host'}                                  -->
-                                                <!-- col49 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                                <!-- col50 =                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                                <!-- col51 =                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                                <!-- col52 =                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                                 <!-- where = None -->
                                                 <SqlTableFromClauseNode>
@@ -1539,11 +1219,11 @@
                                         <!-- node_id = ss_20 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_443),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_442),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                       -->
                                         <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                                         <!-- where = None -->
@@ -1552,151 +1232,151 @@
                                             <!-- node_id = ss_19 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_415),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                                             <!--    'column_alias': 'created_at'}                          -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                                             <!--    'column_alias': 'created_at__week'}                    -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                                             <!--    'column_alias': 'created_at__month'}                   -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
                                             <!--    'column_alias': 'created_at__quarter'}                 -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
                                             <!--    'column_alias': 'created_at__year'}                    -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_424),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
                                             <!--    'column_alias': 'listing__ds'}                         -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
                                             <!--    'column_alias': 'listing__ds__week'}                   -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
                                             <!--    'column_alias': 'listing__ds__month'}                  -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
                                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                                             <!--    'column_alias': 'listing__ds__year'}                   -->
                                             <!-- col15 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                                             <!--    'column_alias': 'listing__created_at'}                 -->
                                             <!-- col16 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_430),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                                             <!--    'column_alias': 'listing__created_at__week'}           -->
                                             <!-- col17 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_431),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
                                             <!--    'column_alias': 'listing__created_at__month'}          -->
                                             <!-- col18 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_432),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                             <!-- col19 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_433),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                                             <!--    'column_alias': 'listing__created_at__year'}           -->
                                             <!-- col20 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                                             <!--    'column_alias': 'metric_time'}                         -->
                                             <!-- col21 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                                             <!--    'column_alias': 'metric_time__week'}                   -->
                                             <!-- col22 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_436),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                                             <!--    'column_alias': 'metric_time__month'}                  -->
                                             <!-- col23 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_437),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
                                             <!--    'column_alias': 'metric_time__quarter'}                -->
                                             <!-- col24 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_438),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
                                             <!--    'column_alias': 'metric_time__year'}                   -->
                                             <!-- col25 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_439),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
                                             <!--    'column_alias': 'listing'}                             -->
                                             <!-- col26 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_440),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
                                             <!--    'column_alias': 'user'}                                -->
                                             <!-- col27 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                                             <!--    'column_alias': 'listing__user'}                       -->
                                             <!-- col28 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                                             <!--    'column_alias': 'country_latest'}                      -->
                                             <!-- col29 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                                             <!--    'column_alias': 'is_lux_latest'}                       -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                                             <!--    'column_alias': 'capacity_latest'}                     -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                                             <!--    'column_alias': 'listing__country_latest'}             -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_412),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_413),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                             <!--    'column_alias': 'listings'}                            -->
                                             <!-- col35 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                             <!--    'column_alias': 'largest_listing'}                     -->
                                             <!-- col36 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                                             <!--    'column_alias': 'smallest_listing'}                    -->
                                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                             <!-- where = None -->
@@ -1709,127 +1389,127 @@
                                                 <!--    'column_alias': 'listings'}                                 -->
                                                 <!-- col1 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                                 <!--    'column_alias': 'largest_listing'}                       -->
                                                 <!-- col2 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                                 <!--    'column_alias': 'smallest_listing'}                      -->
                                                 <!-- col3 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                                 <!--    'column_alias': 'ds'}                                    -->
                                                 <!-- col4 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col5 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col6 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col7 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col8 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                                 <!--    'column_alias': 'created_at'}                            -->
                                                 <!-- col9 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                                 <!--    'column_alias': 'created_at__week'}                -->
                                                 <!-- col10 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                                 <!--    'column_alias': 'created_at__month'}               -->
                                                 <!-- col11 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                                 <!-- col12 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                                 <!--    'column_alias': 'created_at__year'}                -->
                                                 <!-- col13 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                                 <!--    'column_alias': 'country_latest'}                        -->
                                                 <!-- col14 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                                 <!--    'column_alias': 'is_lux_latest'}                         -->
                                                 <!-- col15 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                                 <!--    'column_alias': 'capacity_latest'}                       -->
                                                 <!-- col16 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                                 <!--    'column_alias': 'listing__ds'}                           -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                                 <!-- col20 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                                 <!-- col21 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                                 <!--    'column_alias': 'listing__created_at'}                   -->
                                                 <!-- col22 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                                 <!-- col23 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                                 <!-- col24 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                                 <!-- col25 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                                 <!-- col26 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                                 <!--    'column_alias': 'listing__country_latest'}               -->
                                                 <!-- col27 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                                 <!-- col28 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                                                 <!-- col29 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                                 <!--    'column_alias': 'listing'}                               -->
                                                 <!-- col30 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                                 <!--    'column_alias': 'user'}                                  -->
                                                 <!-- col31 =                                                     -->
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                                 <!--    'column_alias': 'listing__user'}                         -->
                                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                                 <!-- where = None -->
@@ -1852,11 +1532,11 @@
                 <!-- node_id = ss_30 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
                 <!--    'column_alias': 'booking_value'}                       -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
                 <!-- where = None -->
@@ -1865,7 +1545,7 @@
                     <!-- node_id = ss_29 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -1874,7 +1554,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -1884,11 +1564,11 @@
                         <!-- node_id = ss_28 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
                         <!-- where = None -->
@@ -1897,231 +1577,151 @@
                             <!-- node_id = ss_27 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_462),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_463),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -2248,98 +1848,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_18 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
@@ -21,11 +21,11 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                  -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),        -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),        -->
             <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
             <!--    'column_alias': 'booking_value'}                       -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
             <!-- join_0 =                                                   -->
@@ -40,11 +40,11 @@
                 <!-- node_id = ss_12 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),        -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),        -->
                 <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                 <!-- where = None -->
@@ -53,7 +53,7 @@
                     <!-- node_id = ss_11 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -62,7 +62,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -72,11 +72,11 @@
                         <!-- node_id = ss_10 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                         <!-- where = None -->
@@ -85,15 +85,15 @@
                             <!-- node_id = ss_9 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=is_instant) -->
@@ -104,15 +104,15 @@
                                 <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                 <!--    'column_alias': 'is_instant'}                          -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                 <!--    'column_alias': 'booking_value'}                       -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
@@ -121,231 +121,151 @@
                                     <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -472,98 +392,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -583,11 +423,11 @@
                 <!-- node_id = ss_16 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                 <!--    'column_alias': 'booking_value'}                       -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- where = None -->
@@ -596,7 +436,7 @@
                     <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -605,7 +445,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -615,11 +455,11 @@
                         <!-- node_id = ss_14 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
@@ -628,231 +468,151 @@
                             <!-- node_id = ss_13 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -979,98 +739,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -17,11 +17,11 @@
             <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
             <!--    'column_alias': 'delayed_bookings'}                    -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- where = None -->
@@ -30,7 +30,7 @@
                 <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -39,7 +39,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -49,11 +49,11 @@
                     <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
@@ -62,15 +62,15 @@
                         <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                         <!-- where = SqlStringExpression(node_id=str_0 sql_expr=NOT is_instant) -->
@@ -81,15 +81,15 @@
                             <!-- node_id = ss_8 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                             <!-- where = None -->
@@ -98,231 +98,151 @@
                                 <!-- node_id = ss_7 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                 <!--    'column_alias': 'ds__week'}                            -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                 <!--    'column_alias': 'ds__month'}                           -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                 <!--    'column_alias': 'ds__quarter'}                         -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                 <!--    'column_alias': 'ds__year'}                            -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col8 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                     -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}               -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                 <!-- col14 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col15 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col16 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col17 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col18 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col19 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col20 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col21 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col22 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col23 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col24 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col25 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col26 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col27 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col28 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col29 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
                                 <!-- col30 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
                                 <!-- col31 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- col32 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
                                 <!-- col33 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
                                 <!-- col34 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                <!--    'column_alias': 'metric_time__year'}                   -->
-                                <!-- col35 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col36 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col38 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col39 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col40 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col41 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col43 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col46 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col47 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col48 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col49 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col50 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- col51 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                <!--    'column_alias': 'referred_bookings'}                   -->
-                                <!-- col52 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                <!--    'column_alias': 'median_booking_value'}                -->
-                                <!-- col53 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                <!--    'column_alias': 'booking_value_p99'}                   -->
-                                <!-- col54 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                 <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                <!-- col55 =                                                         -->
+                                <!-- col35 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                 <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                <!-- col56 =                                                       -->
+                                <!-- col36 =                                                       -->
                                 <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                 <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                 <!-- where = None -->
@@ -449,98 +369,18 @@
                                     <!--   {'class': 'SqlSelectColumn',                        -->
                                     <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col30 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col30 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
                                     <!-- col31 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col32 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col33 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col34 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col35 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col36 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col37 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col38 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col39 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col40 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col41 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col42 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col43 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col44 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col45 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col46 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col47 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                     <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col48 =                                                     -->
+                                    <!-- col32 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                     <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col49 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col50 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col51 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col52 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
@@ -13,11 +13,11 @@
             <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
             <!--    'column_alias': 'listings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- join_0 =                                                   -->
@@ -32,7 +32,7 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_214),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -52,7 +52,7 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -61,231 +61,151 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -412,98 +332,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -521,7 +361,7 @@
                 <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
                 <!--    'column_alias': 'listings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
@@ -541,7 +381,7 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                         <!--    'column_alias': 'listings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
@@ -550,151 +390,151 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                             <!--    'column_alias': 'created_at'}                          -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                             <!--    'column_alias': 'created_at__week'}                    -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                             <!--    'column_alias': 'created_at__month'}                   -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                             <!--    'column_alias': 'created_at__quarter'}                 -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                             <!--    'column_alias': 'created_at__year'}                    -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                             <!--    'column_alias': 'listing__ds'}                         -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                             <!--    'column_alias': 'listing__ds__week'}                   -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                             <!--    'column_alias': 'listing__ds__month'}                  -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                             <!--    'column_alias': 'listing__ds__year'}                   -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                             <!--    'column_alias': 'listing__created_at'}                 -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                             <!--    'column_alias': 'listing__created_at__week'}           -->
                             <!-- col17 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                             <!--    'column_alias': 'listing__created_at__month'}          -->
                             <!-- col18 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                             <!--    'column_alias': 'listing__created_at__year'}           -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col21 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col22 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col23 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col24 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col25 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col26 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                             <!--    'column_alias': 'user'}                                -->
                             <!-- col27 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                             <!--    'column_alias': 'listing__user'}                       -->
                             <!-- col28 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                             <!--    'column_alias': 'country_latest'}                      -->
                             <!-- col29 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                             <!--    'column_alias': 'is_lux_latest'}                       -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                             <!--    'column_alias': 'capacity_latest'}                     -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                             <!--    'column_alias': 'listings'}                            -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                             <!--    'column_alias': 'largest_listing'}                     -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                             <!--    'column_alias': 'smallest_listing'}                    -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                             <!-- where = None -->
@@ -707,127 +547,127 @@
                                 <!--    'column_alias': 'listings'}                                 -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                 <!--    'column_alias': 'largest_listing'}                       -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                 <!--    'column_alias': 'smallest_listing'}                      -->
                                 <!-- col3 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col8 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                 <!--    'column_alias': 'created_at'}                            -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'created_at__week'}                -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'created_at__month'}               -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                 <!-- col12 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'created_at__year'}                -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                 <!--    'column_alias': 'country_latest'}                        -->
                                 <!-- col14 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                 <!--    'column_alias': 'is_lux_latest'}                         -->
                                 <!-- col15 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                 <!--    'column_alias': 'capacity_latest'}                       -->
                                 <!-- col16 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                 <!--    'column_alias': 'listing__ds'}                           -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                 <!-- col21 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                 <!--    'column_alias': 'listing__created_at'}                   -->
                                 <!-- col22 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                 <!-- col23 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                 <!-- col24 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                 <!-- col25 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                 <!-- col26 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                 <!--    'column_alias': 'listing__country_latest'}               -->
                                 <!-- col27 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                 <!-- col28 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                                 <!-- col29 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col30 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                 <!--    'column_alias': 'listing__user'}                         -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
@@ -252,99 +252,99 @@
                                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
                                 <!--    'column_alias': 'booking_value'}                         -->
                                 <!-- col3 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10236),  -->
                                 <!--    'column_alias': 'bookers'}                               -->
                                 <!-- col4 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10270),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10237),  -->
                                 <!--    'column_alias': 'average_booking_value'}                 -->
                                 <!-- col5 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10271),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10238),  -->
                                 <!--    'column_alias': 'booking_payments'}                      -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10272),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10239),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
                                 <!-- col7 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10240),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10245),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col13 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10128),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10129),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col17 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10283),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10250),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}           -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}          -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}        -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                                 <!-- col22 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10288),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10255),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10256),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
                                 <!-- col24 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10290),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10257),  -->
                                 <!--    'column_alias': 'host'}                                  -->
                                 <!-- col25 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10291),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10258),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10015) -->
                                 <!-- where = None -->
@@ -535,119 +535,119 @@
                                 <!-- node_id = ss_10017 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10299),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10266),  -->
                                 <!--    'column_alias': 'window_start'}                          -->
                                 <!-- col1 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10136),  -->
                                 <!--    'column_alias': 'window_start__week'}              -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10137),  -->
                                 <!--    'column_alias': 'window_start__month'}             -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10138),  -->
                                 <!--    'column_alias': 'window_start__quarter'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10139),  -->
                                 <!--    'column_alias': 'window_start__year'}              -->
                                 <!-- col5 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10304),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10271),  -->
                                 <!--    'column_alias': 'window_end'}                            -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10140),  -->
                                 <!--    'column_alias': 'window_end__week'}                -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10141),  -->
                                 <!--    'column_alias': 'window_end__month'}               -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10142),  -->
                                 <!--    'column_alias': 'window_end__quarter'}             -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10143),  -->
                                 <!--    'column_alias': 'window_end__year'}                -->
                                 <!-- col10 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10309),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
                                 <!--    'column_alias': 'country'}                               -->
                                 <!-- col11 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10310),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
                                 <!--    'column_alias': 'is_lux'}                                -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10311),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
                                 <!--    'column_alias': 'capacity'}                              -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10312),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10279),  -->
                                 <!--    'column_alias': 'listing__window_start'}                 -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
                                 <!--    'column_alias': 'listing__window_start__week'}     -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
                                 <!--    'column_alias': 'listing__window_start__month'}    -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
                                 <!--    'column_alias': 'listing__window_start__quarter'}  -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
                                 <!--    'column_alias': 'listing__window_start__year'}     -->
                                 <!-- col18 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10317),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10284),  -->
                                 <!--    'column_alias': 'listing__window_end'}                   -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
                                 <!--    'column_alias': 'listing__window_end__week'}       -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
                                 <!--    'column_alias': 'listing__window_end__month'}      -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
                                 <!--    'column_alias': 'listing__window_end__quarter'}    -->
                                 <!-- col22 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
                                 <!--    'column_alias': 'listing__window_end__year'}       -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10322),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
                                 <!--    'column_alias': 'listing__country'}                      -->
                                 <!-- col24 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10323),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10290),  -->
                                 <!--    'column_alias': 'listing__is_lux'}                       -->
                                 <!-- col25 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10324),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10291),  -->
                                 <!--    'column_alias': 'listing__capacity'}                     -->
                                 <!-- col26 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10325),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10292),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col27 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10326),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10293),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- col28 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10327),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10294),  -->
                                 <!--    'column_alias': 'listing__user'}                         -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10017) -->
                                 <!-- where = None -->
@@ -733,55 +733,55 @@
                                     <!-- node_id = ss_10021 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10377),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10344),  -->
                                     <!--    'column_alias': 'ds'}                                    -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10204),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10184),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10205),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10185),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10206),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10186),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10207),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10187),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10382),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10349),  -->
                                     <!--    'column_alias': 'home_state_latest'}                     -->
                                     <!-- col6 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10383),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10350),  -->
                                     <!--    'column_alias': 'user__ds'}                              -->
                                     <!-- col7 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10208),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10188),  -->
                                     <!--    'column_alias': 'user__ds__week'}                  -->
                                     <!-- col8 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10209),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10189),  -->
                                     <!--    'column_alias': 'user__ds__month'}                 -->
                                     <!-- col9 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10210),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10190),  -->
                                     <!--    'column_alias': 'user__ds__quarter'}               -->
                                     <!-- col10 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10211),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10191),  -->
                                     <!--    'column_alias': 'user__ds__year'}                  -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10388),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10355),  -->
                                     <!--    'column_alias': 'user__home_state_latest'}               -->
                                     <!-- col12 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10389),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10356),  -->
                                     <!--    'column_alias': 'user'}                                  -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10021) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
@@ -252,99 +252,99 @@
                                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
                                 <!--    'column_alias': 'booking_value'}                         -->
                                 <!-- col3 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10236),  -->
                                 <!--    'column_alias': 'bookers'}                               -->
                                 <!-- col4 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10270),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10237),  -->
                                 <!--    'column_alias': 'average_booking_value'}                 -->
                                 <!-- col5 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10271),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10238),  -->
                                 <!--    'column_alias': 'booking_payments'}                      -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10272),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10239),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
                                 <!-- col7 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10240),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10245),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col13 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10128),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10129),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col17 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10283),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10250),  -->
                                 <!--    'column_alias': 'booking_paid_at'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),  -->
                                 <!--    'column_alias': 'booking_paid_at__week'}           -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),  -->
                                 <!--    'column_alias': 'booking_paid_at__month'}          -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),  -->
                                 <!--    'column_alias': 'booking_paid_at__quarter'}        -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                                 <!-- col22 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10288),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10255),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10256),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
                                 <!-- col24 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10290),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10257),  -->
                                 <!--    'column_alias': 'host'}                                  -->
                                 <!-- col25 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10291),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10258),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10015) -->
                                 <!-- where = None -->
@@ -454,15 +454,15 @@
                                 <!-- node_id = ss_10018 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10328),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10295),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10329),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10296),  -->
                                 <!--    'column_alias': 'lux_listing'}                           -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10330),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10297),  -->
                                 <!--    'column_alias': 'listing__lux_listing'}                  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10018) -->
                                 <!-- where = None -->
@@ -599,95 +599,95 @@
                                     <!-- node_id = ss_10019 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10331),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10298),  -->
                                     <!--    'column_alias': 'window_start'}                          -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10172),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),  -->
                                     <!--    'column_alias': 'window_start__week'}              -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10173),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),  -->
                                     <!--    'column_alias': 'window_start__month'}             -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10174),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),  -->
                                     <!--    'column_alias': 'window_start__quarter'}           -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10175),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),  -->
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10336),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10303),  -->
                                     <!--    'column_alias': 'window_end'}                            -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10176),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
                                     <!--    'column_alias': 'window_end__week'}                -->
                                     <!-- col7 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10177),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
                                     <!--    'column_alias': 'window_end__month'}               -->
                                     <!-- col8 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10178),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
                                     <!--    'column_alias': 'window_end__quarter'}             -->
                                     <!-- col9 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10179),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10341),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10308),  -->
                                     <!--    'column_alias': 'is_confirmed_lux'}                      -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10342),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10309),  -->
                                     <!--    'column_alias': 'lux_listing__window_start'}             -->
                                     <!-- col12 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                         -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10180),   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),   -->
                                     <!--    'column_alias': 'lux_listing__window_start__week'}  -->
                                     <!-- col13 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10181),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),    -->
                                     <!--    'column_alias': 'lux_listing__window_start__month'}  -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10182),      -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),      -->
                                     <!--    'column_alias': 'lux_listing__window_start__quarter'}  -->
                                     <!-- col15 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                         -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10183),   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),   -->
                                     <!--    'column_alias': 'lux_listing__window_start__year'}  -->
                                     <!-- col16 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10347),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10314),  -->
                                     <!--    'column_alias': 'lux_listing__window_end'}               -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10184),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__week'}   -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10185),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__month'}  -->
                                     <!-- col19 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10186),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),    -->
                                     <!--    'column_alias': 'lux_listing__window_end__quarter'}  -->
                                     <!-- col20 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10187),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__year'}   -->
                                     <!-- col21 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10352),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10319),  -->
                                     <!--    'column_alias': 'lux_listing__is_confirmed_lux'}         -->
                                     <!-- col22 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10353),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10320),  -->
                                     <!--    'column_alias': 'lux_listing'}                           -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10019) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -170,98 +170,18 @@
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                <!-- col30 =                                                             -->
-                <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                <!-- col30 =                                                     -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                <!--    'column_alias': 'listing'}                               -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                <!-- col32 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                <!-- col33 =                                                            -->
-                <!--   {'class': 'SqlSelectColumn',                                     -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                <!-- col34 =                                                              -->
-                <!--   {'class': 'SqlSelectColumn',                                       -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                <!-- col35 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                <!-- col36 =                                                                 -->
-                <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                <!-- col37 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                <!-- col38 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                <!-- col39 =                                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                <!-- col40 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                <!-- col41 =                                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                <!-- col42 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                <!-- col43 =                                                                         -->
-                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                <!-- col44 =                                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                <!-- col45 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                <!-- col46 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'listing'}                               -->
-                <!-- col47 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                 <!--    'column_alias': 'guest'}                                 -->
-                <!-- col48 =                                                     -->
+                <!-- col32 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                 <!--    'column_alias': 'host'}                                  -->
-                <!-- col49 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                <!-- col50 =                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                <!-- col51 =                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                <!-- col52 =                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
                 <SqlTableFromClauseNode>
@@ -295,127 +215,127 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col11 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col12 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col23 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col24 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col25 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                 <!-- where = None -->
@@ -450,127 +370,127 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col11 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col12 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col23 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col24 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col25 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
@@ -220,99 +220,99 @@
                                 <!-- node_id = ss_10010 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10204),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10171),  -->
                                 <!--    'column_alias': 'txn_count'}                             -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10205),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10172),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10092),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10093),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10094),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10095),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10210),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10177),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10096),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10097),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10098),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10099),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col11 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10215),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10182),  -->
                                 <!--    'column_alias': 'account_month'}                         -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10216),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10183),  -->
                                 <!--    'column_alias': 'account_id__ds_partitioned'}            -->
                                 <!-- col13 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10120),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10100),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
                                 <!-- col14 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10121),     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10101),     -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
                                 <!-- col15 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10122),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10102),       -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
                                 <!-- col16 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10123),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10103),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
                                 <!-- col17 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10221),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10188),  -->
                                 <!--    'column_alias': 'account_id__ds'}                        -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),  -->
                                 <!--    'column_alias': 'account_id__ds__week'}            -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),  -->
                                 <!--    'column_alias': 'account_id__ds__month'}           -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),  -->
                                 <!--    'column_alias': 'account_id__ds__quarter'}         -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),  -->
                                 <!--    'column_alias': 'account_id__ds__year'}            -->
                                 <!-- col22 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10226),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10193),  -->
                                 <!--    'column_alias': 'account_id__account_month'}             -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10227),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10194),  -->
                                 <!--    'column_alias': 'account_id'}                            -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10010) -->
                                 <!-- where = None -->
@@ -447,63 +447,63 @@
                                 <!-- node_id = ss_10011 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10228),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10195),  -->
                                 <!--    'column_alias': 'extra_dim'}                             -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10229),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10196),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10128),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10129),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10234),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10201),  -->
                                 <!--    'column_alias': 'account_id__extra_dim'}                 -->
                                 <!-- col7 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10202),  -->
                                 <!--    'column_alias': 'account_id__ds_partitioned'}            -->
                                 <!-- col8 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
                                 <!-- col9 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),     -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
                                 <!-- col10 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),       -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
                                 <!-- col11 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10240),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10207),  -->
                                 <!--    'column_alias': 'account_id'}                            -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10241),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10208),  -->
                                 <!--    'column_alias': 'customer_id'}                           -->
                                 <!-- col14 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10242),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10209),  -->
                                 <!--    'column_alias': 'account_id__customer_id'}               -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
                                 <!-- where = None -->
@@ -599,63 +599,63 @@
                                     <!-- node_id = ss_10013 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10217),  -->
                                     <!--    'column_alias': 'customer_name'}                         -->
                                     <!-- col1 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10218),  -->
                                     <!--    'column_alias': 'customer_atomic_weight'}                -->
                                     <!-- col2 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10219),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                        -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10136),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10137),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col5 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10138),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10139),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col7 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10224),  -->
                                     <!--    'column_alias': 'customer_id__customer_name'}            -->
                                     <!-- col8 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10258),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10225),  -->
                                     <!--    'column_alias': 'customer_id__customer_atomic_weight'}   -->
                                     <!-- col9 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10259),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10226),  -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned'}           -->
                                     <!-- col10 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10140),     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10120),     -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__week'}  -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10141),      -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10121),      -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__month'}  -->
                                     <!-- col12 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10142),        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10122),        -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__quarter'}  -->
                                     <!-- col13 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10143),     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10123),     -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__year'}  -->
                                     <!-- col14 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10264),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10231),  -->
                                     <!--    'column_alias': 'customer_id'}                           -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10013) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
@@ -23,7 +23,7 @@
             <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- where = None -->
@@ -43,7 +43,7 @@
                     <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- where = None -->
@@ -53,231 +53,151 @@
                         <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                        <!-- col15 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col16 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
+                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!-- col17 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
+                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!-- col18 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
+                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!-- col19 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
+                        <!--    'column_alias': 'metric_time__year'}                   -->
+                        <!-- col20 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
+                        <!--    'column_alias': 'listing'}                             -->
+                        <!-- col21 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
+                        <!--    'column_alias': 'guest'}                               -->
+                        <!-- col22 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
+                        <!--    'column_alias': 'host'}                                -->
+                        <!-- col23 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
+                        <!--    'column_alias': 'is_instant'}                          -->
+                        <!-- col24 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- col25 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
+                        <!--    'column_alias': 'instant_bookings'}                    -->
+                        <!-- col26 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+                        <!--    'column_alias': 'booking_value'}                       -->
+                        <!-- col27 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+                        <!--    'column_alias': 'max_booking_value'}                   -->
+                        <!-- col28 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+                        <!--    'column_alias': 'min_booking_value'}                   -->
+                        <!-- col29 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
+                        <!--    'column_alias': 'bookers'}                             -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
-                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
+                        <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
-                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+                        <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
-                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
+                        <!--    'column_alias': 'median_booking_value'}                -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
-                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),  -->
+                        <!--    'column_alias': 'booking_value_p99'}                   -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
-                        <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
-                        <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
-                        <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),  -->
-                        <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                        <!--    'column_alias': 'bookings'}                            -->
-                        <!-- col45 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                        <!--    'column_alias': 'instant_bookings'}                    -->
-                        <!-- col46 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                        <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- col47 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                        <!--    'column_alias': 'max_booking_value'}                   -->
-                        <!-- col48 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                        <!--    'column_alias': 'min_booking_value'}                   -->
-                        <!-- col49 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                        <!--    'column_alias': 'bookers'}                             -->
-                        <!-- col50 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                        <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- col51 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                        <!--    'column_alias': 'referred_bookings'}                   -->
-                        <!-- col52 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                        <!--    'column_alias': 'median_booking_value'}                -->
-                        <!-- col53 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                        <!--    'column_alias': 'booking_value_p99'}                   -->
-                        <!-- col54 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),        -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),      -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = SqlBetweenExpression(node_id=betw_2) -->
@@ -286,231 +206,151 @@
                             <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_433),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_436),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_437),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_438),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_439),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_440),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_442),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_443),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_444),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_445),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_446),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_447),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_448),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_449),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_450),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_451),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_452),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_453),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_454),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_455),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_456),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_457),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_458),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_459),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_460),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_461),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_462),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_463),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_431),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_432),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_424),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_430),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -637,98 +477,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -747,7 +507,7 @@
             <!-- node_id = ss_20 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
             <!--    'column_alias': 'listings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
             <!-- where = None -->
@@ -767,7 +527,7 @@
                     <!-- node_id = ss_18 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
                     <!--    'column_alias': 'listings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
@@ -777,151 +537,151 @@
                         <!-- node_id = ss_17 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_450),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_451),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_452),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_453),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_454),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_455),  -->
                         <!--    'column_alias': 'created_at'}                          -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_456),  -->
                         <!--    'column_alias': 'created_at__week'}                    -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_457),  -->
                         <!--    'column_alias': 'created_at__month'}                   -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_458),  -->
                         <!--    'column_alias': 'created_at__quarter'}                 -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_459),  -->
                         <!--    'column_alias': 'created_at__year'}                    -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_460),  -->
                         <!--    'column_alias': 'listing__ds'}                         -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_461),  -->
                         <!--    'column_alias': 'listing__ds__week'}                   -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_462),  -->
                         <!--    'column_alias': 'listing__ds__month'}                  -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_463),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}                -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
                         <!--    'column_alias': 'listing__ds__year'}                   -->
                         <!-- col15 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
                         <!--    'column_alias': 'listing__created_at'}                 -->
                         <!-- col16 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
                         <!--    'column_alias': 'listing__created_at__week'}           -->
                         <!-- col17 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
                         <!--    'column_alias': 'listing__created_at__month'}          -->
                         <!-- col18 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}        -->
                         <!-- col19 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
                         <!--    'column_alias': 'listing__created_at__year'}           -->
                         <!-- col20 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col21 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col22 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col23 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col24 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col25 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
                         <!--    'column_alias': 'listing'}                             -->
                         <!-- col26 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col27 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
                         <!--    'column_alias': 'listing__user'}                       -->
                         <!-- col28 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_444),  -->
                         <!--    'column_alias': 'country_latest'}                      -->
                         <!-- col29 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_445),  -->
                         <!--    'column_alias': 'is_lux_latest'}                       -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_446),  -->
                         <!--    'column_alias': 'capacity_latest'}                     -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_447),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_448),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}              -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_449),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}            -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
                         <!--    'column_alias': 'listings'}                            -->
                         <!-- col35 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_442),  -->
                         <!--    'column_alias': 'largest_listing'}                     -->
                         <!-- col36 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_443),  -->
                         <!--    'column_alias': 'smallest_listing'}                    -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = SqlBetweenExpression(node_id=betw_3) -->
@@ -930,151 +690,151 @@
                             <!-- node_id = ss_16 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_412),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_413),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_415),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
                             <!--    'column_alias': 'created_at'}                          -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
                             <!--    'column_alias': 'created_at__week'}                    -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
                             <!--    'column_alias': 'created_at__month'}                   -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
                             <!--    'column_alias': 'created_at__quarter'}                 -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
                             <!--    'column_alias': 'created_at__year'}                    -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
                             <!--    'column_alias': 'listing__ds'}                         -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
                             <!--    'column_alias': 'listing__ds__week'}                   -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_424),  -->
                             <!--    'column_alias': 'listing__ds__month'}                  -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
                             <!--    'column_alias': 'listing__ds__year'}                   -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
                             <!--    'column_alias': 'listing__created_at'}                 -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
                             <!--    'column_alias': 'listing__created_at__week'}           -->
                             <!-- col17 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
                             <!--    'column_alias': 'listing__created_at__month'}          -->
                             <!-- col18 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_430),  -->
                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_431),  -->
                             <!--    'column_alias': 'listing__created_at__year'}           -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_432),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col21 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_433),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col22 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col23 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col24 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_436),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col25 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_437),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col26 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_438),  -->
                             <!--    'column_alias': 'user'}                                -->
                             <!-- col27 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_439),  -->
                             <!--    'column_alias': 'listing__user'}                       -->
                             <!-- col28 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
                             <!--    'column_alias': 'country_latest'}                      -->
                             <!-- col29 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
                             <!--    'column_alias': 'is_lux_latest'}                       -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
                             <!--    'column_alias': 'capacity_latest'}                     -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
                             <!--    'column_alias': 'listings'}                            -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
                             <!--    'column_alias': 'largest_listing'}                     -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
                             <!--    'column_alias': 'smallest_listing'}                    -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                             <!-- where = None -->
@@ -1087,127 +847,127 @@
                                 <!--    'column_alias': 'listings'}                                 -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                                 <!--    'column_alias': 'largest_listing'}                       -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                                 <!--    'column_alias': 'smallest_listing'}                      -->
                                 <!-- col3 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col8 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                                 <!--    'column_alias': 'created_at'}                            -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'created_at__week'}                -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'created_at__month'}               -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                 <!-- col12 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'created_at__year'}                -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                                 <!--    'column_alias': 'country_latest'}                        -->
                                 <!-- col14 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                                 <!--    'column_alias': 'is_lux_latest'}                         -->
                                 <!-- col15 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                                 <!--    'column_alias': 'capacity_latest'}                       -->
                                 <!-- col16 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                                 <!--    'column_alias': 'listing__ds'}                           -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                 <!-- col21 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                                 <!--    'column_alias': 'listing__created_at'}                   -->
                                 <!-- col22 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                 <!-- col23 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                 <!-- col24 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                 <!-- col25 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                 <!-- col26 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                                 <!--    'column_alias': 'listing__country_latest'}               -->
                                 <!-- col27 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                                 <!-- col28 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                                 <!-- col29 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col30 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                                 <!--    'column_alias': 'listing__user'}                         -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_26 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                             -->
         <!--   {'class': 'SqlSelectColumn',                                                                     -->
@@ -21,15 +21,15 @@
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
             <!--    'column_alias': 'non_referred'}                        -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
             <!--    'column_alias': 'instant'}                             -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
             <!-- join_0 =                                                   -->
@@ -50,7 +50,7 @@
                 <!-- node_id = ss_16 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                                              -->
                 <!--   {'class': 'SqlSelectColumn',                                                                      -->
@@ -67,11 +67,11 @@
                     <!--    'column_alias': 'metric_time'}                                                 -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                     <!--    'column_alias': 'ref_bookings'}                        -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                     <!-- join_0 =                                                   -->
@@ -86,11 +86,11 @@
                         <!-- node_id = ss_10 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                         <!--    'column_alias': 'ref_bookings'}                        -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                         <!-- where = None -->
@@ -99,7 +99,7 @@
                             <!-- node_id = ss_9 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -108,7 +108,7 @@
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- group_by0 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
@@ -118,11 +118,11 @@
                                 <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                                 <!--    'column_alias': 'referred_bookings'}                   -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
@@ -131,231 +131,151 @@
                                     <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -482,98 +402,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -591,11 +431,11 @@
                         <!-- node_id = ss_14 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
@@ -604,7 +444,7 @@
                             <!-- node_id = ss_13 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -613,7 +453,7 @@
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                             <!-- group_by0 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
@@ -623,11 +463,11 @@
                                 <!-- node_id = ss_12 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                                 <!-- where = None -->
@@ -636,231 +476,151 @@
                                     <!-- node_id = ss_11 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col16 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col17 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col18 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col19 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col20 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col21 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col22 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col23 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col24 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col25 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col26 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col27 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col28 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col29 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col15 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!-- col16 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!-- col17 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!-- col18 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!-- col19 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                    <!--    'column_alias': 'metric_time__year'}                   -->
+                                    <!-- col20 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                    <!--    'column_alias': 'listing'}                             -->
+                                    <!-- col21 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                    <!--    'column_alias': 'guest'}                               -->
+                                    <!-- col22 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                    <!--    'column_alias': 'host'}                                -->
+                                    <!-- col23 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                                    <!--    'column_alias': 'is_instant'}                          -->
+                                    <!-- col24 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
+                                    <!--    'column_alias': 'bookings'}                            -->
+                                    <!-- col25 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                    -->
+                                    <!-- col26 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
+                                    <!--    'column_alias': 'booking_value'}                       -->
+                                    <!-- col27 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                   -->
+                                    <!-- col28 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                   -->
+                                    <!-- col29 =                                                   -->
+                                    <!--   {'class': 'SqlSelectColumn',                            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
+                                    <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
-                                    <!--    'column_alias': 'metric_time'}                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+                                    <!--    'column_alias': 'average_booking_value'}               -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
-                                    <!--    'column_alias': 'metric_time__week'}                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
-                                    <!--    'column_alias': 'metric_time__month'}                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
-                                    <!--    'column_alias': 'metric_time__quarter'}                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                   -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
-                                    <!--    'column_alias': 'metric_time__year'}                   -->
-                                    <!-- col35 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-                                    <!--    'column_alias': 'listing'}                             -->
-                                    <!-- col36 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-                                    <!--    'column_alias': 'guest'}                               -->
-                                    <!-- col37 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
-                                    <!--    'column_alias': 'host'}                                -->
-                                    <!-- col38 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                    <!-- col39 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col40 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col41 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- col42 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
-                                    <!--    'column_alias': 'is_instant'}                          -->
-                                    <!-- col43 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col44 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
-                                    <!--    'column_alias': 'bookings'}                            -->
-                                    <!-- col45 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                    -->
-                                    <!-- col46 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
-                                    <!--    'column_alias': 'booking_value'}                       -->
-                                    <!-- col47 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                   -->
-                                    <!-- col48 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                   -->
-                                    <!-- col49 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
-                                    <!--    'column_alias': 'bookers'}                             -->
-                                    <!-- col50 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
-                                    <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- col51 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
-                                    <!--    'column_alias': 'referred_bookings'}                   -->
-                                    <!-- col52 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
-                                    <!--    'column_alias': 'median_booking_value'}                -->
-                                    <!-- col53 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
-                                    <!--    'column_alias': 'booking_value_p99'}                   -->
-                                    <!-- col54 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                                    <!-- col55 =                                                         -->
+                                    <!-- col35 =                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),        -->
                                     <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                                    <!-- col56 =                                                       -->
+                                    <!-- col36 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),      -->
                                     <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
@@ -987,98 +747,18 @@
                                         <!--   {'class': 'SqlSelectColumn',                        -->
                                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                        <!-- col30 =                                                             -->
-                                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
                                         <!-- col31 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col32 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col33 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col34 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col35 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col36 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col37 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col38 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col39 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col40 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col41 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col42 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col43 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col44 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col45 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col46 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'listing'}                               -->
-                                        <!-- col47 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                         <!--    'column_alias': 'guest'}                                 -->
-                                        <!-- col48 =                                                     -->
+                                        <!-- col32 =                                                     -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                         <!--    'column_alias': 'host'}                                  -->
-                                        <!-- col49 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                        <!-- col50 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col51 =                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col52 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
                                         <SqlTableFromClauseNode>
@@ -1098,11 +778,11 @@
                 <!-- node_id = ss_20 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                 <!--    'column_alias': 'instant'}                             -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                 <!-- where = None -->
@@ -1111,7 +791,7 @@
                     <!-- node_id = ss_19 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -1120,7 +800,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -1130,11 +810,11 @@
                         <!-- node_id = ss_18 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                         <!--    'column_alias': 'instant_bookings'}                    -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                         <!-- where = None -->
@@ -1143,231 +823,151 @@
                             <!-- node_id = ss_17 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_412),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_413),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_414),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_415),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -1494,98 +1094,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
@@ -1603,11 +1123,11 @@
                 <!-- node_id = ss_24 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
                 <!-- where = None -->
@@ -1616,7 +1136,7 @@
                     <!-- node_id = ss_23 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -1625,7 +1145,7 @@
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
@@ -1635,11 +1155,11 @@
                         <!-- node_id = ss_22 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
                         <!-- where = None -->
@@ -1648,231 +1168,151 @@
                             <!-- node_id = ss_21 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_439),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_440),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_441),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_442),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_443),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_444),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_445),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_446),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_447),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_448),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_449),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_450),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_451),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_452),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_453),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_454),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_455),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_456),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_457),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_458),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_459),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_460),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_461),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_462),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_463),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col15 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col16 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col17 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col18 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col19 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col20 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col21 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col22 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col23 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col24 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col25 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col26 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col27 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col28 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col29 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col35 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col36 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col38 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col39 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col40 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col41 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_437),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col43 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_438),            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_424),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col46 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_426),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col47 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_427),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col48 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_428),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col49 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_429),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col50 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_430),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- col51 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_431),  -->
-                            <!--    'column_alias': 'referred_bookings'}                   -->
-                            <!-- col52 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_432),  -->
-                            <!--    'column_alias': 'median_booking_value'}                -->
-                            <!-- col53 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_433),  -->
-                            <!--    'column_alias': 'booking_value_p99'}                   -->
-                            <!-- col54 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_434),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                             <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                            <!-- col55 =                                                         -->
+                            <!-- col35 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_435),        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),        -->
                             <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                            <!-- col56 =                                                       -->
+                            <!-- col36 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_436),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),      -->
                             <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
@@ -1999,98 +1439,18 @@
                                 <!--   {'class': 'SqlSelectColumn',                        -->
                                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col30 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col30 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                                <!--    'column_alias': 'listing'}                               -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col32 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col33 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col34 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col35 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col36 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col37 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col38 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col39 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col40 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col41 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col42 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col43 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col44 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col45 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col46 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col47 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                                 <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col48 =                                                     -->
+                                <!-- col32 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                                 <!--    'column_alias': 'host'}                                  -->
-                                <!-- col49 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col50 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col51 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col52 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -208,98 +208,18 @@
                         <!--   {'class': 'SqlSelectColumn',                        -->
                         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
-                        <!-- col30 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                        <!-- col30 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                        <!--    'column_alias': 'listing'}                               -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col32 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col33 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col34 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col35 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col36 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col37 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col38 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col39 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col40 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col41 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col42 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col43 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col44 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col45 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col46 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'listing'}                               -->
-                        <!-- col47 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                         <!--    'column_alias': 'guest'}                                 -->
-                        <!-- col48 =                                                     -->
+                        <!-- col32 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                         <!--    'column_alias': 'host'}                                  -->
-                        <!-- col49 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                        <!-- col50 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col51 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col52 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
                         <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
         <!--    'column_alias': 'user__home_state'}                    -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
         <!--    'column_alias': 'identity_verifications'}              -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
             <!--    'column_alias': 'user__home_state'}                    -->
             <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
             <!--    'column_alias': 'user__home_state'}                    -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                 <!--    'column_alias': 'user__home_state'}                    -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                 <!--    'column_alias': 'identity_verifications'}              -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
@@ -49,23 +49,23 @@
                     <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
                     <!--    'column_alias': 'ds_partitioned'}                      -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                     <!--    'column_alias': 'user__ds_partitioned'}                -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                     <!--    'column_alias': 'user__home_state'}                    -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
                     <!--    'column_alias': 'identity_verifications'}              -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- join_0 =                                                  -->
@@ -82,15 +82,15 @@
                         <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
                         <!--    'column_alias': 'identity_verifications'}              -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
@@ -99,127 +99,127 @@
                             <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
                             <!--    'column_alias': 'verification__ds'}                    -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                             <!--    'column_alias': 'verification__ds__week'}              -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                             <!--    'column_alias': 'verification__ds__month'}             -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                             <!--    'column_alias': 'verification__ds__quarter'}           -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                             <!--    'column_alias': 'verification__ds__year'}              -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                             <!--    'column_alias': 'verification__ds_partitioned'}        -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                             <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
                             <!-- col17 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                             -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),   -->
                             <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
                             <!-- col18 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),     -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),     -->
                             <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                             <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col21 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col22 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col23 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col24 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col25 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                             <!--    'column_alias': 'verification'}                        -->
                             <!-- col26 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
                             <!--    'column_alias': 'user'}                                -->
                             <!-- col27 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
                             <!--    'column_alias': 'verification__user'}                  -->
                             <!-- col28 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
                             <!--    'column_alias': 'verification_type'}                   -->
                             <!-- col29 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                             <!--    'column_alias': 'verification__verification_type'}     -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                             <!--    'column_alias': 'identity_verifications'}              -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10003) -->
                             <!-- where = None -->
@@ -232,103 +232,103 @@
                                 <!--    'column_alias': 'identity_verifications'}                   -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10067),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
                                 <!--    'column_alias': 'ds'}                                    -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col11 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10077),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
                                 <!--    'column_alias': 'verification_type'}                     -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10078),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
                                 <!--    'column_alias': 'verification__ds'}                      -->
                                 <!-- col13 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'verification__ds__week'}          -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
                                 <!--    'column_alias': 'verification__ds__month'}         -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'verification__ds__quarter'}       -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'verification__ds__year'}          -->
                                 <!-- col17 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10083),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10063),  -->
                                 <!--    'column_alias': 'verification__ds_partitioned'}          -->
                                 <!-- col18 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),      -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),      -->
                                 <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
                                 <!-- col19 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),       -->
                                 <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
                                 <!-- col20 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),         -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),         -->
                                 <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
                                 <!-- col21 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),      -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),      -->
                                 <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
                                 <!-- col22 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                                 <!--    'column_alias': 'verification__verification_type'}       -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
                                 <!--    'column_alias': 'verification'}                          -->
                                 <!-- col24 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10090),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- col25 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10091),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10071),  -->
                                 <!--    'column_alias': 'verification__user'}                    -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10003) -->
                                 <!-- where = None -->
@@ -347,15 +347,15 @@
                         <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
                         <!--    'column_alias': 'home_state'}                          -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10007) -->
                         <!-- where = None -->
@@ -364,135 +364,135 @@
                             <!-- node_id = ss_10007 -->
                             <!-- col0 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10133),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                             <!--    'column_alias': 'ds'}                                    -->
                             <!-- col1 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col5 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10138),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
                             <!--    'column_alias': 'created_at'}                            -->
                             <!-- col6 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
                             <!--    'column_alias': 'created_at__week'}                -->
                             <!-- col7 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
                             <!--    'column_alias': 'created_at__month'}               -->
                             <!-- col8 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
                             <!--    'column_alias': 'created_at__quarter'}             -->
                             <!-- col9 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
                             <!--    'column_alias': 'created_at__year'}                -->
                             <!-- col10 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10143),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10123),  -->
                             <!--    'column_alias': 'ds_partitioned'}                        -->
                             <!-- col11 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col12 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col13 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col14 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10148),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10128),  -->
                             <!--    'column_alias': 'home_state'}                            -->
                             <!-- col16 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10149),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10129),  -->
                             <!--    'column_alias': 'user__ds'}                              -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                             <!--    'column_alias': 'user__ds__week'}                  -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
                             <!--    'column_alias': 'user__ds__month'}                 -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                             <!--    'column_alias': 'user__ds__quarter'}               -->
                             <!-- col20 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                             <!--    'column_alias': 'user__ds__year'}                  -->
                             <!-- col21 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10154),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10134),  -->
                             <!--    'column_alias': 'user__created_at'}                      -->
                             <!-- col22 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                             <!--    'column_alias': 'user__created_at__week'}          -->
                             <!-- col23 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                             <!--    'column_alias': 'user__created_at__month'}         -->
                             <!-- col24 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
                             <!--    'column_alias': 'user__created_at__quarter'}       -->
                             <!-- col25 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                             <!--    'column_alias': 'user__created_at__year'}          -->
                             <!-- col26 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10159),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10139),  -->
                             <!--    'column_alias': 'user__ds_partitioned'}                  -->
                             <!-- col27 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                             <!--    'column_alias': 'user__ds_partitioned__week'}      -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                             <!--    'column_alias': 'user__ds_partitioned__month'}     -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                             <!--    'column_alias': 'user__ds_partitioned__quarter'}   -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
                             <!--    'column_alias': 'user__ds_partitioned__year'}      -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10164),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10144),  -->
                             <!--    'column_alias': 'user__home_state'}                      -->
                             <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10165),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10145),  -->
                             <!--    'column_alias': 'user'}                                  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10007) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
@@ -160,98 +160,18 @@
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
-                <!-- col30 =                                                             -->
-                <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                <!-- col30 =                                                     -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                <!--    'column_alias': 'listing'}                               -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                <!-- col32 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                <!-- col33 =                                                            -->
-                <!--   {'class': 'SqlSelectColumn',                                     -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                <!-- col34 =                                                              -->
-                <!--   {'class': 'SqlSelectColumn',                                       -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                <!-- col35 =                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                <!-- col36 =                                                                 -->
-                <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                <!-- col37 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                <!-- col38 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                <!-- col39 =                                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                <!-- col40 =                                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                                -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                <!-- col41 =                                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                <!-- col42 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                <!-- col43 =                                                                         -->
-                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                <!-- col44 =                                                                           -->
-                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                <!-- col45 =                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                <!-- col46 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'listing'}                               -->
-                <!-- col47 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                 <!--    'column_alias': 'guest'}                                 -->
-                <!-- col48 =                                                     -->
+                <!-- col32 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                 <!--    'column_alias': 'host'}                                  -->
-                <!-- col49 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                <!-- col50 =                                                          -->
-                <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                <!-- col51 =                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                <!-- col52 =                                                       -->
-                <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
                 <SqlTableFromClauseNode>
@@ -285,127 +205,127 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col11 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col12 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10092),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col23 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col24 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col25 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10118),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10119),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
@@ -122,98 +122,18 @@
         <!--   {'class': 'SqlSelectColumn',                        -->
         <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
         <!--    'column_alias': 'booking_paid_at__year'}           -->
-        <!-- col30 =                                                             -->
-        <!--   {'class': 'SqlSelectColumn',                                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+        <!-- col30 =                                                     -->
+        <!--   {'class': 'SqlSelectColumn',                              -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+        <!--    'column_alias': 'listing'}                               -->
         <!-- col31 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-        <!-- col32 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-        <!-- col33 =                                                            -->
-        <!--   {'class': 'SqlSelectColumn',                                     -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-        <!-- col34 =                                                              -->
-        <!--   {'class': 'SqlSelectColumn',                                       -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-        <!-- col35 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-        <!-- col36 =                                                                 -->
-        <!--   {'class': 'SqlSelectColumn',                                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-        <!-- col37 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-        <!-- col38 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-        <!-- col39 =                                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                                   -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-        <!-- col40 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-        <!-- col41 =                                                                  -->
-        <!--   {'class': 'SqlSelectColumn',                                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-        <!-- col42 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-        <!-- col43 =                                                                         -->
-        <!--   {'class': 'SqlSelectColumn',                                                  -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-        <!-- col44 =                                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                                    -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-        <!-- col45 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-        <!-- col46 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-        <!--    'column_alias': 'listing'}                               -->
-        <!-- col47 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
         <!--    'column_alias': 'guest'}                                 -->
-        <!-- col48 =                                                     -->
+        <!-- col32 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
         <!--    'column_alias': 'host'}                                  -->
-        <!-- col49 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-        <!-- col50 =                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-        <!-- col51 =                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-        <!-- col52 =                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
         <!-- where = None -->
         <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC(booking_paid_at, month) AS booking_paid_at__month
   , DATE_TRUNC(booking_paid_at, quarter) AS booking_paid_at__quarter
   , DATE_TRUNC(booking_paid_at, isoyear) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC(ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC(ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC(ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC(ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC(ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC(ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC(booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC(booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC(booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC(booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC(booking_paid_at, isoweek) AS metric_time__week
   , DATE_TRUNC(booking_paid_at, month) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
     , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC(booking_paid_at, month) AS booking_paid_at__month
   , DATE_TRUNC(booking_paid_at, quarter) AS booking_paid_at__quarter
   , DATE_TRUNC(booking_paid_at, isoyear) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC(ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC(ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC(ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC(ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC(ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC(ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC(booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC(booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC(booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC(booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC(ds, isoweek) AS metric_time__week
   , DATE_TRUNC(ds, month) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
             , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC('week', booking_paid_at) AS metric_time__week
   , DATE_TRUNC('month', booking_paid_at) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC('week', booking_paid_at) AS metric_time__week
   , DATE_TRUNC('month', booking_paid_at) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC('week', booking_paid_at) AS metric_time__week
   , DATE_TRUNC('month', booking_paid_at) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC('week', booking_paid_at) AS metric_time__week
   , DATE_TRUNC('month', booking_paid_at) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.booking_paid_at AS metric_time
   , subq_0.booking_paid_at__week AS metric_time__week
   , subq_0.booking_paid_at__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.booking_payments
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
@@ -78,28 +58,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , booking_paid_at AS metric_time
   , DATE_TRUNC('week', booking_paid_at) AS metric_time__week
   , DATE_TRUNC('month', booking_paid_at) AS metric_time__month
@@ -39,11 +24,6 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , booking_value AS booking_payments
 FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -15,21 +15,6 @@ SELECT
   , subq_0.booking_paid_at__month
   , subq_0.booking_paid_at__quarter
   , subq_0.booking_paid_at__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds
-  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
   , subq_0.ds AS metric_time
   , subq_0.ds__week AS metric_time__week
   , subq_0.ds__month AS metric_time__month
@@ -38,12 +23,7 @@ SELECT
   , subq_0.listing
   , subq_0.guest
   , subq_0.host
-  , subq_0.create_a_cycle_in_the_join_graph
-  , subq_0.create_a_cycle_in_the_join_graph__listing
-  , subq_0.create_a_cycle_in_the_join_graph__guest
-  , subq_0.create_a_cycle_in_the_join_graph__host
   , subq_0.is_instant
-  , subq_0.create_a_cycle_in_the_join_graph__is_instant
   , subq_0.bookings
   , subq_0.instant_bookings
   , subq_0.booking_value
@@ -90,28 +70,8 @@ FROM (
     , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
     , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_0

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -16,21 +16,6 @@ SELECT
   , DATE_TRUNC('month', booking_paid_at) AS booking_paid_at__month
   , DATE_TRUNC('quarter', booking_paid_at) AS booking_paid_at__quarter
   , DATE_TRUNC('year', booking_paid_at) AS booking_paid_at__year
-  , ds AS create_a_cycle_in_the_join_graph__ds
-  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
-  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
-  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
-  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-  , booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-  , DATE_TRUNC('week', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-  , DATE_TRUNC('month', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-  , DATE_TRUNC('quarter', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-  , DATE_TRUNC('year', booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
   , ds AS metric_time
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
@@ -39,12 +24,7 @@ SELECT
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host
-  , guest_id AS create_a_cycle_in_the_join_graph
-  , listing_id AS create_a_cycle_in_the_join_graph__listing
-  , guest_id AS create_a_cycle_in_the_join_graph__guest
-  , host_id AS create_a_cycle_in_the_join_graph__host
   , is_instant
-  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
   , 1 AS bookings
   , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
   , booking_value

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -37,21 +37,6 @@ FROM (
           , subq_0.booking_paid_at__month
           , subq_0.booking_paid_at__quarter
           , subq_0.booking_paid_at__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds
-          , subq_0.create_a_cycle_in_the_join_graph__ds__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds__year
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_0.ds AS metric_time
           , subq_0.ds__week AS metric_time__week
           , subq_0.ds__month AS metric_time__month
@@ -60,12 +45,7 @@ FROM (
           , subq_0.listing
           , subq_0.guest
           , subq_0.host
-          , subq_0.create_a_cycle_in_the_join_graph
-          , subq_0.create_a_cycle_in_the_join_graph__listing
-          , subq_0.create_a_cycle_in_the_join_graph__guest
-          , subq_0.create_a_cycle_in_the_join_graph__host
           , subq_0.is_instant
-          , subq_0.create_a_cycle_in_the_join_graph__is_instant
           , subq_0.bookings
           , subq_0.instant_bookings
           , subq_0.booking_value
@@ -112,29 +92,9 @@ FROM (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_0
       ) subq_1
@@ -177,21 +137,6 @@ FULL OUTER JOIN (
           , subq_5.booking_paid_at__month
           , subq_5.booking_paid_at__quarter
           , subq_5.booking_paid_at__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds
-          , subq_5.create_a_cycle_in_the_join_graph__ds__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds__year
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
           , subq_5.booking_paid_at AS metric_time
           , subq_5.booking_paid_at__week AS metric_time__week
           , subq_5.booking_paid_at__month AS metric_time__month
@@ -200,12 +145,7 @@ FULL OUTER JOIN (
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
-          , subq_5.create_a_cycle_in_the_join_graph
-          , subq_5.create_a_cycle_in_the_join_graph__listing
-          , subq_5.create_a_cycle_in_the_join_graph__guest
-          , subq_5.create_a_cycle_in_the_join_graph__host
           , subq_5.is_instant
-          , subq_5.create_a_cycle_in_the_join_graph__is_instant
           , subq_5.booking_payments
         FROM (
           -- Read Elements From Semantic Model 'bookings_source'
@@ -240,29 +180,9 @@ FULL OUTER JOIN (
             , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
             , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_5
       ) subq_6

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -4,181 +4,101 @@
         <!-- node_id = ss_0 -->
         <!-- col0 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
         <!--    'column_alias': 'ds'}                                -->
         <!-- col1 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
         <!--    'column_alias': 'ds__week'}                          -->
         <!-- col2 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
         <!--    'column_alias': 'ds__month'}                         -->
         <!-- col3 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
         <!--    'column_alias': 'ds__quarter'}                       -->
         <!-- col4 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
         <!--    'column_alias': 'ds__year'}                          -->
         <!-- col5 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
         <!--    'column_alias': 'ds_partitioned'}                    -->
         <!-- col6 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
         <!--    'column_alias': 'ds_partitioned__week'}              -->
-        <!-- col7 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
-        <!--    'column_alias': 'ds_partitioned__month'}              -->
+        <!-- col7 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
+        <!--    'column_alias': 'ds_partitioned__month'}             -->
         <!-- col8 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
         <!--    'column_alias': 'ds_partitioned__quarter'}            -->
         <!-- col9 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),  -->
         <!--    'column_alias': 'ds_partitioned__year'}               -->
         <!-- col10 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
         <!--    'column_alias': 'booking_paid_at'}                    -->
         <!-- col11 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
         <!--    'column_alias': 'booking_paid_at__week'}              -->
         <!-- col12 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
         <!--    'column_alias': 'booking_paid_at__month'}             -->
         <!-- col13 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
         <!--    'column_alias': 'booking_paid_at__quarter'}           -->
         <!-- col14 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
         <!--    'column_alias': 'booking_paid_at__year'}              -->
-        <!-- col15 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),     -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-        <!-- col16 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-        <!-- col17 =                                                            -->
-        <!--   {'class': 'SqlSelectColumn',                                     -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),            -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-        <!-- col18 =                                                              -->
-        <!--   {'class': 'SqlSelectColumn',                                       -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-        <!-- col19 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-        <!-- col20 =                                                                 -->
-        <!--   {'class': 'SqlSelectColumn',                                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),                 -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-        <!-- col21 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),                       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-        <!-- col22 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-        <!-- col23 =                                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),                          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-        <!-- col24 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),                       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-        <!-- col25 =                                                                  -->
-        <!--   {'class': 'SqlSelectColumn',                                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),                  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-        <!-- col26 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-        <!-- col27 =                                                                         -->
-        <!--   {'class': 'SqlSelectColumn',                                                  -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),                         -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-        <!-- col28 =                                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),                           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-        <!-- col29 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-        <!-- col30 =                                                  -->
+        <!-- col15 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
         <!--    'column_alias': 'metric_time'}                        -->
-        <!-- col31 =                                                  -->
+        <!-- col16 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
         <!--    'column_alias': 'metric_time__week'}                  -->
-        <!-- col32 =                                                  -->
+        <!-- col17 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
         <!--    'column_alias': 'metric_time__month'}                 -->
-        <!-- col33 =                                                  -->
+        <!-- col18 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
         <!--    'column_alias': 'metric_time__quarter'}               -->
-        <!-- col34 =                                                  -->
+        <!-- col19 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
         <!--    'column_alias': 'metric_time__year'}                  -->
-        <!-- col35 =                                                  -->
+        <!-- col20 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
         <!--    'column_alias': 'listing'}                            -->
-        <!-- col36 =                                                  -->
+        <!-- col21 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
         <!--    'column_alias': 'guest'}                              -->
-        <!-- col37 =                                                  -->
+        <!-- col22 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
         <!--    'column_alias': 'host'}                               -->
-        <!-- col38 =                                                  -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}   -->
-        <!-- col39 =                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-        <!-- col40 =                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-        <!-- col41 =                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-        <!-- col42 =                                                 -->
+        <!-- col23 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
         <!--    'column_alias': 'is_instant'}                        -->
-        <!-- col43 =                                                             -->
-        <!--   {'class': 'SqlSelectColumn',                                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-        <!-- col44 =                                                 -->
+        <!-- col24 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
         <!--    'column_alias': 'booking_payments'}                  -->
@@ -307,98 +227,18 @@
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
             <!--    'column_alias': 'booking_paid_at__year'}           -->
-            <!-- col30 =                                                             -->
-            <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+            <!-- col30 =                                                     -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+            <!--    'column_alias': 'listing'}                               -->
             <!-- col31 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-            <!-- col32 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-            <!-- col33 =                                                            -->
-            <!--   {'class': 'SqlSelectColumn',                                     -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-            <!-- col34 =                                                              -->
-            <!--   {'class': 'SqlSelectColumn',                                       -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-            <!-- col35 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-            <!-- col36 =                                                                 -->
-            <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-            <!-- col37 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-            <!-- col38 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-            <!-- col39 =                                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                                   -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-            <!-- col40 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-            <!-- col41 =                                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-            <!-- col42 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-            <!-- col43 =                                                                         -->
-            <!--   {'class': 'SqlSelectColumn',                                                  -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-            <!-- col44 =                                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-            <!-- col45 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-            <!-- col46 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-            <!--    'column_alias': 'listing'}                               -->
-            <!-- col47 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
             <!--    'column_alias': 'guest'}                                 -->
-            <!-- col48 =                                                     -->
+            <!-- col32 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
             <!--    'column_alias': 'host'}                                  -->
-            <!-- col49 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-            <!-- col50 =                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-            <!-- col51 =                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-            <!-- col52 =                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->
             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -4,229 +4,149 @@
         <!-- node_id = ss_0 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
         <!--    'column_alias': 'ds'}                                 -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
         <!--    'column_alias': 'ds__week'}                           -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
         <!--    'column_alias': 'ds__month'}                          -->
         <!-- col3 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_17),  -->
         <!--    'column_alias': 'ds__quarter'}                        -->
         <!-- col4 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_18),  -->
         <!--    'column_alias': 'ds__year'}                           -->
         <!-- col5 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_19),  -->
         <!--    'column_alias': 'ds_partitioned'}                     -->
         <!-- col6 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_20),  -->
         <!--    'column_alias': 'ds_partitioned__week'}               -->
         <!-- col7 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_21),  -->
         <!--    'column_alias': 'ds_partitioned__month'}              -->
         <!-- col8 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_22),  -->
         <!--    'column_alias': 'ds_partitioned__quarter'}            -->
         <!-- col9 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
         <!--    'column_alias': 'ds_partitioned__year'}               -->
         <!-- col10 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
         <!--    'column_alias': 'booking_paid_at'}                    -->
         <!-- col11 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
         <!--    'column_alias': 'booking_paid_at__week'}              -->
         <!-- col12 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
         <!--    'column_alias': 'booking_paid_at__month'}             -->
         <!-- col13 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
         <!--    'column_alias': 'booking_paid_at__quarter'}           -->
         <!-- col14 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
         <!--    'column_alias': 'booking_paid_at__year'}              -->
-        <!-- col15 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),     -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-        <!-- col16 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-        <!-- col17 =                                                            -->
-        <!--   {'class': 'SqlSelectColumn',                                     -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),            -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-        <!-- col18 =                                                              -->
-        <!--   {'class': 'SqlSelectColumn',                                       -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),              -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-        <!-- col19 =                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-        <!-- col20 =                                                                 -->
-        <!--   {'class': 'SqlSelectColumn',                                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),                 -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-        <!-- col21 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),                       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-        <!-- col22 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-        <!-- col23 =                                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),                          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-        <!-- col24 =                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),                       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-        <!-- col25 =                                                                  -->
-        <!--   {'class': 'SqlSelectColumn',                                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),                  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-        <!-- col26 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-        <!-- col27 =                                                                         -->
-        <!--   {'class': 'SqlSelectColumn',                                                  -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),                         -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-        <!-- col28 =                                                                           -->
-        <!--   {'class': 'SqlSelectColumn',                                                    -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),                           -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-        <!-- col29 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),                        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-        <!-- col30 =                                                  -->
+        <!-- col15 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
         <!--    'column_alias': 'metric_time'}                        -->
-        <!-- col31 =                                                  -->
+        <!-- col16 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
         <!--    'column_alias': 'metric_time__week'}                  -->
-        <!-- col32 =                                                  -->
+        <!-- col17 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
         <!--    'column_alias': 'metric_time__month'}                 -->
-        <!-- col33 =                                                  -->
+        <!-- col18 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
         <!--    'column_alias': 'metric_time__quarter'}               -->
-        <!-- col34 =                                                  -->
+        <!-- col19 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
         <!--    'column_alias': 'metric_time__year'}                  -->
-        <!-- col35 =                                                  -->
+        <!-- col20 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
         <!--    'column_alias': 'listing'}                            -->
-        <!-- col36 =                                                  -->
+        <!-- col21 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
         <!--    'column_alias': 'guest'}                              -->
-        <!-- col37 =                                                  -->
+        <!-- col22 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
         <!--    'column_alias': 'host'}                               -->
-        <!-- col38 =                                                  -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}   -->
-        <!-- col39 =                                                          -->
-        <!--   {'class': 'SqlSelectColumn',                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),          -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-        <!-- col40 =                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),        -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-        <!-- col41 =                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),       -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-        <!-- col42 =                                                  -->
+        <!-- col23 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
         <!--    'column_alias': 'is_instant'}                         -->
-        <!-- col43 =                                                             -->
-        <!--   {'class': 'SqlSelectColumn',                                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),             -->
-        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-        <!-- col44 =                                                 -->
+        <!-- col24 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
         <!--    'column_alias': 'bookings'}                          -->
-        <!-- col45 =                                                 -->
+        <!-- col25 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
         <!--    'column_alias': 'instant_bookings'}                  -->
-        <!-- col46 =                                                 -->
+        <!-- col26 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
         <!--    'column_alias': 'booking_value'}                     -->
-        <!-- col47 =                                                 -->
+        <!-- col27 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
         <!--    'column_alias': 'max_booking_value'}                 -->
-        <!-- col48 =                                                 -->
+        <!-- col28 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
         <!--    'column_alias': 'min_booking_value'}                 -->
-        <!-- col49 =                                                 -->
+        <!-- col29 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
         <!--    'column_alias': 'bookers'}                           -->
-        <!-- col50 =                                                 -->
+        <!-- col30 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
         <!--    'column_alias': 'average_booking_value'}             -->
-        <!-- col51 =                                                 -->
+        <!-- col31 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
         <!--    'column_alias': 'referred_bookings'}                 -->
-        <!-- col52 =                                                 -->
+        <!-- col32 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
         <!--    'column_alias': 'median_booking_value'}              -->
-        <!-- col53 =                                                 -->
+        <!-- col33 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
         <!--    'column_alias': 'booking_value_p99'}                 -->
-        <!-- col54 =                                                  -->
+        <!-- col34 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
         <!--    'column_alias': 'discrete_booking_value_p99'}         -->
-        <!-- col55 =                                                         -->
+        <!-- col35 =                                                         -->
         <!--   {'class': 'SqlSelectColumn',                                  -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),         -->
         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-        <!-- col56 =                                                       -->
+        <!-- col36 =                                                       -->
         <!--   {'class': 'SqlSelectColumn',                                -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),       -->
         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
@@ -355,98 +275,18 @@
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
             <!--    'column_alias': 'booking_paid_at__year'}           -->
-            <!-- col30 =                                                             -->
-            <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+            <!-- col30 =                                                     -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+            <!--    'column_alias': 'listing'}                               -->
             <!-- col31 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-            <!-- col32 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-            <!-- col33 =                                                            -->
-            <!--   {'class': 'SqlSelectColumn',                                     -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-            <!-- col34 =                                                              -->
-            <!--   {'class': 'SqlSelectColumn',                                       -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-            <!-- col35 =                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-            <!-- col36 =                                                                 -->
-            <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-            <!-- col37 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-            <!-- col38 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-            <!-- col39 =                                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                                   -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-            <!-- col40 =                                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                                -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-            <!-- col41 =                                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-            <!-- col42 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-            <!-- col43 =                                                                         -->
-            <!--   {'class': 'SqlSelectColumn',                                                  -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-            <!-- col44 =                                                                           -->
-            <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-            <!-- col45 =                                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                                 -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-            <!-- col46 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-            <!--    'column_alias': 'listing'}                               -->
-            <!-- col47 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
             <!--    'column_alias': 'guest'}                                 -->
-            <!-- col48 =                                                     -->
+            <!-- col32 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
             <!--    'column_alias': 'host'}                                  -->
-            <!-- col49 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-            <!-- col50 =                                                          -->
-            <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-            <!-- col51 =                                                        -->
-            <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-            <!-- col52 =                                                       -->
-            <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->
             <SqlTableFromClauseNode>

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -31,11 +31,11 @@
             <!-- node_id = ss_10 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_216),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_217),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- where = None -->
@@ -44,7 +44,7 @@
                 <!-- node_id = ss_9 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -53,7 +53,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_215),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -63,11 +63,11 @@
                     <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_213),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_212),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                     <!-- where = None -->
@@ -76,231 +76,151 @@
                         <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_194),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                        <!-- col15 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col16 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!-- col17 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
+                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!-- col18 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!-- col19 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+                        <!--    'column_alias': 'metric_time__year'}                   -->
+                        <!-- col20 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+                        <!--    'column_alias': 'listing'}                             -->
+                        <!-- col21 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+                        <!--    'column_alias': 'guest'}                               -->
+                        <!-- col22 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+                        <!--    'column_alias': 'host'}                                -->
+                        <!-- col23 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                        <!--    'column_alias': 'is_instant'}                          -->
+                        <!-- col24 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- col25 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                        <!--    'column_alias': 'instant_bookings'}                    -->
+                        <!-- col26 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                        <!--    'column_alias': 'booking_value'}                       -->
+                        <!-- col27 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                        <!--    'column_alias': 'max_booking_value'}                   -->
+                        <!-- col28 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                        <!--    'column_alias': 'min_booking_value'}                   -->
+                        <!-- col29 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                        <!--    'column_alias': 'bookers'}                             -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
-                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                        <!--    'column_alias': 'average_booking_value'}               -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
-                        <!--    'column_alias': 'metric_time__week'}                   -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                        <!--    'column_alias': 'referred_bookings'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
-                        <!--    'column_alias': 'metric_time__month'}                  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                        <!--    'column_alias': 'median_booking_value'}                -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
-                        <!--    'column_alias': 'metric_time__quarter'}                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                        <!--    'column_alias': 'booking_value_p99'}                   -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
-                        <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
-                        <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
-                        <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
-                        <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
-                        <!--    'column_alias': 'bookings'}                            -->
-                        <!-- col45 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
-                        <!--    'column_alias': 'instant_bookings'}                    -->
-                        <!-- col46 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
-                        <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- col47 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
-                        <!--    'column_alias': 'max_booking_value'}                   -->
-                        <!-- col48 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
-                        <!--    'column_alias': 'min_booking_value'}                   -->
-                        <!-- col49 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
-                        <!--    'column_alias': 'bookers'}                             -->
-                        <!-- col50 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
-                        <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- col51 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
-                        <!--    'column_alias': 'referred_bookings'}                   -->
-                        <!-- col52 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
-                        <!--    'column_alias': 'median_booking_value'}                -->
-                        <!-- col53 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
-                        <!--    'column_alias': 'booking_value_p99'}                   -->
-                        <!-- col54 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),  -->
                         <!--    'column_alias': 'discrete_booking_value_p99'}          -->
-                        <!-- col55 =                                                         -->
+                        <!-- col35 =                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),        -->
                         <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
-                        <!-- col56 =                                                       -->
+                        <!-- col36 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
                         <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
@@ -427,98 +347,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>
@@ -536,11 +376,11 @@
             <!-- node_id = ss_14 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
             <!--    'column_alias': 'booking_payments'}                    -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
             <!-- where = None -->
@@ -549,7 +389,7 @@
                 <!-- node_id = ss_13 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                               -->
@@ -558,7 +398,7 @@
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
@@ -568,11 +408,11 @@
                     <!-- node_id = ss_12 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                     <!--    'column_alias': 'booking_payments'}                    -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
@@ -581,183 +421,103 @@
                         <!-- node_id = ss_11 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_220),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_221),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),    -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                        <!-- col16 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                        <!-- col17 =                                                            -->
-                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),           -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                        <!-- col18 =                                                              -->
-                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),             -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                        <!-- col19 =                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                        <!-- col20 =                                                                 -->
-                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),                -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                        <!-- col21 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                        <!-- col22 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                        <!-- col23 =                                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),                         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                        <!-- col24 =                                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),                      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                        <!-- col25 =                                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),                 -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                        <!-- col26 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                        <!-- col27 =                                                                         -->
-                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),                        -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                        <!-- col28 =                                                                           -->
-                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),                          -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                        <!-- col29 =                                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),                       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                        <!-- col30 =                                                   -->
+                        <!-- col15 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
-                        <!-- col31 =                                                   -->
+                        <!-- col16 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
-                        <!-- col32 =                                                   -->
+                        <!-- col17 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
-                        <!-- col33 =                                                   -->
+                        <!-- col18 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
-                        <!-- col34 =                                                   -->
+                        <!-- col19 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
-                        <!-- col35 =                                                   -->
+                        <!-- col20 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                         <!--    'column_alias': 'listing'}                             -->
-                        <!-- col36 =                                                   -->
+                        <!-- col21 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                         <!--    'column_alias': 'guest'}                               -->
-                        <!-- col37 =                                                   -->
+                        <!-- col22 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                         <!--    'column_alias': 'host'}                                -->
-                        <!-- col38 =                                                   -->
+                        <!-- col23 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                        <!-- col39 =                                                          -->
-                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),         -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                        <!-- col40 =                                                        -->
-                        <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),       -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                        <!-- col41 =                                                       -->
-                        <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),      -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                        <!-- col42 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_219),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
-                        <!-- col43 =                                                             -->
-                        <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),            -->
-                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                        <!-- col44 =                                                   -->
+                        <!-- col24 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_218),  -->
                         <!--    'column_alias': 'booking_payments'}                    -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
@@ -884,98 +644,18 @@
                             <!--   {'class': 'SqlSelectColumn',                        -->
                             <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}           -->
-                            <!-- col30 =                                                             -->
-                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col30 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),  -->
+                            <!--    'column_alias': 'listing'}                               -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col32 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col33 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col34 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col35 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col36 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col37 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col38 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col39 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col40 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col41 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col42 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col43 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col44 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col45 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col46 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col47 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
                             <!--    'column_alias': 'guest'}                                 -->
-                            <!-- col48 =                                                     -->
+                            <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10039),  -->
                             <!--    'column_alias': 'host'}                                  -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                            <!-- col50 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col51 =                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col52 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
                             <SqlTableFromClauseNode>

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -1,30 +1,22 @@
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import pandas as pd
-from dbt_semantic_interfaces.protocols.metric import MetricType
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.pretty_print import pformat_big_objects
 from dbt_semantic_interfaces.references import (
     EntityReference,
     MeasureReference,
-    MetricModelReference,
     MetricReference,
     TimeDimensionReference,
 )
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
-from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
-from metricflow.dataflow.dataflow_plan import BaseOutput
-from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.specs.specs import (
-    DEFAULT_TIME_GRANULARITY,
     TimeDimensionSpec,
 )
 from metricflow.time.time_granularity import (
@@ -70,79 +62,8 @@ class TimeGranularitySolver:
     def __init__(  # noqa: D
         self,
         semantic_manifest_lookup: SemanticManifestLookup,
-        source_nodes: Sequence[BaseOutput[SemanticModelDataSet]],
-        node_output_resolver: DataflowPlanNodeOutputDataSetResolver[SemanticModelDataSet],
     ) -> None:
         self._semantic_manifest_lookup = semantic_manifest_lookup
-        self._metric_reference_to_measure_reference = TimeGranularitySolver._measures_for_metric(
-            self._semantic_manifest_lookup.semantic_manifest
-        )
-
-        self._local_time_dimension_granularities: Dict[
-            LocalTimeDimensionGranularityKey, Set[TimeGranularity]
-        ] = defaultdict(set)
-
-        for source_node in source_nodes:
-            output_data_set = node_output_resolver.get_output_data_set(source_node)
-            for time_dimension_instance in output_data_set.instance_set.time_dimension_instances:
-                time_dimension_spec = time_dimension_instance.spec
-                if len(time_dimension_spec.entity_links) == 0:
-                    for measure_instance in output_data_set.instance_set.measure_instances:
-                        self._local_time_dimension_granularities[
-                            LocalTimeDimensionGranularityKey(
-                                measure_reference=measure_instance.spec.as_reference,
-                                local_time_dimension_reference=time_dimension_spec.reference,
-                            )
-                        ].add(time_dimension_spec.time_granularity)
-
-    @staticmethod
-    def _measures_for_metric(model: SemanticManifest) -> Dict[MetricModelReference, List[MeasureReference]]:
-        """Given a model, return a dict that maps the name of the metric to the names of the measures used."""
-        metric_reference_to_measure_references: Dict[MetricModelReference, List[MeasureReference]] = {}
-        for metric in model.metrics:
-            metric_reference_to_measure_references[MetricModelReference(metric_name=metric.name)] = [
-                MeasureReference(element_name=measure.element_name) for measure in metric.measure_references
-            ]
-
-        return metric_reference_to_measure_references
-
-    def local_dimension_granularity_range(
-        self, metric_references: Sequence[MetricReference], local_time_dimension_reference: TimeDimensionReference
-    ) -> Tuple[TimeGranularity, TimeGranularity]:
-        """Return the ranges of time granularities for a local dimension associated with the measures in metrics.
-
-        For example, let's say we're querying for two metrics that are based on 'bookings' and 'bookings_monthly'
-        respectively.
-
-        The 'bookings' measure defined is in the 'fct_bookings' semantic model. 'fct_bookings' has a local time dimension
-        named 'ds' with granularity DAY.
-
-        The 'monthly_bookings' measure is in defined in the 'fct_bookings_monthly' semantic model. 'fct_bookings_monthly'
-        has a local time dimension named 'ds' with granularity MONTH.
-
-        Then this would return [DAY, MONTH].
-        """
-        all_time_granularities = set()
-
-        for metric_reference in metric_references:
-            for measure_reference in self._metric_reference_to_measure_reference[
-                MetricModelReference(metric_name=metric_reference.element_name)
-            ]:
-                key = LocalTimeDimensionGranularityKey(
-                    measure_reference=measure_reference,
-                    local_time_dimension_reference=local_time_dimension_reference,
-                )
-                valid_time_granularities_for_measure = self._local_time_dimension_granularities[key]
-
-                if len(valid_time_granularities_for_measure) == 0:
-                    raise InvalidQueryException(
-                        f"Local dimension {local_time_dimension_reference} does not exist for measure "
-                        f"'{measure_reference}' of metric '{metric_reference}"
-                    )
-
-                all_time_granularities.add(min(valid_time_granularities_for_measure))
-
-        return min(all_time_granularities), max(all_time_granularities)
 
     def validate_time_granularity(
         self, metric_references: Sequence[MetricReference], time_dimension_specs: Sequence[TimeDimensionSpec]
@@ -151,87 +72,65 @@ class TimeGranularitySolver:
 
         e.g. throw an error if "ds__week" is specified for a metric with a time granularity of MONTH.
         """
+        valid_group_by_elements = self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
+            metric_references=metric_references,
+        )
+
         for time_dimension_spec in time_dimension_specs:
-            # Validate local time dimensions.
-            if time_dimension_spec.entity_links == ():
-                _, min_granularity_for_querying = self.local_dimension_granularity_range(
-                    metric_references=metric_references,
-                    local_time_dimension_reference=time_dimension_spec.reference,
+            match_found = False
+            for path_key in valid_group_by_elements.path_key_to_linkable_dimensions:
+                if (
+                    path_key.element_name == time_dimension_spec.element_name
+                    and (path_key.entity_links == time_dimension_spec.entity_links)
+                    and path_key.time_granularity == time_dimension_spec.time_granularity
+                ):
+                    match_found = True
+                    break
+            if not match_found:
+                raise RequestTimeGranularityException(
+                    f"{time_dimension_spec} is not valid for querying {metric_references}"
                 )
-                if time_dimension_spec.time_granularity < min_granularity_for_querying:
-                    raise RequestTimeGranularityException(
-                        f"The minimum time granularity for querying metrics {metric_references} is "
-                        f"{min_granularity_for_querying}. Got {time_dimension_spec}"
-                    )
-
-                # If there is a cumulative metric, granularity changes aren't supported. We need to check the granularity
-                # specified in the configs for the cumulative metric alone, since `min_granularity_for_querying` may not be supported.
-                for metric_reference in metric_references:
-                    metric = self._semantic_manifest_lookup.metric_lookup.get_metric(metric_reference)
-                    if metric.type == MetricType.CUMULATIVE:
-                        _, only_queryable_granularity = self.local_dimension_granularity_range(
-                            metric_references=[metric_reference],
-                            local_time_dimension_reference=time_dimension_spec.reference,
-                        )
-                        if time_dimension_spec.time_granularity != only_queryable_granularity:
-                            raise RequestTimeGranularityException(
-                                f"For querying cumulative metric '{metric_reference.element_name}', the granularity of "
-                                f"'{time_dimension_spec.qualified_name}' must be {only_queryable_granularity.name}"
-                            )
-
-        # TODO: Validate non-local time dimension granularities here instead of during plan building.
 
     def resolve_granularity_for_partial_time_dimension_specs(
         self,
         metric_references: Sequence[MetricReference],
         partial_time_dimension_specs: Sequence[PartialTimeDimensionSpec],
-        metric_time_dimension_reference: TimeDimensionReference,
-        time_granularity: Optional[TimeGranularity] = None,
     ) -> Dict[PartialTimeDimensionSpec, TimeDimensionSpec]:
         """Figure out the lowest granularity possible for the partially specified time dimension specs.
 
         Returns a dictionary that maps how the partial time dimension spec should be turned into a time dimension spec.
         """
-        replacement_dict: OrderedDict[PartialTimeDimensionSpec, TimeDimensionSpec] = OrderedDict()
+        valid_group_by_elements = self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
+            metric_references=metric_references,
+        )
+        result: Dict[PartialTimeDimensionSpec, TimeDimensionSpec] = {}
         for partial_time_dimension_spec in partial_time_dimension_specs:
-            # Handle local time dimensions
-            if partial_time_dimension_spec.entity_links == ():
-                _, min_time_granularity_for_querying = self.local_dimension_granularity_range(
-                    metric_references=metric_references,
-                    local_time_dimension_reference=TimeDimensionReference(
-                        element_name=partial_time_dimension_spec.element_name
-                    ),
-                )
-
+            minimum_time_granularity: Optional[TimeGranularity] = None
+            for path_key in valid_group_by_elements.path_key_to_linkable_dimensions:
                 if (
-                    partial_time_dimension_spec.element_name == metric_time_dimension_reference.element_name
-                    and time_granularity
+                    path_key.element_name == partial_time_dimension_spec.element_name
+                    and path_key.entity_links == partial_time_dimension_spec.entity_links
+                    and path_key.time_granularity is not None
                 ):
-                    if time_granularity < min_time_granularity_for_querying:
-                        raise RequestTimeGranularityException(
-                            f"Can't use time granularity for time dimension '{metric_time_dimension_reference} since "
-                            f"the minimum granularity is {min_time_granularity_for_querying}"
-                        )
-                    replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
-                        element_name=partial_time_dimension_spec.element_name,
-                        entity_links=(),
-                        time_granularity=time_granularity,
+                    minimum_time_granularity = (
+                        path_key.time_granularity
+                        if minimum_time_granularity is None
+                        else min(minimum_time_granularity, path_key.time_granularity)
                     )
-                else:
-                    replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
-                        element_name=partial_time_dimension_spec.element_name,
-                        entity_links=(),
-                        time_granularity=min_time_granularity_for_querying,
-                    )
-            # Handle joined time dimensions.
-            else:
-                # TODO: For joined time dimensions, also compute the minimum granularity for querying.
-                replacement_dict[partial_time_dimension_spec] = TimeDimensionSpec(
+
+            if minimum_time_granularity is not None:
+                result[partial_time_dimension_spec] = TimeDimensionSpec(
                     element_name=partial_time_dimension_spec.element_name,
                     entity_links=partial_time_dimension_spec.entity_links,
-                    time_granularity=DEFAULT_TIME_GRANULARITY,
+                    time_granularity=minimum_time_granularity,
                 )
-        return replacement_dict
+            else:
+                raise RequestTimeGranularityException(
+                    f"Unable to resolve the time dimension spec for {partial_time_dimension_spec}. "
+                    f"Valid group by elements are:\n"
+                    f"{pformat_big_objects([spec.qualified_name for spec in valid_group_by_elements.as_spec_set.as_tuple])}"
+                )
+        return result
 
     def adjust_time_range_to_granularity(
         self, time_range_constraint: TimeRangeConstraint, time_granularity: TimeGranularity


### PR DESCRIPTION
### Description

`create_a_cycle_in_the_join_graph` is an identifier in the test model that creates a potential cycle in the join graph if the join resolution logic is improperly handled. However, it makes the test output cluttered and confusing, so moving that out of the main test model into a separate one.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
