### PR TITLE
Use year instead of isoyear for BigQuery date_trunc operations

### DIFF
--- a/.changes/unreleased/Fixes-20230830-154233.yaml
+++ b/.changes/unreleased/Fixes-20230830-154233.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update BigQuery YEAR granularity truncation to use January 1st instead of ISOYEAR
+  start
+time: 2023-08-30T15:42:33.979853-07:00
+custom:
+  Author: tlento
+  Issue: "755"

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -121,7 +121,7 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
         arg_rendered = self.render_sql_expr(node.arg)
 
         prefix = ""
-        if node.time_granularity in (TimeGranularity.WEEK, TimeGranularity.YEAR):
+        if node.time_granularity == TimeGranularity.WEEK:
             prefix = "iso"
 
         return SqlExpressionRenderResult(
@@ -131,11 +131,11 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
     @override
     def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:
-        """Render time delta for BigQuery, which requires ISO prefixing on granularity values."""
+        """Render time delta for BigQuery, which requires ISO prefixing for the WEEK granularity value."""
         column = node.arg.accept(self)
         if node.grain_to_date:
             granularity = node.granularity
-            if granularity == TimeGranularity.WEEK or granularity == TimeGranularity.YEAR:
+            if granularity == TimeGranularity.WEEK:
                 granularity_value = "ISO" + granularity.value.upper()
             else:
                 granularity_value = granularity.value

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_query_semantic_model__plan0.sql
@@ -5,12 +5,12 @@ SELECT
   , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
   , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
   , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-  , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+  , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
   , revenue_src_10006.created_at AS company__ds__day
   , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
   , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
   , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-  , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+  , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
   , revenue_src_10006.user_id AS user
   , revenue_src_10006.user_id AS company__user
 FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -5,23 +5,23 @@ SELECT
   , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
   , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
   , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
-  , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS ds__year
+  , DATE_TRUNC(id_verifications_src_10003.ds, year) AS ds__year
   , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
-  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS ds_partitioned__year
+  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, year) AS ds_partitioned__year
   , id_verifications_src_10003.verification_type
   , id_verifications_src_10003.ds AS verification__ds__day
   , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
   , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
   , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
-  , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS verification__ds__year
+  , DATE_TRUNC(id_verifications_src_10003.ds, year) AS verification__ds__year
   , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter
-  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS verification__ds_partitioned__year
+  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, year) AS verification__ds_partitioned__year
   , id_verifications_src_10003.verification_type AS verification__verification_type
   , id_verifications_src_10003.verification_id AS verification
   , id_verifications_src_10003.user_id AS user

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -4,13 +4,13 @@ SELECT
   , DATE_TRUNC(users_latest_src_10008.ds, isoweek) AS ds__week
   , DATE_TRUNC(users_latest_src_10008.ds, month) AS ds__month
   , DATE_TRUNC(users_latest_src_10008.ds, quarter) AS ds__quarter
-  , DATE_TRUNC(users_latest_src_10008.ds, isoyear) AS ds__year
+  , DATE_TRUNC(users_latest_src_10008.ds, year) AS ds__year
   , users_latest_src_10008.home_state_latest
   , users_latest_src_10008.ds AS user__ds__day
   , DATE_TRUNC(users_latest_src_10008.ds, isoweek) AS user__ds__week
   , DATE_TRUNC(users_latest_src_10008.ds, month) AS user__ds__month
   , DATE_TRUNC(users_latest_src_10008.ds, quarter) AS user__ds__quarter
-  , DATE_TRUNC(users_latest_src_10008.ds, isoyear) AS user__ds__year
+  , DATE_TRUNC(users_latest_src_10008.ds, year) AS user__ds__year
   , users_latest_src_10008.home_state_latest AS user__home_state_latest
   , users_latest_src_10008.user_id AS user
 FROM ***************************.dim_users_latest users_latest_src_10008

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
@@ -100,33 +100,33 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
@@ -238,33 +238,33 @@ FULL OUTER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
@@ -43,33 +43,33 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
           , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
           , bookings_source_src_10001.paid_at AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
           , bookings_source_src_10001.is_instant AS booking__is_instant
           , bookings_source_src_10001.ds AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
           , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
           , bookings_source_src_10001.paid_at AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
@@ -95,12 +95,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
           , listings_latest_src_10004.created_at AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
@@ -108,12 +108,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
           , listings_latest_src_10004.created_at AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
           , listings_latest_src_10004.country AS listing__country_latest
           , listings_latest_src_10004.is_lux AS listing__is_lux_latest
           , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -124,33 +124,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -217,12 +217,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                   , listings_latest_src_10004.created_at AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
@@ -230,12 +230,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                   , listings_latest_src_10004.created_at AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                   , listings_latest_src_10004.country AS listing__country_latest
                   , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                   , listings_latest_src_10004.capacity AS listing__capacity_latest
