### PR TITLE
Proposed protocols & implementations for query parameters

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple
 
 import pandas as pd
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimensionTypeParams
@@ -47,12 +47,7 @@ from metricflow.plan_conversion.dataflow_to_execution import (
     DataflowToExecutionPlanConverter,
 )
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
-from metricflow.protocols.query_parameter import (
-    GroupByQueryParameter,
-    MetricQueryParameter,
-    OrderByQueryParameter,
-    TimeDimensionQueryParameter,
-)
+from metricflow.protocols.query_parameter import GroupByParameter, MetricQueryParameter, OrderByQueryParameter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
@@ -90,13 +85,15 @@ class MetricFlowQueryRequest:
     """Encapsulates the parameters for a metric query.
 
     metric_names: Names of the metrics to query.
+    metrics: Metric objects to query.
     group_by_names: Names of the dimensions and entities to query.
+    group_by: Dimension or entity objects to query.
     limit: Limit the result to this many rows.
     time_constraint_start: Get data for the start of this time range.
     time_constraint_end: Get data for the end of this time range.
     where_constraint: A SQL string using group by names that can be used like a where clause on the output data.
-    order_by_names: metric and group by names to order by. A "-" can be used to specify reverse order e.g. "-ds"
-    order_by: metric and group by objects to order by
+    order_by_names: metric and group by names to order by. A "-" can be used to specify reverse order e.g. "-ds".
+    order_by: metric, dimension, or entity objects to order by.
     output_table: If specified, output the result data to this table instead of a result dataframe.
     sql_optimization_level: The level of optimization for the generated SQL.
     query_type: Type of MetricFlow query.
@@ -106,7 +103,7 @@ class MetricFlowQueryRequest:
     metric_names: Optional[Sequence[str]] = None
     metrics: Optional[Sequence[MetricQueryParameter]] = None
     group_by_names: Optional[Sequence[str]] = None
-    group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None
+    group_by: Optional[Tuple[GroupByParameter, ...]] = None
     limit: Optional[int] = None
     time_constraint_start: Optional[datetime.datetime] = None
     time_constraint_end: Optional[datetime.datetime] = None
@@ -122,7 +119,7 @@ class MetricFlowQueryRequest:
         metric_names: Optional[Sequence[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
         group_by_names: Optional[Sequence[str]] = None,
-        group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None,
+        group_by: Optional[Tuple[GroupByParameter, ...]] = None,
         limit: Optional[int] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
@@ -294,7 +291,7 @@ class AbstractMetricFlowEngine(ABC):
         metric_names: Optional[List[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
         get_group_by_values: Optional[str] = None,
-        group_by: Optional[Union[GroupByQueryParameter, TimeDimensionQueryParameter]] = None,
+        group_by: Optional[GroupByParameter] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
@@ -691,7 +688,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         metric_names: Optional[List[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
         get_group_by_values: Optional[str] = None,
-        group_by: Optional[Union[GroupByQueryParameter, TimeDimensionQueryParameter]] = None,
+        group_by: Optional[GroupByParameter] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimensionTypeParams
@@ -47,7 +47,12 @@ from metricflow.plan_conversion.dataflow_to_execution import (
     DataflowToExecutionPlanConverter,
 )
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
-from metricflow.protocols.query_parameter import QueryParameterDimension, QueryParameterMetric
+from metricflow.protocols.query_parameter import (
+    GroupByQueryParameter,
+    MetricQueryParameter,
+    OrderByQueryParameter,
+    TimeDimensionQueryParameter,
+)
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
@@ -98,15 +103,15 @@ class MetricFlowQueryRequest:
 
     request_id: MetricFlowRequestId
     metric_names: Optional[Sequence[str]] = None
-    metrics: Optional[Sequence[QueryParameterMetric]] = None
+    metrics: Optional[Sequence[MetricQueryParameter]] = None
     group_by_names: Optional[Sequence[str]] = None
-    group_by: Optional[Sequence[QueryParameterDimension]] = None
+    group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None
     limit: Optional[int] = None
     time_constraint_start: Optional[datetime.datetime] = None
     time_constraint_end: Optional[datetime.datetime] = None
     where_constraint: Optional[str] = None
     order_by_names: Optional[Sequence[str]] = None
-    order_by: Optional[Sequence[QueryParameterDimension]] = None
+    order_by: Optional[Sequence[OrderByQueryParameter]] = None
     output_table: Optional[str] = None
     sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4
     query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
@@ -114,15 +119,15 @@ class MetricFlowQueryRequest:
     @staticmethod
     def create_with_random_request_id(  # noqa: D
         metric_names: Optional[Sequence[str]] = None,
-        metrics: Optional[Sequence[QueryParameterMetric]] = None,
+        metrics: Optional[Sequence[MetricQueryParameter]] = None,
         group_by_names: Optional[Sequence[str]] = None,
-        group_by: Optional[Sequence[QueryParameterDimension]] = None,
+        group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None,
         limit: Optional[int] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
         where_constraint: Optional[str] = None,
         order_by_names: Optional[Sequence[str]] = None,
-        order_by: Optional[Sequence[QueryParameterDimension]] = None,
+        order_by: Optional[Sequence[OrderByQueryParameter]] = None,
         output_table: Optional[str] = None,
         sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
@@ -286,9 +291,9 @@ class AbstractMetricFlowEngine(ABC):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: Optional[List[str]] = None,
-        metrics: Optional[Sequence[QueryParameterMetric]] = None,
+        metrics: Optional[Sequence[MetricQueryParameter]] = None,
         get_group_by_values: Optional[str] = None,
-        group_by: Optional[QueryParameterDimension] = None,
+        group_by: Optional[Union[GroupByQueryParameter, TimeDimensionQueryParameter]] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
@@ -682,9 +687,9 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def explain_get_dimension_values(  # noqa: D
         self,
         metric_names: Optional[List[str]] = None,
-        metrics: Optional[Sequence[QueryParameterMetric]] = None,
+        metrics: Optional[Sequence[MetricQueryParameter]] = None,
         get_group_by_values: Optional[str] = None,
-        group_by: Optional[QueryParameterDimension] = None,
+        group_by: Optional[Union[GroupByQueryParameter, TimeDimensionQueryParameter]] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
     ) -> MetricFlowExplainResult:
@@ -695,8 +700,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             MetricFlowQueryRequest.create_with_random_request_id(
                 metric_names=metric_names,
                 metrics=metrics,
-                group_by_names=[get_group_by_values] if get_group_by_values else None,
-                group_by=[group_by] if group_by else None,
+                group_by_names=(get_group_by_values,) if get_group_by_values else None,
+                group_by=(group_by,) if group_by else None,
                 time_constraint_start=time_constraint_start,
                 time_constraint_end=time_constraint_end,
                 query_type=MetricFlowQueryType.DIMENSION_VALUES,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -96,6 +96,7 @@ class MetricFlowQueryRequest:
     time_constraint_end: Get data for the end of this time range.
     where_constraint: A SQL string using group by names that can be used like a where clause on the output data.
     order_by_names: metric and group by names to order by. A "-" can be used to specify reverse order e.g. "-ds"
+    order_by: metric and group by objects to order by
     output_table: If specified, output the result data to this table instead of a result dataframe.
     sql_optimization_level: The level of optimization for the generated SQL.
     query_type: Type of MetricFlow query.
@@ -426,7 +427,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             time_constraint_start=mf_query_request.time_constraint_start,
             time_constraint_end=mf_query_request.time_constraint_end,
             where_constraint_str=mf_query_request.where_constraint,
-            order=mf_query_request.order_by_names,
+            order_by_names=mf_query_request.order_by_names,
             order_by=mf_query_request.order_by,
         )
         logger.info(f"Query spec is:\n{pformat_big_objects(query_spec)}")
@@ -466,7 +467,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     time_constraint_start=mf_query_request.time_constraint_start,
                     time_constraint_end=mf_query_request.time_constraint_end,
                     where_constraint_str=mf_query_request.where_constraint,
-                    order=mf_query_request.order_by_names,
+                    order_by_names=mf_query_request.order_by_names,
+                    order_by=mf_query_request.order_by,
                 )
                 logger.warning(f"Query spec updated to:\n{pformat_big_objects(query_spec)}")
 

--- a/metricflow/protocols/query_parameter.py
+++ b/metricflow/protocols/query_parameter.py
@@ -18,7 +18,7 @@ class MetricQueryParameter(Protocol):
 
 
 @runtime_checkable
-class GroupByQueryParameter(Protocol):
+class DimensionOrEntityQueryParameter(Protocol):
     """Generic group by parameter for queries. Might be an entity or a dimension."""
 
     @property
@@ -45,11 +45,15 @@ class TimeDimensionQueryParameter(Protocol):  # noqa: D
         raise NotImplementedError
 
 
+GroupByParameter = Union[DimensionOrEntityQueryParameter, TimeDimensionQueryParameter]
+InputOrderByParameter = Union[MetricQueryParameter, GroupByParameter]
+
+
 class OrderByQueryParameter(Protocol):
     """Parameter to order by, specifying ascending or descending."""
 
     @property
-    def order_by(self) -> Union[MetricQueryParameter, GroupByQueryParameter, TimeDimensionQueryParameter]:
+    def order_by(self) -> InputOrderByParameter:
         """Parameter to order results by."""
         raise NotImplementedError
 

--- a/metricflow/protocols/query_parameter.py
+++ b/metricflow/protocols/query_parameter.py
@@ -1,15 +1,34 @@
 from __future__ import annotations
 
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Union, runtime_checkable
 
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 
 from metricflow.time.date_part import DatePart
 
 
-class QueryParameterDimension(Protocol):
-    """A query parameter with a grain."""
+@runtime_checkable
+class MetricQueryParameter(Protocol):
+    """Metric requested in a query."""
 
+    @property
+    def name(self) -> str:
+        """The name of the metric."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class GroupByQueryParameter(Protocol):
+    """Generic group by parameter for queries. Might be an entity or a dimension."""
+
+    @property
+    def name(self) -> str:
+        """The name of the metric."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class TimeDimensionQueryParameter(Protocol):  # noqa: D
     @property
     def name(self) -> str:
         """The name of the item."""
@@ -21,25 +40,20 @@ class QueryParameterDimension(Protocol):
         raise NotImplementedError
 
     @property
-    def descending(self) -> bool:
-        """Set the sort order for order-by."""
-        raise NotImplementedError
-
-    @property
     def date_part(self) -> Optional[DatePart]:
         """Date part to extract from the dimension."""
         raise NotImplementedError
 
 
-class QueryParameterMetric(Protocol):
-    """Metric in the query interface."""
+class OrderByQueryParameter(Protocol):
+    """Parameter to order by, specifying ascending or descending."""
 
     @property
-    def name(self) -> str:
-        """The name of the metric."""
+    def order_by(self) -> Union[MetricQueryParameter, GroupByQueryParameter, TimeDimensionQueryParameter]:
+        """Parameter to order results by."""
         raise NotImplementedError
 
     @property
     def descending(self) -> bool:
-        """Set the sort order for order-by."""
+        """Indicates if the order should be ascending or descending."""
         raise NotImplementedError

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.call_parameter_sets import ParseWhereFilterException
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
@@ -29,7 +29,7 @@ from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.protocols.query_parameter import (
-    GroupByQueryParameter,
+    GroupByParameter,
     MetricQueryParameter,
     OrderByQueryParameter,
     TimeDimensionQueryParameter,
@@ -177,7 +177,7 @@ class MetricFlowQueryParser:
         metric_names: Optional[Sequence[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
         group_by_names: Optional[Sequence[str]] = None,
-        group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None,
+        group_by: Optional[Tuple[GroupByParameter, ...]] = None,
         limit: Optional[int] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
@@ -316,7 +316,7 @@ class MetricFlowQueryParser:
         metric_names: Optional[Sequence[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
         group_by_names: Optional[Sequence[str]] = None,
-        group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None,
+        group_by: Optional[Tuple[GroupByParameter, ...]] = None,
         limit: Optional[int] = None,
         time_constraint_start: Optional[datetime.datetime] = None,
         time_constraint_end: Optional[datetime.datetime] = None,
@@ -665,7 +665,7 @@ class MetricFlowQueryParser:
         self,
         metric_references: Sequence[MetricReference],
         group_by_names: Optional[Sequence[str]] = None,
-        group_by: Optional[Tuple[Union[GroupByQueryParameter, TimeDimensionQueryParameter], ...]] = None,
+        group_by: Optional[Tuple[GroupByParameter, ...]] = None,
     ) -> QueryTimeLinkableSpecSet:
         """Convert the linkable spec names into the respective specification objects."""
         # TODO: refactor to only support group_by object inputs (removing group_by_names param)

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -48,6 +48,7 @@ from metricflow.specs.specs import (
     WhereFilterSpec,
 )
 from metricflow.specs.where_filter_transform import WhereSpecFactory
+from metricflow.time.date_part import DatePart
 from metricflow.time.time_granularity_solver import (
     PartialTimeDimensionSpec,
     RequestTimeGranularityException,
@@ -182,9 +183,8 @@ class MetricFlowQueryParser:
         time_constraint_end: Optional[datetime.datetime] = None,
         where_constraint: Optional[WhereFilter] = None,
         where_constraint_str: Optional[str] = None,
-        order: Optional[Sequence[str]] = None,
+        order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
-        time_granularity: Optional[TimeGranularity] = None,
     ) -> MetricFlowQuerySpec:
         """Parse the query into spec objects, validating them in the process.
 
