### PR TITLE
Remove unused schema property from MetricFlow runtime

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -30,23 +30,19 @@ class MetricFlowClient:
         self,
         sql_client: SqlClient,
         semantic_manifest: SemanticManifest,
-        system_schema: str,
     ):
         """Initializer for MetricFlowClient.
 
         Args:
             sql_client: Client that is connected to your data warehouse.
             semantic_manifest: Model containing all the information about your metric configs.
-            system_schema: schema of where MF system tables are stored.
         """
         self.sql_client = sql_client
         self.semantic_manifest = semantic_manifest
-        self.system_schema = system_schema
         self.semantic_manifest_lookup = SemanticManifestLookup(self.semantic_manifest)
         self.engine = MetricFlowEngine(
             semantic_manifest_lookup=self.semantic_manifest_lookup,
             sql_client=self.sql_client,
-            system_schema=self.system_schema,
         )
 
     def _create_mf_request(

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -87,15 +87,6 @@ class CLIContext:
         return pathlib.Path(self._dbt_project_metadata.project.log_path, "metricflow.log")
 
     @property
-    def mf_system_schema(self) -> str:
-        """Schema to use for MF system operations, such as creating the time spine dataset.
-
-        This is currently sourced from the dbt profile configuration. In the long run, this property
-        should be removed in favor of always sourcing schema locations from manifest entries.
-        """
-        return self.dbt_artifacts.profile.credentials.schema
-
-    @property
     def sql_client(self) -> SqlClient:
         """Property accessor for the sql_client class used in the CLI."""
         if self._sql_client is None:

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -135,7 +135,6 @@ class CLIContext:
             self._mf = MetricFlowEngine(
                 semantic_manifest_lookup=self.semantic_manifest_lookup,
                 sql_client=self.sql_client,
-                system_schema=self.mf_system_schema,
             )
         assert self._mf is not None
         return self._mf

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -657,7 +657,7 @@ def validate_configs(
     dw_results = SemanticManifestValidationResults()
     if not skip_dw:
         # fetch dbt adapters. This rebuilds the manifest again, but whatever.
-        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, system_schema=cfg.mf_system_schema)
+        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client)
         dw_results = _data_warehouse_validations_runner(
             dw_validator=dw_validator, manifest=semantic_manifest, timeout=dw_timeout
         )

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -289,7 +289,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         self,
         semantic_manifest_lookup: SemanticManifestLookup,
         sql_client: SqlClient,
-        system_schema: str,
         time_source: TimeSource = ServerTimeSource(),
         column_association_resolver: Optional[ColumnAssociationResolver] = None,
     ) -> None:
@@ -308,8 +307,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
         self._time_source = time_source
         self._time_spine_source = semantic_manifest_lookup.time_spine_source
-
-        self._schema = system_schema
 
         self._source_data_sets: List[SemanticModelDataSet] = []
         converter = SemanticModelToDataSetConverter(column_association_resolver=self._column_association_resolver)
@@ -349,9 +346,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             source_nodes=source_nodes,
             node_output_resolver=node_output_resolver,
         )
-
-    def _generate_sql_table(self, table_name: str) -> SqlTable:
-        return SqlTable.from_string(f"{self._schema}.{table_name}")
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def query(self, mf_request: MetricFlowQueryRequest) -> MetricFlowQueryResult:  # noqa: D

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -427,14 +427,11 @@ class DataWarehouseTaskBuilder:
         return (explain_result.rendered_sql.sql_query, explain_result.rendered_sql.bind_parameters)
 
     @classmethod
-    def gen_metric_tasks(
-        cls, manifest: SemanticManifest, sql_client: SqlClient, system_schema: str
-    ) -> List[DataWarehouseValidationTask]:
+    def gen_metric_tasks(cls, manifest: SemanticManifest, sql_client: SqlClient) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the manifest."""
         mf_engine = MetricFlowEngine(
             semantic_manifest_lookup=SemanticManifestLookup(semantic_manifest=manifest),
             sql_client=sql_client,
-            system_schema=system_schema,
         )
         tasks: List[DataWarehouseValidationTask] = []
         for metric in manifest.metrics:
@@ -591,7 +588,5 @@ class DataWarehouseModelValidator:
         Returns:
             A list of validation issues. If there are no validation issues, an empty list is returned.
         """
-        tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
-            manifest=manifest, sql_client=self._sql_client, system_schema=self._sql_schema
-        )
+        tasks = DataWarehouseTaskBuilder.gen_metric_tasks(manifest=manifest, sql_client=self._sql_client)
         return self.run_tasks(tasks=tasks, timeout=timeout)

