### PR TITLE
Allow tabulate versions >= 0.8.9

### DIFF
--- a/.changes/unreleased/Dependencies-20230905-164614.yaml
+++ b/.changes/unreleased/Dependencies-20230905-164614.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Allow tabulate versions >= 0.8.9
+time: 2023-09-05T16:46:14.56318-07:00
+custom:
+  Author: tlento
+  PR: "762"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "rapidfuzz~=3.0",
   "ruamel.yaml~=0.17.21",
   "rudder-sdk-python~=1.0.3",
-  "tabulate~=0.8.9",
+  "tabulate>=0.8.9",
   "typing_extensions>=4.0.0",
   "update-checker~=0.18.0",
 ]


### PR DESCRIPTION
Tabulate is an optional dependency of Pandas, which we use for printing
our query results. This means we must depend on tabulate directly
otherwise users see unhelpful errors about installing the tabulate
dependency.

Our version was pinned to ~0.8.9, but this comes with unexpected
limitations for users interacting with other packages in the broader
dbt ecosystem which require 0.9 or later, so here we are.

Resolves #397 