@@ -329,22 +329,22 @@ FROM (
                   , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS ds__week
                   , DATE_TRUNC(views_source_src_10009.ds, month) AS ds__month
                   , DATE_TRUNC(views_source_src_10009.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(views_source_src_10009.ds, year) AS ds__year
                   , views_source_src_10009.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, year) AS ds_partitioned__year
                   , views_source_src_10009.ds AS view__ds__day
                   , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS view__ds__week
                   , DATE_TRUNC(views_source_src_10009.ds, month) AS view__ds__month
                   , DATE_TRUNC(views_source_src_10009.ds, quarter) AS view__ds__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS view__ds__year
+                  , DATE_TRUNC(views_source_src_10009.ds, year) AS view__ds__year
                   , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS view__ds_partitioned__week
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS view__ds_partitioned__month
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS view__ds_partitioned__quarter
-                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS view__ds_partitioned__year
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, year) AS view__ds_partitioned__year
                   , views_source_src_10009.listing_id AS listing
                   , views_source_src_10009.user_id AS user
                   , views_source_src_10009.listing_id AS view__listing
@@ -409,12 +409,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                   , listings_latest_src_10004.created_at AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
@@ -422,12 +422,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                   , listings_latest_src_10004.created_at AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                   , listings_latest_src_10004.country AS listing__country_latest
                   , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                   , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -46,33 +46,33 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
           , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
           , bookings_source_src_10001.paid_at AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
           , bookings_source_src_10001.is_instant AS booking__is_instant
           , bookings_source_src_10001.ds AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
           , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
           , bookings_source_src_10001.paid_at AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
@@ -98,12 +98,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
           , listings_latest_src_10004.created_at AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
@@ -111,12 +111,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
           , listings_latest_src_10004.created_at AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
           , listings_latest_src_10004.country AS listing__country_latest
           , listings_latest_src_10004.is_lux AS listing__is_lux_latest
           , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
@@ -43,33 +43,33 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
           , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
           , bookings_source_src_10001.paid_at AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
           , bookings_source_src_10001.is_instant AS booking__is_instant
           , bookings_source_src_10001.ds AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
           , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
           , bookings_source_src_10001.paid_at AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host
@@ -95,12 +95,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
           , listings_latest_src_10004.created_at AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
@@ -108,12 +108,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
           , listings_latest_src_10004.created_at AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
           , listings_latest_src_10004.country AS listing__country_latest
           , listings_latest_src_10004.is_lux AS listing__is_lux_latest
           , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
