### PR TITLE
Expose `granularity_free_qualified_name` on `StructuredLinkableSpecName`

### DIFF
--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -109,10 +109,7 @@ class Dimension:
         Dimension set has de-duplicated TimeDimensions such that you never have more than one granularity
         in your set for each TimeDimension.
         """
-        parsed_name = StructuredLinkableSpecName.from_name(qualified_name=self.qualified_name)
-        return StructuredLinkableSpecName(
-            entity_link_names=parsed_name.entity_link_names, element_name=self.name
-        ).qualified_name
+        return StructuredLinkableSpecName.from_name(qualified_name=self.qualified_name).granularity_free_qualified_name
 
 
 @dataclass(frozen=True)

--- a/metricflow/naming/linkable_spec_name.py
+++ b/metricflow/naming/linkable_spec_name.py
@@ -91,3 +91,17 @@ class StructuredLinkableSpecName:
     def date_part_suffix(date_part: DatePart) -> str:
         """Suffix used for names with a date_part."""
         return f"extract_{date_part.value}"
+
+    @property
+    def granularity_free_qualified_name(self) -> str:
+        """Renders the qualified name without the granularity suffix.
+
+        In the list metrics and list dimensions outputs we want to render the qualified name of the dimension, but
+        without including the base granularity for time dimensions. This method is useful in those contexts.
+        Note: in most cases you should be using the qualified_name - this is only useful in cases where the
+        Dimension set has de-duplicated TimeDimensions such that you never have more than one granularity
+        in your set for each TimeDimension.
+        """
+        return StructuredLinkableSpecName(
+            entity_link_names=self.entity_link_names, element_name=self.element_name
+        ).qualified_name


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Sometimes in the API we need to parse a qualified name into its `time_granularity` and its `name`. For the `name`, we want to include entity links, not just the `element_name`. Currently, `StructuredLinkableSpecName` only supports parsing `element_name`, `entity_links`, and `time_granularity`. Adding this here to ensure we always use the same logic to get the qualified name without granularity.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
