### PR TITLE
Expose `all_time_constraint` on MFEngine

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -33,6 +33,7 @@ from metricflow.errors.errors import ExecutionException
 from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
+from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.formatting import indent_log_line
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.model.semantics.linkable_element_properties import (
@@ -400,6 +401,11 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             result_df=task_execution_result.df,
             result_table=explain_result.output_table,
         )
+
+    @property
+    def all_time_constraint(self) -> TimeRangeConstraint:
+        """TimeRangeConstraint representing the min & max dates supported."""
+        return TimeRangeConstraint.all_time()
 
     def _create_execution_plan(self, mf_query_request: MetricFlowQueryRequest) -> MetricFlowExplainResult:
         query_spec = self._query_parser.parse_and_validate_query(

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -307,7 +307,11 @@ class AbstractMetricFlowEngine(ABC):
 
 
 class MetricFlowEngine(AbstractMetricFlowEngine):
-    """Main entry point for queries."""
+    """Main entry point for queries.
+
+    Attributes on this class should be treated as in use by our APIs.
+    TODO: provide a more stable API layer instead of assuming this class is stable.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Exposes `all_time_constraint` on MFEngine. This will be used in our APIs to expose the min and max dates MetricFlow supports.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