@@ -37,33 +37,33 @@ FROM (
         , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
         , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
         , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+        , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
         , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
         , bookings_source_src_10001.paid_at AS paid_at__day
         , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
         , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
         , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-        , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+        , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
         , bookings_source_src_10001.is_instant AS booking__is_instant
         , bookings_source_src_10001.ds AS booking__ds__day
         , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
         , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
         , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+        , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
         , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
         , bookings_source_src_10001.paid_at AS booking__paid_at__day
         , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
         , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
         , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-        , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+        , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
         , bookings_source_src_10001.listing_id AS listing
         , bookings_source_src_10001.guest_id AS guest
         , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric__plan0.sql
@@ -42,12 +42,12 @@ FROM (
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
           , revenue_src_10006.created_at AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
           , revenue_src_10006.user_id AS user
           , revenue_src_10006.user_id AS company__user
         FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_grain_to_date__plan0.sql
@@ -42,12 +42,12 @@ FROM (
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
           , revenue_src_10006.created_at AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
           , revenue_src_10006.user_id AS user
           , revenue_src_10006.user_id AS company__user
         FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
@@ -39,12 +39,12 @@ FROM (
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
           , revenue_src_10006.created_at AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
           , revenue_src_10006.user_id AS user
           , revenue_src_10006.user_id AS company__user
         FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window__plan0.sql
@@ -42,12 +42,12 @@ FROM (
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
           , revenue_src_10006.created_at AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+          , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
           , revenue_src_10006.user_id AS user
           , revenue_src_10006.user_id AS company__user
         FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -63,12 +63,12 @@ FROM (
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+            , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
             , revenue_src_10006.created_at AS company__ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+            , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
             , revenue_src_10006.user_id AS user
             , revenue_src_10006.user_id AS company__user
           FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -63,12 +63,12 @@ FROM (
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+            , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
             , revenue_src_10006.created_at AS company__ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS company__ds__year
+            , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
             , revenue_src_10006.user_id AS user
             , revenue_src_10006.user_id AS company__user
           FROM ***************************.fct_revenue revenue_src_10006

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
@@ -105,33 +105,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -243,33 +243,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -105,33 +105,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -304,33 +304,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -105,33 +105,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -304,33 +304,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -105,33 +105,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -304,33 +304,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -105,33 +105,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -304,33 +304,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -166,33 +166,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
@@ -368,33 +368,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -27,7 +27,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC(subq_2.metric_time__day, isoyear) AS metric_time__year
+            DATE_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -166,33 +166,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host
@@ -204,7 +204,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC(subq_2.metric_time__day, month) = subq_1.metric_time__day
-          WHERE DATE_TRUNC(subq_2.metric_time__day, isoyear) = subq_2.metric_time__day
+          WHERE DATE_TRUNC(subq_2.metric_time__day, year) = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -230,7 +230,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC(subq_10.metric_time__day, isoyear) AS metric_time__year
+            DATE_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -369,33 +369,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC(subq_20.ds, isoyear) AS metric_time__year
+      DATE_TRUNC(subq_20.ds, year) AS metric_time__year
       , SUM(subq_18.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
     INNER JOIN (
@@ -28,7 +28,7 @@ FROM (
     ) subq_18
     ON
       DATE_TRUNC(subq_20.ds, month) = subq_18.metric_time__day
-    WHERE DATE_TRUNC(subq_20.ds, isoyear) = subq_20.ds
+    WHERE DATE_TRUNC(subq_20.ds, year) = subq_20.ds
     GROUP BY
       metric_time__year
   ) subq_24
@@ -39,7 +39,7 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC(subq_28.ds, isoyear) AS metric_time__year
+      DATE_TRUNC(subq_28.ds, year) AS metric_time__year
       , SUM(subq_26.bookings) AS bookings_1_month_ago
     FROM ***************************.mf_time_spine subq_28
     INNER JOIN (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_one_input_metric__plan0.sql
@@ -110,33 +110,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -225,33 +225,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -160,33 +160,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
@@ -115,33 +115,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -208,12 +208,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                   , listings_latest_src_10004.created_at AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
@@ -221,12 +221,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                   , listings_latest_src_10004.created_at AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                   , listings_latest_src_10004.country AS listing__country_latest
                   , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                   , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
@@ -24,33 +24,33 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
     , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
     , bookings_source_src_10001.paid_at AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
     , bookings_source_src_10001.is_instant AS booking__is_instant
     , bookings_source_src_10001.ds AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
     , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
     , bookings_source_src_10001.paid_at AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
@@ -30,33 +30,33 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
       , bookings_source_src_10001.paid_at AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
       , bookings_source_src_10001.is_instant AS booking__is_instant
       , bookings_source_src_10001.ds AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
       , bookings_source_src_10001.paid_at AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -121,33 +121,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -214,12 +214,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                   , listings_latest_src_10004.created_at AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
@@ -227,12 +227,12 @@ FROM (
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                   , listings_latest_src_10004.created_at AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                   , listings_latest_src_10004.country AS listing__country_latest
                   , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                   , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
@@ -109,33 +109,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10015.ds, year) AS ds__year
                   , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10015.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS paid_at__year
                   , bookings_source_src_10015.is_instant AS booking__is_instant
                   , bookings_source_src_10015.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10015.ds, year) AS booking__ds__year
                   , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10015.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10015.listing_id AS listing
                   , bookings_source_src_10015.guest_id AS guest
                   , bookings_source_src_10015.host_id AS host
@@ -163,12 +163,12 @@ FROM (
                 , DATE_TRUNC(listings_src_10017.active_from, isoweek) AS window_start__week
                 , DATE_TRUNC(listings_src_10017.active_from, month) AS window_start__month
                 , DATE_TRUNC(listings_src_10017.active_from, quarter) AS window_start__quarter
-                , DATE_TRUNC(listings_src_10017.active_from, isoyear) AS window_start__year
+                , DATE_TRUNC(listings_src_10017.active_from, year) AS window_start__year
                 , listings_src_10017.active_to AS window_end__day
                 , DATE_TRUNC(listings_src_10017.active_to, isoweek) AS window_end__week
                 , DATE_TRUNC(listings_src_10017.active_to, month) AS window_end__month
                 , DATE_TRUNC(listings_src_10017.active_to, quarter) AS window_end__quarter
-                , DATE_TRUNC(listings_src_10017.active_to, isoyear) AS window_end__year
+                , DATE_TRUNC(listings_src_10017.active_to, year) AS window_end__year
                 , listings_src_10017.country
                 , listings_src_10017.is_lux
                 , listings_src_10017.capacity
@@ -176,12 +176,12 @@ FROM (
                 , DATE_TRUNC(listings_src_10017.active_from, isoweek) AS listing__window_start__week
                 , DATE_TRUNC(listings_src_10017.active_from, month) AS listing__window_start__month
                 , DATE_TRUNC(listings_src_10017.active_from, quarter) AS listing__window_start__quarter
-                , DATE_TRUNC(listings_src_10017.active_from, isoyear) AS listing__window_start__year
+                , DATE_TRUNC(listings_src_10017.active_from, year) AS listing__window_start__year
                 , listings_src_10017.active_to AS listing__window_end__day
                 , DATE_TRUNC(listings_src_10017.active_to, isoweek) AS listing__window_end__week
                 , DATE_TRUNC(listings_src_10017.active_to, month) AS listing__window_end__month
                 , DATE_TRUNC(listings_src_10017.active_to, quarter) AS listing__window_end__quarter
-                , DATE_TRUNC(listings_src_10017.active_to, isoyear) AS listing__window_end__year
+                , DATE_TRUNC(listings_src_10017.active_to, year) AS listing__window_end__year
                 , listings_src_10017.country AS listing__country
                 , listings_src_10017.is_lux AS listing__is_lux
                 , listings_src_10017.capacity AS listing__capacity

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -110,33 +110,33 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -110,33 +110,33 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -110,33 +110,33 @@ INNER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
@@ -99,33 +99,33 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_local_dimension_using_local_entity__plan0.sql
@@ -63,12 +63,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
           , listings_latest_src_10004.created_at AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
@@ -76,12 +76,12 @@ FROM (
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
           , listings_latest_src_10004.created_at AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+          , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
           , listings_latest_src_10004.country AS listing__country_latest
           , listings_latest_src_10004.is_lux AS listing__is_lux_latest
           , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
@@ -34,33 +34,33 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
       , bookings_source_src_10001.paid_at AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
       , bookings_source_src_10001.is_instant AS booking__is_instant
       , bookings_source_src_10001.ds AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
       , bookings_source_src_10001.paid_at AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
@@ -133,33 +133,33 @@ FROM (
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                       , bookings_source_src_10001.paid_at AS paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                       , bookings_source_src_10001.is_instant AS booking__is_instant
                       , bookings_source_src_10001.ds AS booking__ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                       , bookings_source_src_10001.paid_at AS booking__paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
@@ -226,12 +226,12 @@ FROM (
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                       , listings_latest_src_10004.created_at AS created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
@@ -239,12 +239,12 @@ FROM (
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                       , listings_latest_src_10004.created_at AS listing__created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                       , listings_latest_src_10004.country AS listing__country_latest
                       , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                       , listings_latest_src_10004.capacity AS listing__capacity_latest
@@ -390,33 +390,33 @@ FROM (
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                       , bookings_source_src_10001.paid_at AS paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                       , bookings_source_src_10001.is_instant AS booking__is_instant
                       , bookings_source_src_10001.ds AS booking__ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                       , bookings_source_src_10001.paid_at AS booking__paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                       , bookings_source_src_10001.listing_id AS listing
                       , bookings_source_src_10001.guest_id AS guest
                       , bookings_source_src_10001.host_id AS host
@@ -483,12 +483,12 @@ FROM (
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
                       , listings_latest_src_10004.created_at AS created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
@@ -496,12 +496,12 @@ FROM (
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
                       , listings_latest_src_10004.created_at AS listing__created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
                       , listings_latest_src_10004.country AS listing__country_latest
                       , listings_latest_src_10004.is_lux AS listing__is_lux_latest
                       , listings_latest_src_10004.capacity AS listing__capacity_latest
@@ -630,33 +630,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
@@ -118,33 +118,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -259,33 +259,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -112,33 +112,33 @@ FROM (
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                 , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                 , bookings_source_src_10001.is_instant AS booking__is_instant
                 , bookings_source_src_10001.ds AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                 , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                 , bookings_source_src_10001.paid_at AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                 , bookings_source_src_10001.listing_id AS listing
                 , bookings_source_src_10001.guest_id AS guest
                 , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -100,33 +100,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -202,12 +202,12 @@ FROM (
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
               , listings_latest_src_10004.created_at AS created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
@@ -215,12 +215,12 @@ FROM (
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
               , listings_latest_src_10004.created_at AS listing__created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
               , listings_latest_src_10004.country AS listing__country_latest
               , listings_latest_src_10004.is_lux AS listing__is_lux_latest
               , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
@@ -99,33 +99,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10015.ds, year) AS ds__year
               , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10015.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS paid_at__year
               , bookings_source_src_10015.is_instant AS booking__is_instant
               , bookings_source_src_10015.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10015.ds, year) AS booking__ds__year
               , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10015.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10015.listing_id AS listing
               , bookings_source_src_10015.guest_id AS guest
               , bookings_source_src_10015.host_id AS host
@@ -191,12 +191,12 @@ FROM (
               , DATE_TRUNC(listings_src_10017.active_from, isoweek) AS window_start__week
               , DATE_TRUNC(listings_src_10017.active_from, month) AS window_start__month
               , DATE_TRUNC(listings_src_10017.active_from, quarter) AS window_start__quarter
-              , DATE_TRUNC(listings_src_10017.active_from, isoyear) AS window_start__year
+              , DATE_TRUNC(listings_src_10017.active_from, year) AS window_start__year
               , listings_src_10017.active_to AS window_end__day
               , DATE_TRUNC(listings_src_10017.active_to, isoweek) AS window_end__week
               , DATE_TRUNC(listings_src_10017.active_to, month) AS window_end__month
               , DATE_TRUNC(listings_src_10017.active_to, quarter) AS window_end__quarter
-              , DATE_TRUNC(listings_src_10017.active_to, isoyear) AS window_end__year
+              , DATE_TRUNC(listings_src_10017.active_to, year) AS window_end__year
               , listings_src_10017.country
               , listings_src_10017.is_lux
               , listings_src_10017.capacity
@@ -204,12 +204,12 @@ FROM (
               , DATE_TRUNC(listings_src_10017.active_from, isoweek) AS listing__window_start__week
               , DATE_TRUNC(listings_src_10017.active_from, month) AS listing__window_start__month
               , DATE_TRUNC(listings_src_10017.active_from, quarter) AS listing__window_start__quarter
-              , DATE_TRUNC(listings_src_10017.active_from, isoyear) AS listing__window_start__year
+              , DATE_TRUNC(listings_src_10017.active_from, year) AS listing__window_start__year
               , listings_src_10017.active_to AS listing__window_end__day
               , DATE_TRUNC(listings_src_10017.active_to, isoweek) AS listing__window_end__week
               , DATE_TRUNC(listings_src_10017.active_to, month) AS listing__window_end__month
               , DATE_TRUNC(listings_src_10017.active_to, quarter) AS listing__window_end__quarter
-              , DATE_TRUNC(listings_src_10017.active_to, isoyear) AS listing__window_end__year
+              , DATE_TRUNC(listings_src_10017.active_to, year) AS listing__window_end__year
               , listings_src_10017.country AS listing__country
               , listings_src_10017.is_lux AS listing__is_lux
               , listings_src_10017.capacity AS listing__capacity
@@ -254,13 +254,13 @@ FROM (
                 , DATE_TRUNC(users_latest_src_10021.ds, isoweek) AS ds__week
                 , DATE_TRUNC(users_latest_src_10021.ds, month) AS ds__month
                 , DATE_TRUNC(users_latest_src_10021.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(users_latest_src_10021.ds, isoyear) AS ds__year
+                , DATE_TRUNC(users_latest_src_10021.ds, year) AS ds__year
                 , users_latest_src_10021.home_state_latest
                 , users_latest_src_10021.ds AS user__ds__day
                 , DATE_TRUNC(users_latest_src_10021.ds, isoweek) AS user__ds__week
                 , DATE_TRUNC(users_latest_src_10021.ds, month) AS user__ds__month
                 , DATE_TRUNC(users_latest_src_10021.ds, quarter) AS user__ds__quarter
-                , DATE_TRUNC(users_latest_src_10021.ds, isoyear) AS user__ds__year
+                , DATE_TRUNC(users_latest_src_10021.ds, year) AS user__ds__year
                 , users_latest_src_10021.home_state_latest AS user__home_state_latest
                 , users_latest_src_10021.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_10021

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
@@ -99,33 +99,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10015.ds, year) AS ds__year
               , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10015.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS paid_at__year
               , bookings_source_src_10015.is_instant AS booking__is_instant
               , bookings_source_src_10015.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10015.ds, year) AS booking__ds__year
               , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10015.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10015.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10015.listing_id AS listing
               , bookings_source_src_10015.guest_id AS guest
               , bookings_source_src_10015.host_id AS host
@@ -230,23 +230,23 @@ FROM (
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, isoweek) AS window_start__week
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, month) AS window_start__month
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, quarter) AS window_start__quarter
-                , DATE_TRUNC(lux_listings_src_10019.valid_from, isoyear) AS window_start__year
+                , DATE_TRUNC(lux_listings_src_10019.valid_from, year) AS window_start__year
                 , lux_listings_src_10019.valid_to AS window_end__day
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, isoweek) AS window_end__week
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, month) AS window_end__month
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, quarter) AS window_end__quarter
-                , DATE_TRUNC(lux_listings_src_10019.valid_to, isoyear) AS window_end__year
+                , DATE_TRUNC(lux_listings_src_10019.valid_to, year) AS window_end__year
                 , lux_listings_src_10019.is_confirmed_lux
                 , lux_listings_src_10019.valid_from AS lux_listing__window_start__day
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, isoweek) AS lux_listing__window_start__week
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, month) AS lux_listing__window_start__month
                 , DATE_TRUNC(lux_listings_src_10019.valid_from, quarter) AS lux_listing__window_start__quarter
-                , DATE_TRUNC(lux_listings_src_10019.valid_from, isoyear) AS lux_listing__window_start__year
+                , DATE_TRUNC(lux_listings_src_10019.valid_from, year) AS lux_listing__window_start__year
                 , lux_listings_src_10019.valid_to AS lux_listing__window_end__day
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, isoweek) AS lux_listing__window_end__week
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, month) AS lux_listing__window_end__month
                 , DATE_TRUNC(lux_listings_src_10019.valid_to, quarter) AS lux_listing__window_end__quarter
-                , DATE_TRUNC(lux_listings_src_10019.valid_to, isoyear) AS lux_listing__window_end__year
+                , DATE_TRUNC(lux_listings_src_10019.valid_to, year) AS lux_listing__window_end__year
                 , lux_listings_src_10019.is_confirmed_lux AS lux_listing__is_confirmed_lux
                 , lux_listings_src_10019.lux_listing_id AS lux_listing
               FROM ***************************.dim_lux_listings lux_listings_src_10019

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
@@ -32,33 +32,33 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
       , bookings_source_src_10001.paid_at AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
       , bookings_source_src_10001.is_instant AS booking__is_instant
       , bookings_source_src_10001.ds AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
       , bookings_source_src_10001.paid_at AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
@@ -84,12 +84,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
       , listings_latest_src_10004.created_at AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
@@ -97,12 +97,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
       , listings_latest_src_10004.created_at AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
       , listings_latest_src_10004.country AS listing__country_latest
       , listings_latest_src_10004.is_lux AS listing__is_lux_latest
       , listings_latest_src_10004.capacity AS listing__capacity_latest
@@ -130,12 +130,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
       , listings_latest_src_10004.created_at AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
@@ -143,12 +143,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
       , listings_latest_src_10004.created_at AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
       , listings_latest_src_10004.country AS listing__country_latest
       , listings_latest_src_10004.is_lux AS listing__is_lux_latest
       , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
@@ -68,23 +68,23 @@ FROM (
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, year) AS ds_partitioned__year
               , account_month_txns_src_10010.ds AS ds__day
               , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS ds__week
               , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS ds__month
               , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS ds__year
+              , DATE_TRUNC(account_month_txns_src_10010.ds, year) AS ds__year
               , account_month_txns_src_10010.account_month
               , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS account_id__ds_partitioned__month
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
-              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS account_id__ds_partitioned__year
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, year) AS account_id__ds_partitioned__year
               , account_month_txns_src_10010.ds AS account_id__ds__day
               , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS account_id__ds__week
               , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS account_id__ds__month
               , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS account_id__ds__quarter
-              , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS account_id__ds__year
+              , DATE_TRUNC(account_month_txns_src_10010.ds, year) AS account_id__ds__year
               , account_month_txns_src_10010.account_month AS account_id__account_month
               , account_month_txns_src_10010.account_id
             FROM ***************************.account_month_txns account_month_txns_src_10010
@@ -131,13 +131,13 @@ FROM (
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, year) AS ds_partitioned__year
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
               , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, month) AS account_id__ds_partitioned__month
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
-              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoyear) AS account_id__ds_partitioned__year
+              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, year) AS account_id__ds_partitioned__year
               , bridge_table_src_10011.account_id
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
@@ -185,14 +185,14 @@ FROM (
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoyear) AS ds_partitioned__year
+                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, year) AS ds_partitioned__year
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
                 , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoweek) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, month) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, quarter) AS customer_id__ds_partitioned__quarter
-                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoyear) AS customer_id__ds_partitioned__year
+                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, year) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
             ) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -155,33 +155,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -299,12 +299,12 @@ CROSS JOIN (
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
               , listings_latest_src_10004.created_at AS created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
@@ -312,12 +312,12 @@ CROSS JOIN (
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
               , listings_latest_src_10004.created_at AS listing__created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-              , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+              , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
               , listings_latest_src_10004.country AS listing__country_latest
               , listings_latest_src_10004.is_lux AS listing__is_lux_latest
               , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
@@ -117,33 +117,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -255,33 +255,33 @@ FROM (
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , bookings_source_src_10001.ds AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , bookings_source_src_10001.paid_at AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -405,33 +405,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host
@@ -553,33 +553,33 @@ FROM (
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
               , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
               , bookings_source_src_10001.paid_at AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
               , bookings_source_src_10001.is_instant AS booking__is_instant
               , bookings_source_src_10001.ds AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
               , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
               , bookings_source_src_10001.paid_at AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
               , bookings_source_src_10001.listing_id AS listing
               , bookings_source_src_10001.guest_id AS guest
               , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
@@ -44,33 +44,33 @@ FROM (
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
           , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
           , bookings_source_src_10001.paid_at AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
           , bookings_source_src_10001.is_instant AS booking__is_instant
           , bookings_source_src_10001.ds AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+          , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
           , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
           , bookings_source_src_10001.paid_at AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-          , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
           , bookings_source_src_10001.listing_id AS listing
           , bookings_source_src_10001.guest_id AS guest
           , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
@@ -70,23 +70,23 @@ FROM (
               , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
               , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
               , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS ds__year
+              , DATE_TRUNC(id_verifications_src_10003.ds, year) AS ds__year
               , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS ds_partitioned__year
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, year) AS ds_partitioned__year
               , id_verifications_src_10003.verification_type
               , id_verifications_src_10003.ds AS verification__ds__day
               , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
               , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
               , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
-              , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS verification__ds__year
+              , DATE_TRUNC(id_verifications_src_10003.ds, year) AS verification__ds__year
               , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter
-              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS verification__ds_partitioned__year
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, year) AS verification__ds_partitioned__year
               , id_verifications_src_10003.verification_type AS verification__verification_type
               , id_verifications_src_10003.verification_id AS verification
               , id_verifications_src_10003.user_id AS user
@@ -109,33 +109,33 @@ FROM (
             , DATE_TRUNC(users_ds_source_src_10007.ds, isoweek) AS ds__week
             , DATE_TRUNC(users_ds_source_src_10007.ds, month) AS ds__month
             , DATE_TRUNC(users_ds_source_src_10007.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.ds, isoyear) AS ds__year
+            , DATE_TRUNC(users_ds_source_src_10007.ds, year) AS ds__year
             , users_ds_source_src_10007.created_at AS created_at__day
             , DATE_TRUNC(users_ds_source_src_10007.created_at, isoweek) AS created_at__week
             , DATE_TRUNC(users_ds_source_src_10007.created_at, month) AS created_at__month
             , DATE_TRUNC(users_ds_source_src_10007.created_at, quarter) AS created_at__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.created_at, isoyear) AS created_at__year
+            , DATE_TRUNC(users_ds_source_src_10007.created_at, year) AS created_at__year
             , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, year) AS ds_partitioned__year
             , users_ds_source_src_10007.home_state
             , users_ds_source_src_10007.ds AS user__ds__day
             , DATE_TRUNC(users_ds_source_src_10007.ds, isoweek) AS user__ds__week
             , DATE_TRUNC(users_ds_source_src_10007.ds, month) AS user__ds__month
             , DATE_TRUNC(users_ds_source_src_10007.ds, quarter) AS user__ds__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.ds, isoyear) AS user__ds__year
+            , DATE_TRUNC(users_ds_source_src_10007.ds, year) AS user__ds__year
             , users_ds_source_src_10007.created_at AS user__created_at__day
             , DATE_TRUNC(users_ds_source_src_10007.created_at, isoweek) AS user__created_at__week
             , DATE_TRUNC(users_ds_source_src_10007.created_at, month) AS user__created_at__month
             , DATE_TRUNC(users_ds_source_src_10007.created_at, quarter) AS user__created_at__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.created_at, isoyear) AS user__created_at__year
+            , DATE_TRUNC(users_ds_source_src_10007.created_at, year) AS user__created_at__year
             , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoweek) AS user__ds_partitioned__week
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, month) AS user__ds_partitioned__month
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, quarter) AS user__ds_partitioned__quarter
-            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoyear) AS user__ds_partitioned__year
+            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, year) AS user__ds_partitioned__year
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
     , accounts_source_src_10000.account_type
     , accounts_source_src_10000.ds AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
     , accounts_source_src_10000.account_type AS account__account_type
     , accounts_source_src_10000.user_id AS user
     , accounts_source_src_10000.user_id AS account__user