@@ -202,9 +202,8 @@ class MetricFlowQueryParser:
                 time_constraint_end=time_constraint_end,
                 where_constraint=where_constraint,
                 where_constraint_str=where_constraint_str,
-                order=order,
+                order_by_names=order_by_names,
                 order_by=order_by,
-                time_granularity=time_granularity,
             )
         finally:
             logger.info(f"Parsing the query took: {time.time() - start_time:.2f}s")
@@ -312,14 +311,6 @@ class MetricFlowQueryParser:
             PydanticWhereFilter(where_sql_template=where_constraint_str) if where_constraint_str else where_constraint
         )
 
-    def _get_order(
-        self, order: Optional[Sequence[str]], order_by: Optional[Sequence[OrderByQueryParameter]]
-    ) -> Sequence[str]:
-        assert not (
-            order and order_by
-        ), "Both order_by_names and order_by were set, but if an order by is specified you should only use one of these!"
-        return order if order else [f"{o.name}__{o.grain}" if o.grain else o.name for o in order_by] if order_by else []
-
     def _parse_and_validate_query(
         self,
         metric_names: Optional[Sequence[str]] = None,
@@ -331,13 +322,11 @@ class MetricFlowQueryParser:
         time_constraint_end: Optional[datetime.datetime] = None,
         where_constraint: Optional[WhereFilter] = None,
         where_constraint_str: Optional[str] = None,
-        order: Optional[Sequence[str]] = None,
+        order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
-        time_granularity: Optional[TimeGranularity] = None,
     ) -> MetricFlowQuerySpec:
         metric_names = self._get_metric_names(metric_names, metrics)
         where_filter = self._get_where_filter(where_constraint, where_constraint_str)
