### PR TITLE
Move Databricks query execution to AdapterBackedSqlClient

### DIFF
--- a/.changes/unreleased/Features-20230726-173129.yaml
+++ b/.changes/unreleased/Features-20230726-173129.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable Databricks support for the dbt-metricflow integration
+time: 2023-07-26T17:31:29.847808-07:00
+custom:
+  Author: tlento
+  Issue: "580"

--- a/metricflow/test/fixtures/dbt_projects/metricflow_testing/profiles.yml
+++ b/metricflow/test/fixtures/dbt_projects/metricflow_testing/profiles.yml
@@ -1,3 +1,13 @@
+databricks:
+  target: dev
+  outputs:
+    dev:
+      type: databricks
+      host: "{{ env_var('MF_SQL_ENGINE_HOST') }}"
+      port: "{{ env_var('MF_SQL_ENGINE_PORT') | int }}"
+      token: "{{ env_var('MF_SQL_ENGINE_PASSWORD') }}"
+      http_path: "{{ env_var('MF_DATABRICKS_HTTP_PATH') }}"
+      schema: "{{ env_var('MF_SQL_ENGINE_SCHEMA') }}"
 postgres:
   target: dev
   outputs:


### PR DESCRIPTION
This effectively enables Databricks querying through the CLI for
the dbt-metricflow integation.

This includes a number of minor finicky databricks-specific adjustments
to the test classes and explain plan handling in the main class. These
are fairly hacky, but they are either specific to test classes and
therefore good enough until we can move to something more universally
robust like calling `dbt seed` or similar, or they are temporary until
some of the issues with the BaseAdapter.validate_sql_query method are
resolved.

As such, in order to allow for an all-green commit state, the legacy
SqlClient class will be removed in a follow-up.