### PR TITLE
Render date literals as strings in time range filters

### DIFF
--- a/.changes/unreleased/Fixes-20230814-231516.yaml
+++ b/.changes/unreleased/Fixes-20230814-231516.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove barrier to partition pruning certain time partition filter predicates
+time: 2023-08-14T23:15:16.658262-07:00
+custom:
+  Author: tlento
+  Issue: "712"

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -83,7 +83,6 @@ from metricflow.sql.optimizer.optimization_levels import (
 )
 from metricflow.sql.sql_exprs import (
     SqlBetweenExpression,
-    SqlCastToTimestampExpression,
     SqlColumnReference,
     SqlColumnReferenceExpression,
     SqlDateTruncExpression,
@@ -124,15 +123,11 @@ def _make_time_range_comparison_expr(
                 column_name=column_alias,
             )
         ),
-        start_expr=SqlCastToTimestampExpression(
-            arg=SqlStringLiteralExpression(
-                literal_value=time_range_constraint.start_time.strftime(ISO8601_PYTHON_FORMAT),
-            )
+        start_expr=SqlStringLiteralExpression(
+            literal_value=time_range_constraint.start_time.strftime(ISO8601_PYTHON_FORMAT),
         ),
-        end_expr=SqlCastToTimestampExpression(
-            arg=SqlStringLiteralExpression(
-                literal_value=time_range_constraint.end_time.strftime(ISO8601_PYTHON_FORMAT),
-            )
+        end_expr=SqlStringLiteralExpression(
+            literal_value=time_range_constraint.end_time.strftime(ISO8601_PYTHON_FORMAT),
         ),
     )
 

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-02' AS DATETIME)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-02' AS DATETIME)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC(created_at, month) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC(created_at, month) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2021-01-01' AS DATETIME)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
@@ -74,4 +74,4 @@ FROM (
     ) subq_0
   ) subq_1
 ) subq_2
-WHERE subq_2.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE subq_2.metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0_optimized.sql
@@ -8,4 +8,4 @@ SELECT
   , ds AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-02' AS TIMESTAMP)
+WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -74,7 +74,7 @@ FROM (
           FROM ***************************.fct_revenue revenue_src_10006
         ) subq_0
       ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
     ) subq_2
   ) subq_4
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6
-  WHERE subq_6.ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE subq_6.ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_5
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2021-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2021-01-01'
 ) subq_12
 INNER JOIN (
   -- Compute Metrics via Expressions

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
@@ -191,7 +191,7 @@ FROM (
             FROM ***************************.fct_bookings bookings_source_src_10001
           ) subq_0
         ) subq_1
-        WHERE subq_1.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_1.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_2
     ) subq_3
   ) subq_4
@@ -327,7 +327,7 @@ CROSS JOIN (
             FROM ***************************.dim_listings_latest listings_latest_src_10004
           ) subq_6
         ) subq_7
-        WHERE subq_7.metric_time__day BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+        WHERE subq_7.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
       ) subq_8
     ) subq_9
   ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23


### PR DESCRIPTION
MetricFlow's rendering has historically cast date literals to
the underlying engine type in date range comparison filters, so
if a user passed in a start_time of 2021-01-01 and an end_time
of 2021-01-31 we would render something like:

`WHERE ds BETWEEN CAST('2021-01-01' AS TIMESTAMP) AND CAST('2021-01-31' AS TIMESTAMP)`

This turns out to cause problems with time partition columns, because
they typically only apply pruning to literal predicates - any value
processed by a CAST function prevents pruning from kicking in, as the
engine takes the appropriately conservative approach of doing full
row-by-row comparisons between the cast output and the partition value.

In researching this issue two things became clear:

1. We need a holistic answer to ensuring engines apply partition
pruning, one which is beyond the scope of this change.
2. We can solve part of the problem by removing the CAST call
in time range filters based on literal value inputs.

It turns out every engine we support does implicit type coercion
between string values and date/time types. This means we don't have
to care what the appropriate time type column might be in this case,
because the standard behavior is to simply do the comparison correctly
regardless of underlying partition column type.

This change simple removes the CAST calls from this particular rendering
block, which should enable users to at least run queries that will do
some level of pruning, even if the solution is incomplete with respect
to the types of time partition columns it can address.

Note that we assume all engines accept and convert from ISO-standard
date strings, but this is not a change from the prior behavior, which
assumed the same thing but wrapped it in a CAST function call.