-        order = self._get_order(order, order_by)
 
         # Get metric references used for validations
         # In a case of derived metric, all the input metrics would be here.
@@ -423,7 +412,11 @@ class MetricFlowQueryParser:
         self._time_granularity_solver.validate_time_granularity(metric_references, time_dimension_specs)
         self._validate_date_part(metric_references, time_dimension_specs)
 
-        order_by_specs = self._parse_order_by(order or [], partial_time_dimension_spec_replacements)
+        order_by_specs = self._parse_order_by(
+            order_by_names=order_by_names,
+            order_by=order_by,
+            time_dimension_spec_replacements=partial_time_dimension_spec_replacements,
+        )
 
         # For each metric, verify that it's possible to retrieve all group by elements, including the ones as required
         # by the filters.
@@ -819,29 +812,47 @@ class MetricFlowQueryParser:
 
     def _parse_order_by(
         self,
-        order_by_names: Sequence[str],
         time_dimension_spec_replacements: Dict[PartialTimeDimensionSpec, TimeDimensionSpec],
+        order_by_names: Optional[Sequence[str]] = None,
+        order_by: Optional[Sequence[OrderByQueryParameter]] = None,
     ) -> Tuple[OrderBySpec, ...]:
         """time_dimension_spec_replacements is used to replace a partial spec from parsing the names to a full one."""
         # TODO: Validate entity links
         # TODO: Validate order by items are in the query