@@ -53,13 +53,13 @@ INNER JOIN (
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
       , accounts_source_src_10000.account_type
       , accounts_source_src_10000.ds AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
       , accounts_source_src_10000.account_type AS account__account_type
       , accounts_source_src_10000.user_id AS user
       , accounts_source_src_10000.user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0_optimized.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , DATE_TRUNC(ds, year) AS ds__year
     , account_type
     , ds AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(ds, year) AS account__ds__year
     , account_type AS account__account_type
     , user_id AS user
     , user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
     , accounts_source_src_10000.account_type
     , accounts_source_src_10000.ds AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
     , accounts_source_src_10000.account_type AS account__account_type
     , accounts_source_src_10000.user_id AS user
     , accounts_source_src_10000.user_id AS account__user
@@ -54,13 +54,13 @@ INNER JOIN (
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
       , accounts_source_src_10000.account_type
       , accounts_source_src_10000.ds AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
       , accounts_source_src_10000.account_type AS account__account_type
       , accounts_source_src_10000.user_id AS user
       , accounts_source_src_10000.user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , DATE_TRUNC(ds, year) AS ds__year
     , account_type
     , ds AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(ds, year) AS account__ds__year
     , account_type AS account__account_type
     , user_id AS user
     , user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
     , accounts_source_src_10000.account_type
     , accounts_source_src_10000.ds AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
     , accounts_source_src_10000.account_type AS account__account_type
     , accounts_source_src_10000.user_id AS user
     , accounts_source_src_10000.user_id AS account__user
@@ -54,13 +54,13 @@ INNER JOIN (
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS ds__year
       , accounts_source_src_10000.account_type
       , accounts_source_src_10000.ds AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
-      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS account__ds__year
+      , DATE_TRUNC(accounts_source_src_10000.ds, year) AS account__ds__year
       , accounts_source_src_10000.account_type AS account__account_type
       , accounts_source_src_10000.user_id AS user
       , accounts_source_src_10000.user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -27,13 +27,13 @@ FROM (
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , DATE_TRUNC(ds, year) AS ds__year
     , account_type
     , ds AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
-    , DATE_TRUNC(ds, isoyear) AS account__ds__year
+    , DATE_TRUNC(ds, year) AS account__ds__year
     , account_type AS account__account_type
     , user_id AS user
     , user_id AS account__user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
@@ -30,33 +30,33 @@ FROM (
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
       , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
       , bookings_source_src_10001.paid_at AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
       , bookings_source_src_10001.is_instant AS booking__is_instant
       , bookings_source_src_10001.ds AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+      , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
       , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
       , bookings_source_src_10001.paid_at AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-      , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
       , bookings_source_src_10001.listing_id AS listing
       , bookings_source_src_10001.guest_id AS guest
       , bookings_source_src_10001.host_id AS host
@@ -82,12 +82,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS ds__year
       , listings_latest_src_10004.created_at AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS created_at__year
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
@@ -95,12 +95,12 @@ LEFT OUTER JOIN (
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__ds__year
       , listings_latest_src_10004.created_at AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+      , DATE_TRUNC(listings_latest_src_10004.created_at, year) AS listing__created_at__year
       , listings_latest_src_10004.country AS listing__country_latest
       , listings_latest_src_10004.is_lux AS listing__is_lux_latest
       , listings_latest_src_10004.capacity AS listing__capacity_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
@@ -19,33 +19,33 @@ SELECT
   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
   , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
   , bookings_source_src_10001.paid_at AS paid_at__day
   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
   , bookings_source_src_10001.is_instant AS booking__is_instant
   , bookings_source_src_10001.ds AS booking__ds__day
   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
   , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
   , bookings_source_src_10001.paid_at AS booking__paid_at__day
   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
   , bookings_source_src_10001.listing_id AS listing
   , bookings_source_src_10001.guest_id AS guest
   , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
@@ -19,33 +19,33 @@ SELECT
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS ds__year
+  , DATE_TRUNC(ds, year) AS ds__year
   , ds_partitioned AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS ds_partitioned__year
   , paid_at AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS paid_at__year
+  , DATE_TRUNC(paid_at, year) AS paid_at__year
   , is_instant AS booking__is_instant
   , ds AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS booking__ds__year
+  , DATE_TRUNC(ds, year) AS booking__ds__year
   , ds_partitioned AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS booking__ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS booking__ds_partitioned__year
   , paid_at AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS booking__paid_at__year
+  , DATE_TRUNC(paid_at, year) AS booking__paid_at__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -66,33 +66,33 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
     , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
     , bookings_source_src_10001.paid_at AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
     , bookings_source_src_10001.is_instant AS booking__is_instant
     , bookings_source_src_10001.ds AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
     , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
     , bookings_source_src_10001.paid_at AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -5,37 +5,37 @@ SELECT
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS ds__year
+  , DATE_TRUNC(ds, year) AS ds__year
   , ds_partitioned AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS ds_partitioned__year
   , paid_at AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS paid_at__year
+  , DATE_TRUNC(paid_at, year) AS paid_at__year
   , ds AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS booking__ds__year
+  , DATE_TRUNC(ds, year) AS booking__ds__year
   , ds_partitioned AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS booking__ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS booking__ds_partitioned__year
   , paid_at AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS booking__paid_at__year
+  , DATE_TRUNC(paid_at, year) AS booking__paid_at__year
   , paid_at AS metric_time__day
   , DATE_TRUNC(paid_at, isoweek) AS metric_time__week
   , DATE_TRUNC(paid_at, month) AS metric_time__month
   , DATE_TRUNC(paid_at, quarter) AS metric_time__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS metric_time__year
+  , DATE_TRUNC(paid_at, year) AS metric_time__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -78,33 +78,33 @@ FROM (
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
     , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
     , bookings_source_src_10001.paid_at AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
     , bookings_source_src_10001.is_instant AS booking__is_instant
     , bookings_source_src_10001.ds AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
     , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
     , bookings_source_src_10001.paid_at AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
     , bookings_source_src_10001.listing_id AS listing
     , bookings_source_src_10001.guest_id AS guest
     , bookings_source_src_10001.host_id AS host

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -5,37 +5,37 @@ SELECT
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS ds__year
+  , DATE_TRUNC(ds, year) AS ds__year
   , ds_partitioned AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS ds_partitioned__year
   , paid_at AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS paid_at__year
+  , DATE_TRUNC(paid_at, year) AS paid_at__year
   , ds AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
-  , DATE_TRUNC(ds, isoyear) AS booking__ds__year
+  , DATE_TRUNC(ds, year) AS booking__ds__year
   , ds_partitioned AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-  , DATE_TRUNC(ds_partitioned, isoyear) AS booking__ds_partitioned__year
+  , DATE_TRUNC(ds_partitioned, year) AS booking__ds_partitioned__year
   , paid_at AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
-  , DATE_TRUNC(paid_at, isoyear) AS booking__paid_at__year
+  , DATE_TRUNC(paid_at, year) AS booking__paid_at__year
   , ds AS metric_time__day
   , DATE_TRUNC(ds, isoweek) AS metric_time__week
   , DATE_TRUNC(ds, month) AS metric_time__month
   , DATE_TRUNC(ds, quarter) AS metric_time__quarter
-  , DATE_TRUNC(ds, isoyear) AS metric_time__year
+  , DATE_TRUNC(ds, year) AS metric_time__year
   , listing_id AS listing
   , guest_id AS guest
   , host_id AS host

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -100,33 +100,33 @@ FROM (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host
@@ -226,33 +226,33 @@ FULL OUTER JOIN (
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
             , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
             , bookings_source_src_10001.paid_at AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
             , bookings_source_src_10001.is_instant AS booking__is_instant
             , bookings_source_src_10001.ds AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS booking__ds__year
+            , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
             , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS booking__ds_partitioned__year
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
             , bookings_source_src_10001.paid_at AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-            , DATE_TRUNC(bookings_source_src_10001.paid_at, isoyear) AS booking__paid_at__year
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
             , bookings_source_src_10001.listing_id AS listing
             , bookings_source_src_10001.guest_id AS guest
             , bookings_source_src_10001.host_id AS host


### PR DESCRIPTION
BigQuery's time granularity truncation implementation relied,
correctly, on ISOWEEK for weekly granularities (to have the week
start on Monday) and, incorrectly, on ISOYEAR for yearly granularities
(which made the year start on whatever Monday happened to be for the
week containing the first Thursday of the year).

Every other engine we support renders date_trunc to truncate to
the first of January for yearly granularities.

Before this change, BigQuery would adjust the granularity for
the date 2015-06-04 to 2014-12-29

After this change, BigQuery will adjust the granularity for
the date 2015-06-04 to 2015-01-01

This is consistent with the behavior of all other supported engines.