### PR TITLE
Fix click bug with mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "Jinja2>=2.11.3",
   "MarkupSafe==2.0.1",
   "PyYAML~=6.0",
-  "click>=7.1.2, <8.1.4",
+  "click>=7.1.2",
   "dbt-core~=1.6.0",
   "dbt-semantic-interfaces~=0.2.0",
   "graphviz==0.18.2",
@@ -58,6 +58,8 @@ mf = 'metricflow.cli.main:cli'
 dev-packages = [
   "mypy~=1.3.0",
   "pre-commit~=3.2.2",
+  # Bug with mypy: https://github.com/pallets/click/issues/2558#issuecomment-1656546003
+  "click>=8.1.6",
   "pytest-mock~=3.7.0",
   "pytest-xdist~=3.2.1",
   "pytest~=7.1.1",


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Earlier, all the mypy checks broke when click upgraded to `8.1.4`. This caused us to restrict the version to a lower version. Now, that fix is out on `8.1.6` (info here https://github.com/pallets/click/issues/2558). So reverting the version restriction and setting the restriction for mypy use only in the dev dependencies.