+
+        assert not (
+            order_by_names and order_by
+        ), "Both order_by_names and order_by were set, but if an order by is specified you should only use one of these!"
+
         order_by_specs: List[OrderBySpec] = []
-        for order_by_name in order_by_names:
-            descending = False
-            if order_by_name.startswith("-"):
-                order_by_name = order_by_name[1:]
-                descending = True
-            parsed_name = StructuredLinkableSpecName.from_name(order_by_name)
+        for order in order_by_names or order_by or []:
+            # Order might be string or object - parse into relevant parts.
+            time_granularity: Optional[TimeGranularity] = None
+            date_part: Optional[DatePart] = None
+            if isinstance(order, str):
+                # Note: date part cannot be requested via string parameter.
+                descending = False
+                if order.startswith("-"):
+                    order = order[1:]
+                    descending = True
+                parsed_name = StructuredLinkableSpecName.from_name(order)
+                time_granularity = parsed_name.time_granularity
+            else:
+                descending = order.descending
+                parsed_name = StructuredLinkableSpecName.from_name(order.order_by.name)
+                if isinstance(order.order_by, TimeDimensionQueryParameter):
+                    time_granularity = order.order_by.grain
+                    date_part = order.order_by.date_part
+                if parsed_name.time_granularity and parsed_name.time_granularity != time_granularity:
+                    raise InvalidQueryException("Must use object syntax to request a time granularity.")
 
             if MetricReference(element_name=parsed_name.element_name) in self._known_metric_names:
