### PR TITLE
Clean up output of various list dimensions commands

### DIFF
--- a/.changes/unreleased/Fixes-20230802-162013.yaml
+++ b/.changes/unreleased/Fixes-20230802-162013.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Clean up list dimensions outputs
+time: 2023-08-02T16:20:13.623566-06:00
+custom:
+  Author: tlento
+  Issue: None

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -390,9 +390,7 @@ def metrics(cfg: CLIContext, show_all_dimensions: bool = False, search: Optional
     num_dims_to_show = MAX_LIST_OBJECT_ELEMENTS
     for m in metrics:
         # sort dimensions by whether they're local first(if / then global else local) then the dim name
-        dimensions = sorted(map(lambda d: d.name, filter(lambda d: "/" not in d.name, m.dimensions))) + sorted(
-            map(lambda d: d.name, filter(lambda d: "/" in d.name, m.dimensions))
-        )
+        dimensions = sorted([dimension.granularity_free_qualified_name for dimension in m.dimensions])
         if show_all_dimensions:
             num_dims_to_show = len(dimensions)
         click.echo(
@@ -424,8 +422,8 @@ def dimensions(cfg: CLIContext, metrics: List[str]) -> None:
         spinner.fail("List of dimensions unavailable.")
 
     spinner.succeed(f"🌱 We've found {len(dimensions)} common dimensions for metrics {metrics}.")
-    for d in dimensions:
-        click.echo(f"• {click.style(d.name, bold=True, fg='green')}")
+    for dimension in dimensions:
+        click.echo(f"• {click.style(dimension.granularity_free_qualified_name, bold=True, fg='green')}")
 
 
 @list.command()

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -611,7 +611,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         # and no other extraneous output columns
         dim_vals = result_dataframe[result_dataframe.columns[~result_dataframe.columns.isin(metric_names)]].iloc[:, 0]
 
-        return [str(val) for val in dim_vals]
+        return sorted([str(val) for val in dim_vals])
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def explain_get_dimension_values(  # noqa: D

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -19,6 +19,7 @@ from dbt_semantic_interfaces.transformations.add_input_metric_measures import Ad
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
 from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
+from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.specs.specs import DimensionSpec
 
 
@@ -87,6 +88,22 @@ class Dimension:
             is_partition=pydantic_dimension.is_partition,
             expr=pydantic_dimension.expr,
         )
+
+    @property
+    def granularity_free_qualified_name(self) -> str:
+        """Renders the qualified name without the granularity suffix.
+
+        In the list metrics and list dimensions outputs we want to render the qualified name of the dimension, but
+        without including the base granularity for time dimensions. This method is useful in those contexts.
+
+        Note: in most cases you should be using the qualified_name - this is only useful in cases where the
+        Dimension set has de-duplicated TimeDimensions such that you never have more than one granularity
+        in your set for each TimeDimension.
+        """
+        parsed_name = StructuredLinkableSpecName.from_name(qualified_name=self.qualified_name)
+        return StructuredLinkableSpecName(
+            entity_link_names=parsed_name.entity_link_names, element_name=self.name
+        ).qualified_name
 
 
 @dataclass(frozen=True)

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -52,7 +52,7 @@ def test_list_metrics(capsys: pytest.CaptureFixture, cli_runner: MetricFlowCliRu
     with capsys.disabled():
         resp = cli_runner.run(metrics)
 
-    assert "bookings_per_listing: capacity_latest" in resp.output
+    assert "bookings_per_listing: listing__capacity_latest" in resp.output
     assert resp.exit_code == 0
 
 


### PR DESCRIPTION
There were a handful of rough edges in the list dimensions outputs.

1. list dimension-values was returning an unsorted set, which is cumbersome
with large outputs.
2. list metrics and list dimensions was not returning the queryable qualified names