--- a/metricflow/test/api/conftest.py
+++ b/metricflow/test/api/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from metricflow.api.metricflow_client import MetricFlowClient
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 
 
 @pytest.fixture
@@ -13,11 +12,9 @@ def mf_client(
     create_source_tables: bool,
     sql_client: SqlClient,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
-    mf_test_session_state: MetricFlowTestSessionState,
 ) -> MetricFlowClient:
     """Fixture for MetricFlowClient."""
     return MetricFlowClient(
         sql_client=sql_client,
         semantic_manifest=simple_semantic_manifest_lookup.semantic_manifest,
-        system_schema=mf_test_session_state.mf_system_schema,
     )

--- a/metricflow/test/api/test_metricflow_client.py
+++ b/metricflow/test/api/test_metricflow_client.py
@@ -6,9 +6,10 @@ from metricflow.api.metricflow_client import MetricFlowClient
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.engine.models import Dimension, Metric
 from metricflow.random_id import random_id
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 
 
-def test_query(mf_client: MetricFlowClient) -> None:  # noqa: D
+def test_query(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
     result = mf_client.query(
         ["bookings"],
         ["metric_time"],
@@ -23,7 +24,7 @@ def test_query(mf_client: MetricFlowClient) -> None:  # noqa: D
     assert len(result.result_df) == 2
     assert result.result_table is None
 
-    output_table = SqlTable(schema_name=mf_client.system_schema, table_name=f"test_table_{random_id()}")
+    output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
     result = mf_client.query(
         ["bookings"],
         ["metric_time"],
@@ -39,7 +40,7 @@ def test_query(mf_client: MetricFlowClient) -> None:  # noqa: D
     assert result.result_table == output_table
 
 
-def test_explain(mf_client: MetricFlowClient) -> None:  # noqa: D
+def test_explain(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
     result = mf_client.explain(
         ["bookings"],
         ["metric_time"],
@@ -52,7 +53,7 @@ def test_explain(mf_client: MetricFlowClient) -> None:  # noqa: D
     assert result.execution_plan
     assert result.output_table is None
 
-    output_table = SqlTable(schema_name=mf_client.system_schema, table_name=f"test_table_{random_id()}")
+    output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
     result = mf_client.explain(
         ["bookings"],
         ["metric_time"],

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -17,7 +17,6 @@ from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 
@@ -37,7 +36,6 @@ class FakeCLIContext(CLIContext):
         self._sql_client: Optional[SqlClient] = None
         self._semantic_manifest: Optional[SemanticManifest] = None
         self._semantic_manifest_lookup: Optional[SemanticManifestLookup] = None
-        self._mf_system_schema: Optional[str] = None
         self._log_file_path: Optional[pathlib.Path] = None
 
     @property
@@ -55,12 +53,6 @@ class FakeCLIContext(CLIContext):
     def log_file_path(self) -> pathlib.Path:
         assert self._log_file_path
         return self._log_file_path
-
-    @property
-    @override
-    def mf_system_schema(self) -> str:
-        assert self._mf_system_schema, "Must set _mf_system_schema before use!"
-        return self._mf_system_schema
 
     @property
     @override
@@ -85,7 +77,6 @@ class FakeCLIContext(CLIContext):
 def cli_context(  # noqa: D
     sql_client: SqlClient,
     simple_semantic_manifest: SemanticManifest,
-    mf_test_session_state: MetricFlowTestSessionState,
     create_source_tables: bool,
 ) -> Generator[CLIContext, None, None]:
     semantic_manifest_lookup = SemanticManifestLookup(simple_semantic_manifest)
@@ -100,7 +91,6 @@ def cli_context(  # noqa: D
     context._sql_client = sql_client
     context._semantic_manifest = simple_semantic_manifest
     context._semantic_manifest_lookup = semantic_manifest_lookup
-    context._mf_system_schema = mf_test_session_state.mf_system_schema
     with tempfile.NamedTemporaryFile() as file:
         context._log_file_path = pathlib.Path(file.name)
         yield context

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -94,7 +94,6 @@ def cli_context(  # noqa: D
         sql_client=sql_client,
         column_association_resolver=DunderColumnAssociationResolver(semantic_manifest_lookup=semantic_manifest_lookup),
         time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
-        system_schema=mf_test_session_state.mf_system_schema,
     )
     context = FakeCLIContext()
     context._mf = mf_engine

--- a/metricflow/test/integration/conftest.py
+++ b/metricflow/test/integration/conftest.py
@@ -40,7 +40,6 @@ def it_helpers(  # noqa: D
                 semantic_manifest_lookup=simple_semantic_manifest_lookup
             ),
             time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
-            system_schema=mf_test_session_state.mf_system_schema,
         ),
         mf_system_schema=mf_test_session_state.mf_system_schema,
         source_schema=mf_test_session_state.mf_source_schema,

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -234,7 +234,6 @@ def test_case(
         sql_client=sql_client,
         column_association_resolver=DunderColumnAssociationResolver(semantic_manifest_lookup),
         time_source=ConfigurableTimeSource(as_datetime("2021-01-04")),
-        system_schema=mf_test_session_state.mf_system_schema,
     )
 
     check_query_helpers = CheckQueryHelpers(sql_client)

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -234,7 +234,6 @@ def test_build_metric_tasks(  # noqa: D
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
         manifest=data_warehouse_validation_model,
-        system_schema=mf_test_session_state.mf_system_schema,
         sql_client=sql_client,
     )
     assert len(tasks) == 1

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -43,22 +43,14 @@ def dw_backed_warehouse_validation_model(
 
 
 def test_build_semantic_model_tasks(  # noqa:D
-    mf_test_session_state: MetricFlowTestSessionState,
     data_warehouse_validation_model: PydanticSemanticManifest,
-    sql_client: SqlClient,
 ) -> None:
-    tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(
-        manifest=data_warehouse_validation_model,
-        sql_client=sql_client,
-        system_schema=mf_test_session_state.mf_system_schema,
-    )
+    tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(manifest=data_warehouse_validation_model)
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
 
 def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     def good_query() -> Tuple[str, SqlBindParameters]:
         return ("SELECT 'foo' AS foo", SqlBindParameters())
@@ -90,9 +82,7 @@ def test_validate_semantic_models(  # noqa: D
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     issues = dw_validator.validate_semantic_models(model)
     assert len(issues.all_issues) == 0
@@ -113,12 +103,10 @@ def test_validate_semantic_models(  # noqa: D
 def test_build_dimension_tasks(  # noqa: D
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
         manifest=data_warehouse_validation_model,
         sql_client=sql_client,
-        system_schema=mf_test_session_state.mf_system_schema,
     )
     # on semantic model query with all dimensions
     assert len(tasks) == 1
@@ -133,9 +121,7 @@ def test_validate_dimensions(  # noqa: D
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     issues = dw_validator.validate_dimensions(model)
     assert len(issues.all_issues) == 0
@@ -153,12 +139,10 @@ def test_validate_dimensions(  # noqa: D
 def test_build_entities_tasks(  # noqa: D
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_entity_tasks(
         manifest=data_warehouse_validation_model,
         sql_client=sql_client,
-        system_schema=mf_test_session_state.mf_system_schema,
     )
     assert len(tasks) == 1  # on semantic model query with all entities
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each entity on the semantic model
@@ -171,9 +155,7 @@ def test_validate_entities(  # noqa: D
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     issues = dw_validator.validate_entities(model)
     assert len(issues.all_issues) == 0
@@ -191,12 +173,10 @@ def test_validate_entities(  # noqa: D
 def test_build_measure_tasks(  # noqa: D
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
         manifest=data_warehouse_validation_model,
         sql_client=sql_client,
-        system_schema=mf_test_session_state.mf_system_schema,
     )
     assert len(tasks) == 1  # on semantic model query with all measures
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each measure on the semantic model
@@ -209,9 +189,7 @@ def test_validate_measures(  # noqa: D
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     issues = dw_validator.validate_measures(model)
     assert len(issues.all_issues) == 0
@@ -258,9 +236,7 @@ def test_validate_metrics(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     issues = dw_validator.validate_metrics(model)
     assert len(issues.all_issues) == 0
@@ -280,9 +256,7 @@ def test_validate_metrics(  # noqa: D
     model = PydanticSemanticManifestTransformer.transform(model)
 
     # Validate new metric created by proxy causes an issue (because the column used doesn't exist)
-    dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
-    )
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
     issues = dw_validator.validate_metrics(model)
     assert len(issues.all_issues) == 1
     assert len(issues.errors) == 1


### PR DESCRIPTION
The schema property for the MetricFlowEngine was no longer used
in any way. This PR removes it from the engine and from all affected
callers, and cleans out the surrounding parameters used solely as
inputs.