### PR TITLE
Bump dbt-metricflow version to 0.0.5 for local deployment

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.0.4"
+version = "0.0.5"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
@@ -24,8 +24,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "dbt-core~=1.6.0rc1",
-  "metricflow==0.200.0.dev13"
+  "dbt-core~=1.6.0rc2",
+  "metricflow==0.200.0.dev15"
 ]
 
 [project.urls]


### PR DESCRIPTION
Update dbt-metricflow with latest updates to dbt-semantic-interfaces/dbt-core/metricflow