### PR TITLE
Modified dimensions_for_metric to allow for returning more details

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -204,7 +204,9 @@ class AbstractMetricFlowEngine(ABC):
         pass
 
     @abstractmethod
-    def simple_dimensions_for_metrics(self, metric_names: List[str]) -> List[Dimension]:
+    def simple_dimensions_for_metrics(
+        self, metric_names: List[str], without_any_property: Sequence[LinkableElementProperties]
+    ) -> List[Dimension]:
         """Retrieves a list of all common dimensions for metric_names.
 
         "simple" dimensions are the ones that people expect from a UI perspective. For example, if "ds" is a time
@@ -212,6 +214,7 @@ class AbstractMetricFlowEngine(ABC):
 
         Args:
             metric_names: Names of metrics to get common dimensions from.
+            without_any_property: Return dimensions not matching these properties.
 
         Returns:
             A list of Dimension objects containing metadata.
@@ -468,17 +471,19 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def explain(self, mf_request: MetricFlowQueryRequest) -> MetricFlowExplainResult:  # noqa: D
         return self._create_execution_plan(mf_request)
 
-    def simple_dimensions_for_metrics(self, metric_names: List[str]) -> List[Dimension]:  # noqa: D
+    def simple_dimensions_for_metrics(  # noqa: D
+        self,
+        metric_names: List[str],
+        without_any_property: Sequence[LinkableElementProperties] = (
+            LinkableElementProperties.ENTITY,
+            LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+            LinkableElementProperties.LOCAL_LINKED,
+        ),
+    ) -> List[Dimension]:
         path_key_to_linkable_dimensions = (
             self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
                 metric_references=[MetricReference(element_name=mname) for mname in metric_names],
-                without_any_property=frozenset(
-                    {
-                        LinkableElementProperties.ENTITY,
-                        LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-                        LinkableElementProperties.LOCAL_LINKED,
-                    }
-                ),
+                without_any_property=frozenset(without_any_property),
             )
         ).path_key_to_linkable_dimensions
 

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
+from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimensionTypeParams
 from dbt_semantic_interfaces.protocols.dimension import (
     Dimension as SemanticManifestDimension,
 )
@@ -78,12 +79,18 @@ class Dimension:
             element_name=path_key.element_name,
             entity_links=path_key.entity_links,
         ).qualified_name
+        parsed_type_params: Optional[DimensionTypeParams] = None
+        if pydantic_dimension.type_params:
+            parsed_type_params = PydanticDimensionTypeParams(
+                time_granularity=path_key.time_granularity,
+                validity_params=pydantic_dimension.type_params.validity_params,
+            )
         return cls(
             name=pydantic_dimension.name,
             qualified_name=qualified_name,
             description=pydantic_dimension.description,
             type=pydantic_dimension.type,
-            type_params=pydantic_dimension.type_params,
+            type_params=parsed_type_params,
             metadata=pydantic_dimension.metadata,
             is_partition=pydantic_dimension.is_partition,
             expr=pydantic_dimension.expr,


### PR DESCRIPTION
## Context
We want a way to return a list of dimensions while showing the available granularities for time dimensions. Currently, we filter dimensions with `LinkableElementProperties.DERIVED_TIME_GRANULARITY` property and that is generally the behaviour we want where we're just returning unique dimensions. With this change, one can request dimensions with that property and it would return dimensions where each row may repeat but has a different granularity.  Ie., something like this,
```
Dimension("ordered_at", time_granularity="day")
Dimension("ordered_at", time_granularity="month")
Dimension("ordered_at", time_granularity="quarter")
Dimension("ordered_at", time_granularity="year")
Dimension("customer_type", time_granularity=None)
...
```