-                if parsed_name.time_granularity:
+                if time_granularity:
                     raise InvalidQueryException(
-                        f"Order by item '{order_by_name}' references a metric but has a time granularity"
+                        f"Order by item '{order}' references a metric but has a time granularity"
                     )
                 if parsed_name.entity_link_names:
-                    raise InvalidQueryException(
-                        f"Order by item '{order_by_name}' references a metric but has entity links"
-                    )
+                    raise InvalidQueryException(f"Order by item '{order}' references a metric but has entity links")
                 order_by_specs.append(
                     OrderBySpec(
                         metric_spec=MetricSpec(element_name=parsed_name.element_name),
@@ -849,10 +860,9 @@ class MetricFlowQueryParser:
                     )
                 )
             elif DimensionReference(element_name=parsed_name.element_name) in self._known_dimension_element_references:
-                if parsed_name.time_granularity:
+                if time_granularity:
                     raise InvalidQueryException(
-                        f"Order by item '{order_by_name}' references a categorical dimension but has a time "
-                        f"granularity"
+                        f"Order by item '{order}' references a categorical dimension but has a time " f"granularity"
                     )
                 order_by_specs.append(
                     OrderBySpec(
@@ -868,14 +878,14 @@ class MetricFlowQueryParser:
                 in self._known_time_dimension_element_references
             ):
                 entity_links = tuple(EntityReference(element_name=x) for x in parsed_name.entity_link_names)
-                if parsed_name.time_granularity:
+                if time_granularity:
                     order_by_specs.append(
                         OrderBySpec(
                             time_dimension_spec=TimeDimensionSpec(
                                 element_name=parsed_name.element_name,
                                 entity_links=entity_links,
-                                time_granularity=parsed_name.time_granularity,
-                                date_part=parsed_name.date_part,
+                                time_granularity=time_granularity,
+                                date_part=date_part,
                             ),
                             descending=descending,
                         )
@@ -886,6 +896,7 @@ class MetricFlowQueryParser:
                     partial_time_dimension_spec = PartialTimeDimensionSpec(
                         element_name=parsed_name.element_name,
                         entity_links=entity_links,
+                        date_part=date_part,
                     )
 
                     if partial_time_dimension_spec in time_dimension_spec_replacements:
@@ -897,14 +908,14 @@ class MetricFlowQueryParser:
                         )
                     else:
                         raise RequestTimeGranularityException(
-                            f"Order by item '{order_by_name}' does not specify a time granularity and it does not "
+                            f"Order by item '{order}' does not specify a time granularity and it does not "
                             f"match a requested time dimension"
                         )
 
             elif EntityReference(element_name=parsed_name.element_name) in self._known_entity_element_references:
-                if parsed_name.time_granularity:
+                if time_granularity:
                     raise InvalidQueryException(
-                        f"Order by item '{order_by_name}' references an entity but has a time granularity"
+                        f"Order by item '{order}' references an entity but has a time granularity"
                     )
                 order_by_specs.append(
                     OrderBySpec(
@@ -916,6 +927,6 @@ class MetricFlowQueryParser:
                     )
                 )
             else:
-                raise InvalidQueryException(f"Order by item '{order_by_name}' references an element that is not known")
+                raise InvalidQueryException(f"Order by item '{order}' references an element that is not known")
 
         return tuple(order_by_specs)

--- a/metricflow/specs/query_param_implementations.py
+++ b/metricflow/specs/query_param_implementations.py
@@ -1,24 +1,57 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow.protocols.query_parameter import (
+    GroupByQueryParameter,
+    MetricQueryParameter,
+    TimeDimensionQueryParameter,
+)
 from metricflow.time.date_part import DatePart
 
 
 @dataclass(frozen=True)
-class DimensionQueryParameter:
+class TimeDimensionParameter:
     """Time dimension requested in a query."""
 
     name: str
     grain: Optional[TimeGranularity] = None
-    descending: bool = False
     date_part: Optional[DatePart] = None
 
     def __post_init__(self) -> None:  # noqa: D
         parsed_name = StructuredLinkableSpecName.from_name(self.name)
         if parsed_name.time_granularity:
             raise ValueError("Must use object syntax for `grain` parameter if `date_part` is requested.")
+
+
+@dataclass(frozen=True)
+class GroupByParameter:
+    """Group by parameter requested in a query.
+
+    Might represent an entity or a dimension.
+    """
+
+    name: str
+
+
+@dataclass(frozen=True)
+class MetricParameter:
+    """Metric requested in a query."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class OrderByParameter:
+    """Order by requested in a query."""
+
+    order_by: Union[MetricQueryParameter, GroupByQueryParameter, TimeDimensionQueryParameter]
+    descending: bool = False
+
+
+# Do we want one generic type for QueryParameter which includes grain & date_part?
+# The main question: do we need to know what type we're passing into MF? Or are we ok with MF just figuring it out?

--- a/metricflow/specs/query_param_implementations.py
+++ b/metricflow/specs/query_param_implementations.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
-from metricflow.protocols.query_parameter import (
-    GroupByQueryParameter,
-    MetricQueryParameter,
-    TimeDimensionQueryParameter,
-)
+from metricflow.protocols.query_parameter import InputOrderByParameter
 from metricflow.time.date_part import DatePart
 
 
@@ -29,7 +25,7 @@ class TimeDimensionParameter:
 
 
 @dataclass(frozen=True)
-class GroupByParameter:
+class DimensionOrEntityParameter:
     """Group by parameter requested in a query.
 
     Might represent an entity or a dimension.
@@ -49,5 +45,5 @@ class MetricParameter:
 class OrderByParameter:
     """Order by requested in a query."""
 
-    order_by: Union[MetricQueryParameter, GroupByQueryParameter, TimeDimensionQueryParameter]
+    order_by: InputOrderByParameter
     descending: bool = False

--- a/metricflow/specs/query_param_implementations.py
+++ b/metricflow/specs/query_param_implementations.py
@@ -51,7 +51,3 @@ class OrderByParameter:
 
     order_by: Union[MetricQueryParameter, GroupByQueryParameter, TimeDimensionQueryParameter]
     descending: bool = False
-
-
-# Do we want one generic type for QueryParameter which includes grain & date_part?
-# The main question: do we need to know what type we're passing into MF? Or are we ok with MF just figuring it out?

--- a/metricflow/test/conftest.py
+++ b/metricflow/test/conftest.py
@@ -1,11 +1,6 @@
 # These imports are required to properly set up pytest fixtures.
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
-
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
-
 from metricflow.test.fixtures.cli_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.dataflow_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.id_fixtures import *  # noqa: F401, F403
@@ -14,14 +9,3 @@ from metricflow.test.fixtures.setup_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.sql_client_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.sql_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.table_fixtures import *  # noqa: F401, F403
-from metricflow.time.date_part import DatePart
-
-
-@dataclass
-class MockQueryParameterDimension:
-    """This is a mock that is just used to test the query parser."""
-
-    name: str
-    grain: Optional[TimeGranularity] = None
-    descending: bool = False
-    date_part: Optional[DatePart] = None

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -18,9 +18,9 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import (
     DunderColumnAssociationResolver,
 )
-from metricflow.protocols.query_parameter import GroupByQueryParameter
+from metricflow.protocols.query_parameter import DimensionOrEntityQueryParameter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.specs.query_param_implementations import GroupByParameter, TimeDimensionParameter
+from metricflow.specs.query_param_implementations import DimensionOrEntityParameter, TimeDimensionParameter
 from metricflow.sql.sql_exprs import (
     SqlCastToTimestampExpression,
     SqlColumnReference,
@@ -256,7 +256,7 @@ def test_case(
 
     check_query_helpers = CheckQueryHelpers(sql_client)
 
-    group_by: List[GroupByQueryParameter] = []
+    group_by: List[DimensionOrEntityQueryParameter] = []
     for group_by_kwargs in case.group_by_objs:
         kwargs = copy(group_by_kwargs)
         date_part = kwargs.get("date_part")
@@ -268,7 +268,7 @@ def test_case(
                 kwargs["grain"] = TimeGranularity(grain)
             group_by.append(TimeDimensionParameter(**kwargs))
         else:
-            group_by.append(GroupByParameter(**kwargs))
+            group_by.append(DimensionOrEntityParameter(**kwargs))
     query_result = engine.query(
         MetricFlowQueryRequest.create_with_random_request_id(
             metric_names=case.metrics,

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -18,8 +18,9 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import (
     DunderColumnAssociationResolver,
 )
+from metricflow.protocols.query_parameter import GroupByQueryParameter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.specs.query_param_implementations import DimensionQueryParameter
+from metricflow.specs.query_param_implementations import GroupByParameter, TimeDimensionParameter
 from metricflow.sql.sql_exprs import (
     SqlCastToTimestampExpression,
     SqlColumnReference,
@@ -255,16 +256,19 @@ def test_case(
 
     check_query_helpers = CheckQueryHelpers(sql_client)
 
-    group_by: List[DimensionQueryParameter] = []
+    group_by: List[GroupByQueryParameter] = []
     for group_by_kwargs in case.group_by_objs:
         kwargs = copy(group_by_kwargs)
         date_part = kwargs.get("date_part")
         grain = kwargs.get("grain")
-        if date_part:
-            kwargs["date_part"] = DatePart(date_part)
-        if grain:
-            kwargs["grain"] = TimeGranularity(grain)
-        group_by.append(DimensionQueryParameter(**kwargs))
+        if date_part or grain:
+            if date_part:
+                kwargs["date_part"] = DatePart(date_part)
+            if grain:
+                kwargs["grain"] = TimeGranularity(grain)
+            group_by.append(TimeDimensionParameter(**kwargs))
+        else:
+            group_by.append(GroupByParameter(**kwargs))
     query_result = engine.query(
         MetricFlowQueryRequest.create_with_random_request_id(
             metric_names=case.metrics,

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -15,7 +15,7 @@ from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.query_param_implementations import (
-    GroupByParameter,
+    DimensionOrEntityParameter,
     MetricParameter,
     OrderByParameter,
     TimeDimensionParameter,
@@ -196,8 +196,8 @@ def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryP
     Metric = namedtuple("Metric", ["name", "descending"])
     metric = Metric("bookings", False)
     group_by = (
-        GroupByParameter("booking__is_instant"),
-        GroupByParameter("listing"),
+        DimensionOrEntityParameter("booking__is_instant"),
+        DimensionOrEntityParameter("listing"),
         TimeDimensionParameter(MTD),
     )
     order_by = (

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -14,6 +14,12 @@ from metricflow.errors.errors import UnableToSatisfyQueryError
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
+from metricflow.specs.query_param_implementations import (
+    GroupByParameter,
+    MetricParameter,
+    OrderByParameter,
+    TimeDimensionParameter,
+)
 from metricflow.specs.specs import (
     DimensionSpec,
     EntitySpec,
@@ -21,7 +27,6 @@ from metricflow.specs.specs import (
     OrderBySpec,
     TimeDimensionSpec,
 )
-from metricflow.test.conftest import MockQueryParameterDimension
 from metricflow.test.fixtures.model_fixtures import query_parser_from_yaml
 from metricflow.test.model.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE
 from metricflow.test.time.metric_time_dimension import MTD
@@ -188,12 +193,15 @@ def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # 
 def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
     Metric = namedtuple("Metric", ["name", "descending"])
     metric = Metric("bookings", False)
-    group_by = [
-        MockQueryParameterDimension("booking__is_instant"),
-        MockQueryParameterDimension("listing"),
-        MockQueryParameterDimension(MTD),
-    ]
-    order_by = [MockQueryParameterDimension(MTD), MockQueryParameterDimension("-bookings")]
+    group_by = (
+        GroupByParameter("booking__is_instant"),
+        GroupByParameter("listing"),
+        TimeDimensionParameter(MTD),
+    )
+    order_by = (
+        OrderByParameter(order_by=TimeDimensionParameter(MTD)),
+        OrderByParameter(order_by=MetricParameter("bookings"), descending=True),
+    )
     query_spec = bookings_query_parser.parse_and_validate_query(metrics=[metric], group_by=group_by, order_by=order_by)
     assert query_spec.metric_specs == (MetricSpec(element_name="bookings"),)
     assert query_spec.dimension_specs == (
@@ -414,34 +422,34 @@ def test_date_part_parsing() -> None:
     with pytest.raises(RequestTimeGranularityException):
         query_parser.parse_and_validate_query(
             metric_names=["revenue"],
-            group_by=[MockQueryParameterDimension(name="metric_time", date_part=DatePart.DOW)],
+            group_by=(TimeDimensionParameter(name="metric_time", date_part=DatePart.DOW),),
         )
 
     # Can't query date part for cumulative metrics
     with pytest.raises(UnableToSatisfyQueryError):
         query_parser.parse_and_validate_query(
             metric_names=["revenue_cumulative"],
-            group_by=[MockQueryParameterDimension(name="metric_time", date_part=DatePart.YEAR)],
+            group_by=(TimeDimensionParameter(name="metric_time", date_part=DatePart.YEAR),),
         )
 
     # Can't query date part for metrics with offset to grain
     with pytest.raises(UnableToSatisfyQueryError):
         query_parser.parse_and_validate_query(
             metric_names=["revenue_since_start_of_year"],
-            group_by=[MockQueryParameterDimension(name="metric_time", date_part=DatePart.MONTH)],
+            group_by=(TimeDimensionParameter(name="metric_time", date_part=DatePart.MONTH),),
         )
 
     # Requested granularity doesn't match resolved granularity
     with pytest.raises(RequestTimeGranularityException):
         query_parser.parse_and_validate_query(
             metric_names=["revenue"],
-            group_by=[
-                MockQueryParameterDimension(name="metric_time", grain=TimeGranularity.YEAR, date_part=DatePart.MONTH)
-            ],
+            group_by=(
+                TimeDimensionParameter(name="metric_time", grain=TimeGranularity.YEAR, date_part=DatePart.MONTH),
+            ),
         )
 
     # Date part is compatible
     query_parser.parse_and_validate_query(
         metric_names=["revenue"],
-        group_by=[MockQueryParameterDimension(name="metric_time", date_part=DatePart.MONTH)],
+        group_by=(TimeDimensionParameter(name="metric_time", date_part=DatePart.MONTH),),
     )

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -165,7 +165,9 @@ def bookings_query_parser() -> MetricFlowQueryParser:  # noqa
 
 def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
     query_spec = bookings_query_parser.parse_and_validate_query(
-        metric_names=["bookings"], group_by_names=["booking__is_instant", "listing", MTD], order=[MTD, "-bookings"]
+        metric_names=["bookings"],
+        group_by_names=["booking__is_instant", "listing", MTD],
+        order_by_names=[MTD, "-bookings"],
     )
 
     assert query_spec.metric_specs == (MetricSpec(element_name="bookings"),)
@@ -239,7 +241,7 @@ def test_order_by_granularity_conversion() -> None:
         [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, bookings_yaml_file, revenue_yaml_file]
     )
     query_spec = query_parser.parse_and_validate_query(
-        metric_names=["bookings", "revenue"], group_by_names=[MTD], order=[f"-{MTD}"]
+        metric_names=["bookings", "revenue"], group_by_names=[MTD], order_by_names=[f"-{MTD}"]
     )
 
     # The lowest common granularity is MONTH, so we expect the PTD in the order by to have that granularity.
@@ -255,7 +257,7 @@ def test_order_by_granularity_conversion() -> None:
 
 def test_order_by_granularity_no_conversion(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
     query_spec = bookings_query_parser.parse_and_validate_query(
-        metric_names=["bookings"], group_by_names=[MTD], order=[MTD]
+        metric_names=["bookings"], group_by_names=[MTD], order_by_names=[MTD]
     )
 
     # The only granularity is DAY, so we expect the PTD in the order by to have that granularity.


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Completes SL-993

### Description
Proposed updates to the protocols and implementations used for queries.

IMO, we are using the same protocols for too many things. For instance, we had a `QueryParameterDimension` as the type for the `group_by` param. `QueryParameterDimension` was required to have `grain`, and `date_part` attributes. That means that if the client wants to pass an entity or a categorical dimension into the `group_by` param, they still need to use an object with `grain` and `date_part` attributes even though those are not valid attributes for entities or categorical dimensions. This leaves us with 2 options:
1. Force the client to always include those attributes, even when they aren't valid. This simplifies type checking a lot in MF, but it seems pretty unreasonable on the client side.
2. Separate the group by options into two different protocols, one of which includes those attributes (`TimeDimensionQueryParameter`). This creates some awkwardness because we have to accept a `Union` `group_by` parameter and figure out which type the user passed.

In this PR I implement option 2, because to me it seems much cleaner to handle that logic in one place (here in MF) than to put the onus on all clients to handle the awkwardness of passing objects around with invalid attributes.

Second, we were using `DimensionQueryParameter` as the type for both `group_by` and `order_by` inputs. This forces us to add a `descending` parameter to `DimensionQueryParameter`, even though the `descending` param is not valid as a `group_by` input. Instead, I added a new OrderByQueryParameter protocol that includes a `descending` attribute and a nested `order_by` item, which can be a `MetricQueryParameter`, `GroupByQueryParameter`, or `TimeDimensionQueryParameter`.

One other note about the `group_by` param - I changed this param to expect a `Tuple`, since that's the only type hint that allows you to have multiple datatypes in one iterable. (This is just an annoying mypy limitation.)

Let me know if y'all agree with these changes or if you have other ideas!

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  4. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  5. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
