### PR TITLE
Switch test profile env vars for dbt-backed tests to DBT_ENV_SECRET

### DIFF
--- a/metricflow/test/fixtures/dbt_projects/metricflow_testing/profiles.yml
+++ b/metricflow/test/fixtures/dbt_projects/metricflow_testing/profiles.yml
@@ -3,42 +3,42 @@ databricks:
   outputs:
     dev:
       type: databricks
-      host: "{{ env_var('MF_SQL_ENGINE_HOST') }}"
-      port: "{{ env_var('MF_SQL_ENGINE_PORT') | int }}"
-      token: "{{ env_var('MF_SQL_ENGINE_PASSWORD') }}"
-      http_path: "{{ env_var('MF_DATABRICKS_HTTP_PATH') }}"
-      schema: "{{ env_var('MF_SQL_ENGINE_SCHEMA') }}"
+      host: "{{ env_var('DBT_ENV_SECRET_HOST') }}"
+      port: "{{ env_var('DBT_PROFILE_PORT') | int }}"
+      token: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      http_path: "{{ env_var('DBT_ENV_SECRET_HTTP_PATH') }}"
+      schema: "{{ env_var('DBT_ENV_SECRET_SCHEMA') }}"
 postgres:
   target: dev
   outputs:
     dev:
       type: postgres
-      host: "{{ env_var('MF_SQL_ENGINE_HOST') }}"
-      port: "{{ env_var('MF_SQL_ENGINE_PORT') | int }}"
-      user: "{{ env_var('MF_SQL_ENGINE_USER') }}"
-      pass: "{{ env_var('MF_SQL_ENGINE_PASSWORD') }}"
-      dbname: "{{ env_var('MF_SQL_ENGINE_DATABASE') }}"
-      schema: "{{ env_var('MF_SQL_ENGINE_SCHEMA') }}"
+      host: "{{ env_var('DBT_ENV_SECRET_HOST') }}"
+      port: "{{ env_var('DBT_PROFILE_PORT') | int }}"
+      user: "{{ env_var('DBT_ENV_SECRET_USER') }}"
+      pass: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      dbname: "{{ env_var('DBT_ENV_SECRET_DATABASE') }}"
+      schema: "{{ env_var('DBT_ENV_SECRET_SCHEMA') }}"
 redshift:
   target: dev
   outputs:
     dev:
       type: redshift
-      host: "{{ env_var('MF_SQL_ENGINE_HOST') }}"
-      port: "{{ env_var('MF_SQL_ENGINE_PORT') | int }}"
-      user: "{{ env_var('MF_SQL_ENGINE_USER') }}"
-      password: "{{ env_var('MF_SQL_ENGINE_PASSWORD') }}"
-      dbname: "{{ env_var('MF_SQL_ENGINE_DATABASE') }}"
-      schema: "{{ env_var('MF_SQL_ENGINE_SCHEMA') }}"
+      host: "{{ env_var('DBT_ENV_SECRET_HOST') }}"
+      port: "{{ env_var('DBT_PROFILE_PORT') | int }}"
+      user: "{{ env_var('DBT_ENV_SECRET_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      dbname: "{{ env_var('DBT_ENV_SECRET_DATABASE') }}"
+      schema: "{{ env_var('DBT_ENV_SECRET_SCHEMA') }}"
 snowflake:
   target: dev
   outputs:
     dev:
       type: snowflake
       # The snowflake account is equivalent to the host value in the SqlAlchemy parsed URL
-      account: "{{ env_var('MF_SQL_ENGINE_HOST') }}"
-      user: "{{ env_var('MF_SQL_ENGINE_USER') }}"
-      password: "{{ env_var('MF_SQL_ENGINE_PASSWORD') }}"
-      warehouse: "{{ env_var('MF_SQL_ENGINE_WAREHOUSE') }}"
-      database: "{{ env_var('MF_SQL_ENGINE_DATABASE') }}"
-      schema: "{{ env_var('MF_SQL_ENGINE_SCHEMA') }}"
+      account: "{{ env_var('DBT_ENV_SECRET_HOST') }}"
+      user: "{{ env_var('DBT_ENV_SECRET_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_PASSWORD') }}"
+      warehouse: "{{ env_var('DBT_ENV_SECRET_WAREHOUSE') }}"
+      database: "{{ env_var('DBT_ENV_SECRET_DATABASE') }}"
+      schema: "{{ env_var('DBT_ENV_SECRET_SCHEMA') }}"


### PR DESCRIPTION
The dbt env_var macro has special handling for secrets, where any
env var prefixed with DBT_ENV_SECRET will be obfuscated in logs and
other locations.

Since the profile configs we use for our integration tests often involve
runtime secrets from CI or local environments, it makes sense to use this
feature in our test setup.