### PR TITLE
Update Pandas dependency to 1.5.x

### DIFF
--- a/.changes/unreleased/Dependencies-20230810-112855.yaml
+++ b/.changes/unreleased/Dependencies-20230810-112855.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update pandas to 1.5.x
+time: 2023-08-10T11:28:55.086363-07:00
+custom:
+  Author: tlento
+  PR: "719"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jsonschema==3.2.0",
   "more-itertools==8.10.0",
   "numpy>=1.22.2",
-  "pandas~=1.3.0",
+  "pandas~=1.5.0",
   "pydantic~=1.10.0",
   "python-dateutil==2.8.2",
   "rapidfuzz==3.0.0",


### PR DESCRIPTION
Our CI jobs were taking forever due to needing to build an old version
of pandas from source for Python 3.11. This updates the dependency to
1.5.x, which allows us to use versions that should have updated
pre-built wheels available.