### PR TITLE
Improve messaging for populating the persistent source schema

### DIFF
--- a/metricflow/test/source_schema_tools.py
+++ b/metricflow/test/source_schema_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.table_snapshot.table_snapshots import (
@@ -24,13 +25,19 @@ def create_tables_listed_in_table_snapshot_repository(
         snapshot_loader.load(table_snapshot)
 
 
-POPULATE_SOURCE_SCHEMA_SHELL_COMMAND = (
-    f"hatch -v run dev-env:pytest "
-    f"-vv "
-    f"--log-cli-level info "
-    f"--use-persistent-source-schema "
-    f"{__file__}::populate_source_schema"
-)
+def get_populate_source_schema_shell_command(engine: SqlEngine) -> str:
+    """Creates the environment-specific shell command for populating a source schema.
+
+    This needs to be built in this way because different engines use different environments.
+    """
+    # The hatch environments are named in all lower-case, but otherwise should match the values.
+    return (
+        f"hatch -v run {engine.value.lower()}-env:pytest "
+        f"-vv "
+        f"--log-cli-level info "
+        f"--use-persistent-source-schema "
+        f"{__file__}::populate_source_schema"
+    )
 
 
 def populate_source_schema(

--- a/metricflow/test/table_snapshot/test_source_schema.py
+++ b/metricflow/test/table_snapshot/test_source_schema.py
@@ -10,7 +10,7 @@ from metricflow.protocols.sql_client import SqlClient, SqlEngine
 from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.fixtures.table_fixtures import CONFIGURED_SOURCE_TABLE_SNAPSHOT_REPOSITORY
-from metricflow.test.source_schema_tools import POPULATE_SOURCE_SCHEMA_SHELL_COMMAND
+from metricflow.test.source_schema_tools import get_populate_source_schema_shell_command
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotRepository,
     TableSnapshotException,
@@ -66,7 +66,8 @@ def test_validate_data_in_source_schema(
         except Exception as e:
             error_message = (
                 f"Error verifying that a table corresponding to {table_snapshot} exists in the persistent source "
-                f"schema {schema_name}. Try re-populating with: {POPULATE_SOURCE_SCHEMA_SHELL_COMMAND}"
+                f"schema {schema_name}. \nTry re-populating with: \n\n"
+                f"{get_populate_source_schema_shell_command(sql_client.sql_engine_type)}"
             )
             # Add it to the warnings so that it stands out in a sea of test failures.
             warnings.warn(error_message)


### PR DESCRIPTION
When the test runner encounters an error with the persistent source
schema it prompts the user with an example command. That command
no longer works, and it was very difficult to find in the sea
of log output for a failed test run even with the promotion to a
warning.

This change makes the command work in an engine-specific way, which
is the current approach to our test environment management, and
improves the formatting a bit to make it more copy/paste friendly.