### PR TITLE
Change `OrderBySpec` to Use a Single Spec

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -303,9 +303,7 @@ class DataflowPlanBuilder:
             computed_metrics_output=distinct_values_node,
             order_by_specs=(
                 OrderBySpec(
-                    dimension_spec=dimension_spec,
-                    time_dimension_spec=time_dimension_spec,
-                    entity_spec=entity_spec,
+                    instance_spec=linkable_spec,
                     descending=False,
                 ),
             ),

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -887,7 +887,7 @@ class OrderByLimitNode(ComputedMetricsOutput):
 
     @property
     def description(self) -> str:  # noqa: D
-        return f"Order By {[x.item.qualified_name for x in self._order_by_specs]}" + (
+        return f"Order By {[order_by_spec.instance_spec.qualified_name for order_by_spec in self._order_by_specs]}" + (
             f" Limit {self._limit}" if self.limit else ""
         )
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -749,7 +749,9 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     expr=SqlColumnReferenceExpression(
                         col_ref=SqlColumnReference(
                             table_alias=from_data_set_alias,
-                            column_name=self._column_association_resolver.resolve_spec(order_by_spec.item).column_name,
+                            column_name=self._column_association_resolver.resolve_spec(
+                                order_by_spec.instance_spec
+                            ).column_name,
                         )
                     ),
                     desc=order_by_spec.descending,

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -511,10 +511,10 @@ class MetricFlowQueryParser:
         metric_specs = [MetricSpec.from_reference(metric_reference) for metric_reference in metric_references]
         for order_by_spec in order_by_specs:
             if not (
-                order_by_spec.item in metric_specs
-                or order_by_spec.item in linkable_specs.dimension_specs
-                or order_by_spec.item in linkable_specs.time_dimension_specs
-                or order_by_spec.item in linkable_specs.entity_specs
+                order_by_spec.instance_spec in metric_specs
+                or order_by_spec.instance_spec in linkable_specs.dimension_specs
+                or order_by_spec.instance_spec in linkable_specs.time_dimension_specs
+                or order_by_spec.instance_spec in linkable_specs.entity_specs
             ):
                 raise InvalidQueryException(f"Order by item {order_by_spec} not in the query")
 
@@ -855,7 +855,7 @@ class MetricFlowQueryParser:
                     raise InvalidQueryException(f"Order by item '{order}' references a metric but has entity links")
                 order_by_specs.append(
                     OrderBySpec(
-                        metric_spec=MetricSpec(element_name=parsed_name.element_name),
+                        instance_spec=MetricSpec(element_name=parsed_name.element_name),
                         descending=descending,
                     )
                 )
@@ -866,7 +866,7 @@ class MetricFlowQueryParser:
                     )
                 order_by_specs.append(
                     OrderBySpec(
-                        dimension_spec=DimensionSpec(
+                        instance_spec=DimensionSpec(
                             element_name=parsed_name.element_name,
                             entity_links=tuple(EntityReference(element_name=x) for x in parsed_name.entity_link_names),
                         ),
@@ -881,7 +881,7 @@ class MetricFlowQueryParser:
                 if time_granularity:
                     order_by_specs.append(
                         OrderBySpec(
-                            time_dimension_spec=TimeDimensionSpec(
+                            instance_spec=TimeDimensionSpec(
                                 element_name=parsed_name.element_name,
                                 entity_links=entity_links,
                                 time_granularity=time_granularity,
@@ -902,7 +902,7 @@ class MetricFlowQueryParser:
                     if partial_time_dimension_spec in time_dimension_spec_replacements:
                         order_by_specs.append(
                             OrderBySpec(
-                                time_dimension_spec=time_dimension_spec_replacements[partial_time_dimension_spec],
+                                instance_spec=time_dimension_spec_replacements[partial_time_dimension_spec],
                                 descending=descending,
                             )
                         )
@@ -919,7 +919,7 @@ class MetricFlowQueryParser:
                     )
                 order_by_specs.append(
                     OrderBySpec(
-                        entity_spec=EntitySpec(
+                        instance_spec=EntitySpec(
                             element_name=parsed_name.element_name,
                             entity_links=tuple(EntityReference(element_name=x) for x in parsed_name.entity_link_names),
                         ),

--- a/metricflow/specs/specs.py
+++ b/metricflow/specs/specs.py
@@ -29,7 +29,6 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow.aggregation_properties import AggregationState
-from metricflow.assert_one_arg import assert_exactly_one_arg_set
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -479,27 +478,8 @@ class MetricInputMeasureSpec(SerializableDataclass):
 
 @dataclass(frozen=True)
 class OrderBySpec(SerializableDataclass):  # noqa: D
+    instance_spec: InstanceSpec
     descending: bool
-    metric_spec: Optional[MetricSpec] = None
-    dimension_spec: Optional[DimensionSpec] = None
-    time_dimension_spec: Optional[TimeDimensionSpec] = None
-    entity_spec: Optional[EntitySpec] = None
-
-    def __post_init__(self) -> None:  # noqa: D
-        assert_exactly_one_arg_set(
-            metric_spec=self.metric_spec,
-            dimension_spec=self.dimension_spec,
-            time_dimension_spec=self.time_dimension_spec,
-            entity_spec=self.entity_spec,
-        )
-
-    @property
-    def item(self) -> InstanceSpec:  # noqa: D
-        result: Optional[InstanceSpec] = (
-            self.metric_spec or self.dimension_spec or self.time_dimension_spec or self.entity_spec
-        )
-        assert result
-        return result
 
 
 @dataclass(frozen=True)

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -141,11 +141,11 @@ def test_order_by_plan(  # noqa: D
             time_dimension_specs=(MTD_SPEC_DAY,),
             order_by_specs=(
                 OrderBySpec(
-                    time_dimension_spec=MTD_SPEC_DAY,
+                    instance_spec=MTD_SPEC_DAY,
                     descending=False,
                 ),
                 OrderBySpec(
-                    metric_spec=MetricSpec(element_name="bookings"),
+                    instance_spec=MetricSpec(element_name="bookings"),
                     descending=True,
                 ),
             ),

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -856,11 +856,11 @@ def test_order_by_node(
     order_by_node = OrderByLimitNode(
         order_by_specs=[
             OrderBySpec(
-                time_dimension_spec=time_dimension_spec,
+                instance_spec=time_dimension_spec,
                 descending=False,
             ),
             OrderBySpec(
-                metric_spec=metric_spec,
+                instance_spec=metric_spec,
                 descending=True,
             ),
         ],

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -180,13 +180,11 @@ def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # 
     assert query_spec.entity_specs == (EntitySpec(element_name="listing", entity_links=()),)
     assert query_spec.order_by_specs == (
         OrderBySpec(
-            time_dimension_spec=TimeDimensionSpec(
-                element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY
-            ),
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
             descending=False,
         ),
         OrderBySpec(
-            metric_spec=MetricSpec(element_name="bookings"),
+            instance_spec=MetricSpec(element_name="bookings"),
             descending=True,
         ),
     )
@@ -215,13 +213,11 @@ def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryP
     assert query_spec.entity_specs == (EntitySpec(element_name="listing", entity_links=()),)
     assert query_spec.order_by_specs == (
         OrderBySpec(
-            time_dimension_spec=TimeDimensionSpec(
-                element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY
-            ),
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
             descending=False,
         ),
         OrderBySpec(
-            metric_spec=MetricSpec(element_name="bookings"),
+            instance_spec=MetricSpec(element_name="bookings"),
             descending=True,
         ),
     )
@@ -247,9 +243,7 @@ def test_order_by_granularity_conversion() -> None:
     # The lowest common granularity is MONTH, so we expect the PTD in the order by to have that granularity.
     assert (
         OrderBySpec(
-            time_dimension_spec=TimeDimensionSpec(
-                element_name=MTD, entity_links=(), time_granularity=TimeGranularity.MONTH
-            ),
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.MONTH),
             descending=True,
         ),
     ) == query_spec.order_by_specs
@@ -263,9 +257,7 @@ def test_order_by_granularity_no_conversion(bookings_query_parser: MetricFlowQue
     # The only granularity is DAY, so we expect the PTD in the order by to have that granularity.
     assert (
         OrderBySpec(
-            time_dimension_spec=TimeDimensionSpec(
-                element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY
-            ),
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
             descending=False,
         ),
     ) == query_spec.order_by_specs

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -5,16 +5,13 @@
         <OrderByLimitNode>
             <!-- description = Order By ['listing__country_latest'] Limit 100 -->
             <!-- node_id = obl_0 -->
-            <!-- order_by_spec =                                                         -->
-            <!--   {'class': 'OrderBySpec',                                              -->
-            <!--    'descending': False,                                                 -->
-            <!--    'metric_spec': None,                                                 -->
-            <!--    'dimension_spec': {'class': 'DimensionSpec',                         -->
-            <!--                       'element_name': 'country_latest',                 -->
-            <!--                       'entity_links': ({'class': 'EntityReference',     -->
-            <!--                                         'element_name': 'listing'},)},  -->
-            <!--    'time_dimension_spec': None,                                         -->
-            <!--    'entity_spec': None}                                                 -->
+            <!-- order_by_spec =                                                        -->
+            <!--   {'class': 'OrderBySpec',                                             -->
+            <!--    'instance_spec': {'class': 'DimensionSpec',                         -->
+            <!--                      'element_name': 'country_latest',                 -->
+            <!--                      'entity_links': ({'class': 'EntityReference',     -->
+            <!--                                        'element_name': 'listing'},)},  -->
+            <!--    'descending': False}                                                -->
             <!-- limit = 100 -->
             <FilterElementsNode>
                 <!-- description =                    -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -5,30 +5,24 @@
         <OrderByLimitNode>
             <!-- description = Order By ['metric_time__day', 'bookings'] -->
             <!-- node_id = obl_0 -->
-            <!-- order_by_spec =                                                      -->
-            <!--   {'class': 'OrderBySpec',                                           -->
-            <!--    'descending': False,                                              -->
-            <!--    'metric_spec': None,                                              -->
-            <!--    'dimension_spec': None,                                           -->
-            <!--    'time_dimension_spec': {'class': 'TimeDimensionSpec',             -->
-            <!--                            'element_name': 'metric_time',            -->
-            <!--                            'entity_links': (),                       -->
-            <!--                            'time_granularity': TimeGranularity.DAY,  -->
-            <!--                            'date_part': None,                        -->
-            <!--                            'aggregation_state': None},               -->
-            <!--    'entity_spec': None}                                              -->
-            <!-- order_by_spec =                                 -->
-            <!--   {'class': 'OrderBySpec',                      -->
-            <!--    'descending': True,                          -->
-            <!--    'metric_spec': {'class': 'MetricSpec',       -->
-            <!--                    'element_name': 'bookings',  -->
-            <!--                    'constraint': None,          -->
-            <!--                    'alias': None,               -->
-            <!--                    'offset_window': None,       -->
-            <!--                    'offset_to_grain': None},    -->
-            <!--    'dimension_spec': None,                      -->
-            <!--    'time_dimension_spec': None,                 -->
-            <!--    'entity_spec': None}                         -->
+            <!-- order_by_spec =                                                -->
+            <!--   {'class': 'OrderBySpec',                                     -->
+            <!--    'instance_spec': {'class': 'TimeDimensionSpec',             -->
+            <!--                      'element_name': 'metric_time',            -->
+            <!--                      'entity_links': (),                       -->
+            <!--                      'time_granularity': TimeGranularity.DAY,  -->
+            <!--                      'date_part': None,                        -->
+            <!--                      'aggregation_state': None},               -->
+            <!--    'descending': False}                                        -->
+            <!-- order_by_spec =                                   -->
+            <!--   {'class': 'OrderBySpec',                        -->
+            <!--    'instance_spec': {'class': 'MetricSpec',       -->
+            <!--                      'element_name': 'bookings',  -->
+            <!--                      'constraint': None,          -->
+            <!--                      'alias': None,               -->
+            <!--                      'offset_window': None,       -->
+            <!--                      'offset_to_grain': None},    -->
+            <!--    'descending': True}                            -->
             <!-- limit = None -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->


### PR DESCRIPTION
### Description

Thanks to some earlier changes, the `OrderBySpec` class can be made easier / cleaner to use by having a single `InstanceSpec` field instead of more concrete types.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
