### PR TITLE
Coerce time granularity to configured value in all cases

### DIFF
--- a/.changes/unreleased/Fixes-20231005-124722.yaml
+++ b/.changes/unreleased/Fixes-20231005-124722.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Coerce time granularity to configured value to prevent finer-grained timestamps
+  from causing unexpected query behavior
+time: 2023-10-05T12:47:22.662371-07:00
+custom:
+  Author: tlento
+  Issue: "714"

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
   , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
   , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
   , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
   , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
   , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
   , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC(id_verifications_src_10003.ds, day) AS ds__day
   , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
   , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
   , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dayofweek FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(dayofyear FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, day) AS ds_partitioned__day
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dayofweek FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC(id_verifications_src_10003.ds, day) AS verification__ds__day
   , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
   , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
   , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dayofweek FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(dayofyear FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, day) AS verification__ds_partitioned__day
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
   , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/BigQuery/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC(users_latest_src_10008.ds, day) AS ds_latest__day
   , DATE_TRUNC(users_latest_src_10008.ds, isoweek) AS ds_latest__week
   , DATE_TRUNC(users_latest_src_10008.ds, month) AS ds_latest__month
   , DATE_TRUNC(users_latest_src_10008.ds, quarter) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dayofweek FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(dayofyear FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC(users_latest_src_10008.ds, day) AS user__ds_latest__day
   , DATE_TRUNC(users_latest_src_10008.ds, isoweek) AS user__ds_latest__week
   , DATE_TRUNC(users_latest_src_10008.ds, month) AS user__ds_latest__month
   , DATE_TRUNC(users_latest_src_10008.ds, quarter) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Databricks/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC('day', users_latest_src_10008.ds) AS ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dow FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(doy FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC('day', users_latest_src_10008.ds) AS user__ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS user__ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS user__ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/DuckDB/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC('day', users_latest_src_10008.ds) AS ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dow FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(doy FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC('day', users_latest_src_10008.ds) AS user__ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS user__ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS user__ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Postgres/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC('day', users_latest_src_10008.ds) AS ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dow FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(doy FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC('day', users_latest_src_10008.ds) AS user__ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS user__ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS user__ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Redshift/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC('day', users_latest_src_10008.ds) AS ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dow FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(doy FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC('day', users_latest_src_10008.ds) AS user__ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS user__ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS user__ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_query_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_query_semantic_model__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'revenue'
 SELECT
   revenue_src_10006.revenue AS txn_revenue
-  , revenue_src_10006.created_at AS ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
   , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
   , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-  , revenue_src_10006.created_at AS company__ds__day
+  , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
   , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
   , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
   , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_table_semantic_model_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_table_semantic_model_with_measures__plan0.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'id_verifications'
 SELECT
   1 AS identity_verifications
-  , id_verifications_src_10003.ds AS ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -26,7 +26,7 @@ SELECT
   , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
   , id_verifications_src_10003.verification_type
-  , id_verifications_src_10003.ds AS verification__ds__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -38,7 +38,7 @@ SELECT
   , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
   , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
   , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-  , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+  , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
   , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
   , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
   , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_table_semantic_model_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_semantic_model.py/SqlQueryPlan/Snowflake/test_convert_table_semantic_model_without_measures__plan0.sql
@@ -1,6 +1,6 @@
 -- Read Elements From Semantic Model 'users_latest'
 SELECT
-  users_latest_src_10008.ds AS ds_latest__day
+  DATE_TRUNC('day', users_latest_src_10008.ds) AS ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS ds_latest__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(dow FROM users_latest_src_10008.ds) AS ds_latest__extract_dow
   , EXTRACT(doy FROM users_latest_src_10008.ds) AS ds_latest__extract_doy
   , users_latest_src_10008.home_state_latest
-  , users_latest_src_10008.ds AS user__ds_latest__day
+  , DATE_TRUNC('day', users_latest_src_10008.ds) AS user__ds_latest__day
   , DATE_TRUNC('week', users_latest_src_10008.ds) AS user__ds_latest__week
   , DATE_TRUNC('month', users_latest_src_10008.ds) AS user__ds_latest__month
   , DATE_TRUNC('quarter', users_latest_src_10008.ds) AS user__ds_latest__quarter

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/BigQuery/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/BigQuery/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Databricks/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Databricks/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/DuckDB/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/DuckDB/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Postgres/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Postgres/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Redshift/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Redshift/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Snowflake/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_manifest/Snowflake/test_build_metric_tasks__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs
   FROM ***************************.fct_animals animals_src_0
 ) subq_2

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,7 +68,7 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     account_id__customer_id__customer_name                                               -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     account_id__customer_id__customer_name                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,12 +68,12 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->
         <!--     GROUP BY                                                                            -->
-        <!--       ds                                                                                -->
+        <!--       DATE_TRUNC('day', ds)                                                             -->
         <!--       , is_instant                                                                      -->
         <!--   ) subq_14                                                                             -->
         <!--   ON                                                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     subq_7.customer_id__customer_name                                                    -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     subq_7.customer_id__customer_name                                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,12 +68,12 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->
         <!--     GROUP BY                                                                            -->
-        <!--       ds                                                                                -->
+        <!--       DATE_TRUNC('day', ds)                                                             -->
         <!--       , is_instant                                                                      -->
         <!--   ) subq_14                                                                             -->
         <!--   ON                                                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     subq_7.customer_id__customer_name                                                    -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     subq_7.customer_id__customer_name                                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,12 +68,12 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->
         <!--     GROUP BY                                                                            -->
-        <!--       ds                                                                                -->
+        <!--       DATE_TRUNC('day', ds)                                                             -->
         <!--       , is_instant                                                                      -->
         <!--   ) subq_14                                                                             -->
         <!--   ON                                                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     subq_7.customer_id__customer_name                                                    -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     subq_7.customer_id__customer_name                                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,12 +68,12 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->
         <!--     GROUP BY                                                                            -->
-        <!--       ds                                                                                -->
+        <!--       DATE_TRUNC('day', ds)                                                             -->
         <!--       , is_instant                                                                      -->
         <!--   ) subq_14                                                                             -->
         <!--   ON                                                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     subq_7.customer_id__customer_name                                                    -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     subq_7.customer_id__customer_name                                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_combined_metrics_plan__ep_0.xml
@@ -23,7 +23,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['bookings', 'is_instant', 'ds__day']                                        -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , 1 AS bookings                                                                 -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -45,7 +45,7 @@
         <!--       -- Pass Only Elements:                                                            -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds__day']                                -->
         <!--       SELECT                                                                            -->
-        <!--         ds AS ds__day                                                                   -->
+        <!--         DATE_TRUNC('day', ds) AS ds__day                                                -->
         <!--         , is_instant                                                                    -->
         <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
         <!--       FROM ***************************.fct_bookings bookings_source_src_10001           -->
@@ -68,12 +68,12 @@
         <!--     -- Aggregate Measures                                                               -->
         <!--     -- Compute Metrics via Expressions                                                  -->
         <!--     SELECT                                                                              -->
-        <!--       ds AS ds__day                                                                     -->
+        <!--       DATE_TRUNC('day', ds) AS ds__day                                                  -->
         <!--       , is_instant                                                                      -->
         <!--       , SUM(booking_value) AS booking_value                                             -->
         <!--     FROM ***************************.fct_bookings bookings_source_src_10001             -->
         <!--     GROUP BY                                                                            -->
-        <!--       ds                                                                                -->
+        <!--       DATE_TRUNC('day', ds)                                                             -->
         <!--       , is_instant                                                                      -->
         <!--   ) subq_14                                                                             -->
         <!--   ON                                                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_multihop_joined_plan__ep_0.xml
@@ -2,41 +2,41 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                              -->
-        <!--   -- Join Standard Outputs                                                               -->
-        <!--   -- Pass Only Elements:                                                                 -->
-        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                           -->
-        <!--   -- Aggregate Measures                                                                  -->
-        <!--   -- Compute Metrics via Expressions                                                     -->
-        <!--   SELECT                                                                                 -->
-        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
-        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
-        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
-        <!--   LEFT OUTER JOIN (                                                                      -->
-        <!--     -- Join Standard Outputs                                                             -->
-        <!--     -- Pass Only Elements:                                                               -->
-        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']             -->
-        <!--     SELECT                                                                               -->
-        <!--       bridge_table_src_10011.ds_partitioned AS ds_partitioned__day                       -->
-        <!--       , bridge_table_src_10011.account_id AS account_id                                  -->
-        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name             -->
-        <!--     FROM ***************************.bridge_table bridge_table_src_10011                 -->
-        <!--     LEFT OUTER JOIN                                                                      -->
-        <!--       ***************************.customer_table customer_table_src_10013                -->
-        <!--     ON                                                                                   -->
-        <!--       (                                                                                  -->
-        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id        -->
-        <!--       ) AND (                                                                            -->
-        <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
-        <!--       )                                                                                  -->
-        <!--   ) subq_7                                                                               -->
-        <!--   ON                                                                                     -->
-        <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
-        <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned__day           -->
-        <!--     )                                                                                    -->
-        <!--   GROUP BY                                                                               -->
-        <!--     subq_7.customer_id__customer_name                                                    -->
+        <!-- sql_query =                                                                                                                    -->
+        <!--   -- Join Standard Outputs                                                                                                     -->
+        <!--   -- Pass Only Elements:                                                                                                       -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                                                                 -->
+        <!--   -- Aggregate Measures                                                                                                        -->
+        <!--   -- Compute Metrics via Expressions                                                                                           -->
+        <!--   SELECT                                                                                                                       -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name                                                -->
+        <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                                                                 -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_10010                                             -->
+        <!--   LEFT OUTER JOIN (                                                                                                            -->
+        <!--     -- Join Standard Outputs                                                                                                   -->
+        <!--     -- Pass Only Elements:                                                                                                     -->
+        <!--     --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']                                                   -->
+        <!--     SELECT                                                                                                                     -->
+        <!--       DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day                                          -->
+        <!--       , bridge_table_src_10011.account_id AS account_id                                                                        -->
+        <!--       , customer_table_src_10013.customer_name AS customer_id__customer_name                                                   -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_10011                                                       -->
+        <!--     LEFT OUTER JOIN                                                                                                            -->
+        <!--       ***************************.customer_table customer_table_src_10013                                                      -->
+        <!--     ON                                                                                                                         -->
+        <!--       (                                                                                                                        -->
+        <!--         bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id                                              -->
+        <!--       ) AND (                                                                                                                  -->
+        <!--         DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)  -->
+        <!--       )                                                                                                                        -->
+        <!--   ) subq_7                                                                                                                     -->
+        <!--   ON                                                                                                                           -->
+        <!--     (                                                                                                                          -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                                                              -->
+        <!--     ) AND (                                                                                                                    -->
+        <!--       DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_7.ds_partitioned__day                              -->
+        <!--     )                                                                                                                          -->
+        <!--   GROUP BY                                                                                                                     -->
+        <!--     subq_7.customer_id__customer_name                                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,7 +30,7 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC(views_source_src_10009.ds, day) AS ds__day
                   , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS ds__week
                   , DATE_TRUNC(views_source_src_10009.ds, month) AS ds__month
                   , DATE_TRUNC(views_source_src_10009.ds, quarter) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC(views_source_src_10009.ds, day) AS view__ds__day
                   , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS view__ds__week
                   , DATE_TRUNC(views_source_src_10009.ds, month) AS view__ds__month
                   , DATE_TRUNC(views_source_src_10009.ds, quarter) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dayofweek FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(dayofyear FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, day) AS view__ds_partitioned__day
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS view__ds_partitioned__week
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS view__ds_partitioned__month
                   , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC(ds, day) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC(ds, day) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
         , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
         , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
         , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
         , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
         , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
         , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
         , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
         , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
         , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
         , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
         , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
         , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
         , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC(ds, day) AS ds__day
+  , DATE_TRUNC(ds, day) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
           , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
           , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
           , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC(created_at, month) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dayofweek FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
             , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
             , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
             , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC(created_at, month) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC(created_at, day) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC(bookings_source_src_10001.ds, day) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > DATE_SUB(CAST(subq_14.ds AS DATETIME), INTERVAL 2 day)
+        DATE_TRUNC(bookings_source_src_10001.ds, day) > DATE_SUB(CAST(subq_14.ds AS DATETIME), INTERVAL 2 day)
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC(ds, day) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                   , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                   , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                   , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10015.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10015.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,7 +23,7 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,7 +23,7 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,7 +23,7 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC(ds, day) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
           , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
           , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
           , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
                       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
                       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
                       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC(bookings_source_src_10001.ds, day) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC(ds, day) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,7 +91,7 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,7 +35,7 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10015.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10015.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC(users_latest_src_10021.ds, day) AS ds__day
                 , DATE_TRUNC(users_latest_src_10021.ds, isoweek) AS ds__week
                 , DATE_TRUNC(users_latest_src_10021.ds, month) AS ds__month
                 , DATE_TRUNC(users_latest_src_10021.ds, quarter) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dayofweek FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC(users_latest_src_10021.ds, day) AS user__ds__day
                 , DATE_TRUNC(users_latest_src_10021.ds, isoweek) AS user__ds__week
                 , DATE_TRUNC(users_latest_src_10021.ds, month) AS user__ds__month
                 , DATE_TRUNC(users_latest_src_10021.ds, quarter) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10015.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10015.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10015.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10015.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10015.ds, quarter) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10015.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10015.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10015.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10015.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10015.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC(account_month_txns_src_10010.ds, day) AS ds__day
               , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS ds__week
               , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS ds__month
               , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dayofweek FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, day) AS account_id__ds_partitioned__day
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS account_id__ds_partitioned__month
               , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC(account_month_txns_src_10010.ds, day) AS account_id__ds__day
               , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS account_id__ds__week
               , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS account_id__ds__month
               , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dayofweek FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, day) AS account_id__ds_partitioned__day
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, month) AS account_id__ds_partitioned__month
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dayofweek FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, day) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, isoweek) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, month) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC(bridge_table_src_10011.ds_partitioned, quarter) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(dayofyear FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC(customer_table_src_10013.ds_partitioned, day) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoweek) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, month) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, quarter) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC(bridge_table_src_10011.ds_partitioned, day) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC(bridge_table_src_10011.ds_partitioned, day) = DATE_TRUNC(customer_table_src_10013.ds_partitioned, day)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, day) = subq_18.ds_partitioned__day
   )
 GROUP BY
   account_id__customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
               , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
               , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
               , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC(created_at, day) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC(ds, day) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC(ds, day) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
               , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
               , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
               , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
               , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
               , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
               , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
               , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
                 , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
                 , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
                 , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
                 , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
                 , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC(ds, day) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC(id_verifications_src_10003.ds, day) AS ds__day
               , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
               , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
               , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dayofweek FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(dayofyear FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, day) AS ds_partitioned__day
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dayofweek FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(dayofyear FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC(id_verifications_src_10003.ds, day) AS verification__ds__day
               , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
               , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
               , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dayofweek FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(dayofyear FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, day) AS verification__ds_partitioned__day
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
               , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC(users_ds_source_src_10007.ds, day) AS ds__day
             , DATE_TRUNC(users_ds_source_src_10007.ds, isoweek) AS ds__week
             , DATE_TRUNC(users_ds_source_src_10007.ds, month) AS ds__month
             , DATE_TRUNC(users_ds_source_src_10007.ds, quarter) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC(users_ds_source_src_10007.created_at, day) AS created_at__day
             , DATE_TRUNC(users_ds_source_src_10007.created_at, isoweek) AS created_at__week
             , DATE_TRUNC(users_ds_source_src_10007.created_at, month) AS created_at__month
             , DATE_TRUNC(users_ds_source_src_10007.created_at, quarter) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dayofweek FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(dayofyear FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dayofweek FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC(users_ds_source_src_10007.ds, day) AS user__ds__day
             , DATE_TRUNC(users_ds_source_src_10007.ds, isoweek) AS user__ds__week
             , DATE_TRUNC(users_ds_source_src_10007.ds, month) AS user__ds__month
             , DATE_TRUNC(users_ds_source_src_10007.ds, quarter) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dayofweek FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(dayofyear FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC(users_ds_source_src_10007.created_at, day) AS user__created_at__day
             , DATE_TRUNC(users_ds_source_src_10007.created_at, isoweek) AS user__created_at__week
             , DATE_TRUNC(users_ds_source_src_10007.created_at, month) AS user__created_at__month
             , DATE_TRUNC(users_ds_source_src_10007.created_at, quarter) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dayofweek FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(dayofyear FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, day) AS user__ds_partitioned__day
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, isoweek) AS user__ds_partitioned__week
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, month) AS user__ds_partitioned__month
             , DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, quarter) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC(ds_partitioned, day) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC(users_ds_source_src_10007.ds_partitioned, day)
   )
 GROUP BY
   user__home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC(ds, day) AS ds__day
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC(ds, day) AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC(ds, day)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC(ds, day) AS ds__day
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC(ds, day) AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC(ds, day)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
     , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
     , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
     , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dayofweek FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC(accounts_source_src_10000.ds, day) AS account__ds__day
       , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS account__ds__week
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS account__ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC(ds, day) AS ds__day
     , DATE_TRUNC(ds, isoweek) AS ds__week
     , DATE_TRUNC(ds, month) AS ds__month
     , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC(ds, day) AS account__ds__day
     , DATE_TRUNC(ds, isoweek) AS account__ds__week
     , DATE_TRUNC(ds, month) AS account__ds__month
     , DATE_TRUNC(ds, quarter) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC(ds, isoweek) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC(ds, day)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     ds__week

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
           , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
           , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
           , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
           , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
           , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
           , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
           , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
       , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
       , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
       , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
       , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
       , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
       , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
       , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__ds__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dayofweek FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(dayofyear FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC(listings_latest_src_10004.created_at, day) AS listing__created_at__day
       , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
       , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
       , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
   , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
   , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
   , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC(ds, day) AS ds__day
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC(paid_at, day) AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dayofweek FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(dayofyear FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC(ds, day) AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS booking__ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC(paid_at, day) AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS view__ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS view__ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS view__ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC('day', ds) AS ds__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > DATEADD(day, -2, subq_14.ds)
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_14.ds)
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,11 +91,11 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
   ) subq_58
   ON
     (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,11 +35,11 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_24
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC('day', users_latest_src_10021.ds) AS ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dow FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC('day', users_latest_src_10021.ds) AS user__ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS user__ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS user__ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dow FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS account_id__ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(doy FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_18.ds_partitioned__day
   )
 GROUP BY
   subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC('day', users_ds_source_src_10007.ds) AS ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dow FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds) AS user__ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS user__ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS user__ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS user__created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS user__created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS user__created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned)
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC('week', ds) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     DATE_TRUNC('week', ds)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS view__ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS view__ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS view__ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC('day', ds) AS ds__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > subq_14.ds - INTERVAL 2 day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_14.ds - INTERVAL 2 day
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,11 +91,11 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
   ) subq_58
   ON
     (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,11 +35,11 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_24
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC('day', users_latest_src_10021.ds) AS ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dow FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC('day', users_latest_src_10021.ds) AS user__ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS user__ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS user__ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dow FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS account_id__ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(doy FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_18.ds_partitioned__day
   )
 GROUP BY
   subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC('day', users_ds_source_src_10007.ds) AS ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dow FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds) AS user__ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS user__ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS user__ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS user__created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS user__created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS user__created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned)
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC('week', ds) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     DATE_TRUNC('week', ds)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS view__ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS view__ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS view__ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC('day', ds) AS ds__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > subq_14.ds - MAKE_INTERVAL(days => 2)
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_14.ds - MAKE_INTERVAL(days => 2)
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,11 +91,11 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
   ) subq_58
   ON
     (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,11 +35,11 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_24
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC('day', users_latest_src_10021.ds) AS ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dow FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC('day', users_latest_src_10021.ds) AS user__ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS user__ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS user__ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dow FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS account_id__ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(doy FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_18.ds_partitioned__day
   )
 GROUP BY
   subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC('day', users_ds_source_src_10007.ds) AS ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dow FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds) AS user__ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS user__ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS user__ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS user__created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS user__created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS user__created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned)
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC('week', ds) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     DATE_TRUNC('week', ds)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS view__ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS view__ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS view__ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC('day', ds) AS ds__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > DATEADD(day, -2, subq_14.ds)
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_14.ds)
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,11 +91,11 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
   ) subq_58
   ON
     (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,11 +35,11 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_24
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC('day', users_latest_src_10021.ds) AS ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dow FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC('day', users_latest_src_10021.ds) AS user__ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS user__ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS user__ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dow FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS account_id__ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(doy FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_18.ds_partitioned__day
   )
 GROUP BY
   subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC('day', users_ds_source_src_10007.ds) AS ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dow FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds) AS user__ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS user__ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS user__ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS user__created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS user__created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS user__created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned)
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC('week', ds) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     DATE_TRUNC('week', ds)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -398,7 +398,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -435,7 +435,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -169,7 +169,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -181,7 +181,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -193,7 +193,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -206,7 +206,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -218,7 +218,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -230,7 +230,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -339,7 +339,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -351,7 +351,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -366,7 +366,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -378,7 +378,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -514,7 +514,7 @@ FROM (
                 -- Read Elements From Semantic Model 'views_source'
                 SELECT
                   1 AS views
-                  , views_source_src_10009.ds AS ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
@@ -526,7 +526,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
@@ -538,7 +538,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds_partitioned) AS ds_partitioned__extract_doy
-                  , views_source_src_10009.ds AS view__ds__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds) AS view__ds__day
                   , DATE_TRUNC('week', views_source_src_10009.ds) AS view__ds__week
                   , DATE_TRUNC('month', views_source_src_10009.ds) AS view__ds__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds) AS view__ds__quarter
@@ -550,7 +550,7 @@ FROM (
                   , EXTRACT(day FROM views_source_src_10009.ds) AS view__ds__extract_day
                   , EXTRACT(dow FROM views_source_src_10009.ds) AS view__ds__extract_dow
                   , EXTRACT(doy FROM views_source_src_10009.ds) AS view__ds__extract_doy
-                  , views_source_src_10009.ds_partitioned AS view__ds_partitioned__day
+                  , DATE_TRUNC('day', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__day
                   , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__week
                   , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__month
                   , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS view__ds_partitioned__quarter
@@ -657,7 +657,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -669,7 +669,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -684,7 +684,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -696,7 +696,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -49,7 +49,7 @@ INNER JOIN (
     -- Pass Only Elements:
     --   ['views', 'ds__day', 'listing']
     SELECT
-      ds AS ds__day
+      DATE_TRUNC('day', ds) AS ds__day
       , listing_id AS listing
       , 1 AS views
     FROM ***************************.fct_views views_source_src_10009

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -42,7 +42,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -54,7 +54,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -66,7 +66,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -79,7 +79,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -91,7 +91,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -103,7 +103,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -136,7 +136,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -148,7 +148,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -163,7 +163,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -175,7 +175,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
@@ -39,7 +39,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -51,7 +51,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -63,7 +63,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -76,7 +76,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -88,7 +88,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -100,7 +100,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -133,7 +133,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -145,7 +145,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -160,7 +160,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -172,7 +172,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0.sql
@@ -33,7 +33,7 @@ FROM (
         , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
         , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
         , bookings_source_src_10001.is_instant
-        , bookings_source_src_10001.ds AS ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -45,7 +45,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -57,7 +57,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -70,7 +70,7 @@ FROM (
         , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
         , bookings_source_src_10001.is_instant AS booking__is_instant
-        , bookings_source_src_10001.ds AS booking__ds__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -82,7 +82,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-        , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+        , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
         , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
         , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -94,7 +94,7 @@ FROM (
         , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
         , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
         , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-        , bookings_source_src_10001.paid_at AS booking__paid_at__day
+        , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
         , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
         , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
         , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_constrain_time_range_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
 SELECT
-  ds AS ds__day
-  , ds AS metric_time__day
+  DATE_TRUNC('day', ds) AS ds__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , 1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_10001
-WHERE ds BETWEEN '2020-01-01' AND '2020-01-02'
+WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_grain_to_date__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_ds__plan0.sql
@@ -56,7 +56,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -68,7 +68,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window__plan0.sql
@@ -59,7 +59,7 @@ FROM (
         -- Read Elements From Semantic Model 'revenue'
         SELECT
           revenue_src_10006.revenue AS txn_revenue
-          , revenue_src_10006.created_at AS ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -71,7 +71,7 @@ FROM (
           , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
           , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-          , revenue_src_10006.created_at AS company__ds__day
+          , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
           , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
           , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
           , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS revenue_all_time
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2000-01-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           -- Read Elements From Semantic Model 'revenue'
           SELECT
             revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
             , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
             , EXTRACT(dow FROM revenue_src_10006.created_at) AS ds__extract_dow
             , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , revenue_src_10006.created_at AS company__ds__day
+            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
             , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
             , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
             , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -9,6 +9,6 @@ SELECT
   DATE_TRUNC('month', created_at) AS ds__month
   , SUM(revenue) AS trailing_2_months_revenue
 FROM ***************************.fct_revenue revenue_src_10006
-WHERE created_at BETWEEN '2019-12-01' AND '2020-01-01'
+WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
 GROUP BY
   DATE_TRUNC('month', created_at)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -379,7 +379,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -391,7 +391,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -403,7 +403,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -416,7 +416,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -428,7 +428,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -440,7 +440,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['referred_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_13
@@ -39,7 +39,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_16
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -588,7 +588,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -600,7 +600,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -612,7 +612,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -625,7 +625,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -637,7 +637,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -649,7 +649,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -45,7 +45,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -253,7 +253,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -265,7 +265,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -277,7 +277,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -290,7 +290,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -302,7 +302,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -314,7 +314,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -589,7 +589,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -22,7 +22,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_18
@@ -46,7 +46,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_26

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -361,7 +361,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -373,7 +373,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -385,7 +385,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -398,7 +398,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -410,7 +410,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -422,7 +422,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0_optimized.sql
@@ -22,9 +22,9 @@ FROM (
       ***************************.fct_bookings bookings_source_src_10001
     ON
       (
-        bookings_source_src_10001.ds <= subq_14.ds
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_14.ds
       ) AND (
-        bookings_source_src_10001.ds > DATEADD(day, -2, subq_14.ds)
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_14.ds)
       )
   ) subq_15
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -247,7 +247,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -259,7 +259,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -271,7 +271,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -284,7 +284,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -296,7 +296,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -308,7 +308,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0_optimized.sql
@@ -16,7 +16,7 @@ FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0.sql
@@ -160,7 +160,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -172,7 +172,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -197,7 +197,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -209,7 +209,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -221,7 +221,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -330,7 +330,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -342,7 +342,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -357,7 +357,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -369,7 +369,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_node__plan0.sql
@@ -20,7 +20,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -32,7 +32,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -44,7 +44,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -57,7 +57,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -69,7 +69,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -81,7 +81,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,7 +7,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -166,7 +166,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -190,7 +190,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -227,7 +227,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -336,7 +336,7 @@ FROM (
                   1 AS listings
                   , listings_latest_src_10004.capacity AS largest_listing
                   , listings_latest_src_10004.capacity AS smallest_listing
-                  , listings_latest_src_10004.created_at AS ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -348,7 +348,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                  , listings_latest_src_10004.created_at AS created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -363,7 +363,7 @@ FROM (
                   , listings_latest_src_10004.country AS country_latest
                   , listings_latest_src_10004.is_lux AS is_lux_latest
                   , listings_latest_src_10004.capacity AS capacity_latest
-                  , listings_latest_src_10004.created_at AS listing__ds__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -375,7 +375,7 @@ FROM (
                   , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                   , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                   , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                  , listings_latest_src_10004.created_at AS listing__created_at__day
+                  , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                   , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                   , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                   , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0.sql
@@ -154,7 +154,7 @@ FROM (
                   , bookings_source_src_10015.booking_value AS average_booking_value
                   , bookings_source_src_10015.booking_value AS booking_payments
                   , bookings_source_src_10015.is_instant
-                  , bookings_source_src_10015.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -166,7 +166,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -178,7 +178,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -191,7 +191,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10015.is_instant AS booking__is_instant
-                  , bookings_source_src_10015.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -203,7 +203,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -215,7 +215,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10015.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0_optimized.sql
@@ -20,7 +20,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day', 'listing']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -155,7 +155,7 @@ INNER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -167,7 +167,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -179,7 +179,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -192,7 +192,7 @@ INNER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -204,7 +204,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -216,7 +216,7 @@ INNER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -23,12 +23,12 @@ INNER JOIN (
     --   ['booking_value', 'metric_time__day', 'listing']
     -- Aggregate Measures
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
       , listing_id
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0.sql
@@ -144,7 +144,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_limit_rows__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_local_dimension_using_local_entity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_local_dimension_using_local_entity__plan0.sql
@@ -94,7 +94,7 @@ FROM (
           1 AS listings
           , listings_latest_src_10004.capacity AS largest_listing
           , listings_latest_src_10004.capacity AS smallest_listing
-          , listings_latest_src_10004.created_at AS ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -106,7 +106,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-          , listings_latest_src_10004.created_at AS created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -121,7 +121,7 @@ FROM (
           , listings_latest_src_10004.country AS country_latest
           , listings_latest_src_10004.is_lux AS is_lux_latest
           , listings_latest_src_10004.capacity AS capacity_latest
-          , listings_latest_src_10004.created_at AS listing__ds__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -133,7 +133,7 @@ FROM (
           , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
           , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
           , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-          , listings_latest_src_10004.created_at AS listing__created_at__day
+          , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
           , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
           , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
           , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_aggregation_node__plan0.sql
@@ -30,7 +30,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -42,7 +42,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -54,7 +54,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -67,7 +67,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -79,7 +79,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -91,7 +91,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
@@ -178,7 +178,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -190,7 +190,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -202,7 +202,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -215,7 +215,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -227,7 +227,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -348,7 +348,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -360,7 +360,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -375,7 +375,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -387,7 +387,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -589,7 +589,7 @@ FROM (
                       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                       , bookings_source_src_10001.is_instant
-                      , bookings_source_src_10001.ds AS ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -601,7 +601,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -613,7 +613,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -626,7 +626,7 @@ FROM (
                       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                       , bookings_source_src_10001.is_instant AS booking__is_instant
-                      , bookings_source_src_10001.ds AS booking__ds__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -638,7 +638,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -650,7 +650,7 @@ FROM (
                       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -759,7 +759,7 @@ FROM (
                       1 AS listings
                       , listings_latest_src_10004.capacity AS largest_listing
                       , listings_latest_src_10004.capacity AS smallest_listing
-                      , listings_latest_src_10004.created_at AS ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -771,7 +771,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-                      , listings_latest_src_10004.created_at AS created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -786,7 +786,7 @@ FROM (
                       , listings_latest_src_10004.country AS country_latest
                       , listings_latest_src_10004.is_lux AS is_lux_latest
                       , listings_latest_src_10004.capacity AS capacity_latest
-                      , listings_latest_src_10004.created_at AS listing__ds__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -798,7 +798,7 @@ FROM (
                       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
                       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
                       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-                      , listings_latest_src_10004.created_at AS listing__created_at__day
+                      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
                       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
                       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
                       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -983,7 +983,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -995,7 +995,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -1007,7 +1007,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -1020,7 +1020,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -1032,7 +1032,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -1044,7 +1044,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0_optimized.sql
@@ -23,7 +23,7 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        bookings_source_src_10001.ds AS metric_time__day
+        DATE_TRUNC('day', bookings_source_src_10001.ds) AS metric_time__day
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
         , bookings_source_src_10001.booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_10001
@@ -59,7 +59,7 @@ FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time__day', 'listing']
         SELECT
-          ds AS metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
@@ -91,11 +91,11 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
     GROUP BY
-      ds
+      DATE_TRUNC('day', ds)
   ) subq_58
   ON
     (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
@@ -163,7 +163,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -175,7 +175,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -187,7 +187,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -200,7 +200,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -212,7 +212,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -224,7 +224,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -395,7 +395,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -407,7 +407,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -419,7 +419,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -444,7 +444,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -456,7 +456,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Pass Only Elements:
     --   ['booking_value', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
@@ -35,11 +35,11 @@ INNER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , SUM(booking_value) AS booking_value
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    ds
+    DATE_TRUNC('day', ds)
 ) subq_24
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -157,7 +157,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -169,7 +169,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -181,7 +181,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -194,7 +194,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -206,7 +206,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -218,7 +218,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -145,7 +145,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -324,7 +324,7 @@ FROM (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -336,7 +336,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -351,7 +351,7 @@ FROM (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -363,7 +363,7 @@ FROM (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter
@@ -432,7 +432,7 @@ FROM (
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
-                users_latest_src_10021.ds AS ds__day
+                DATE_TRUNC('day', users_latest_src_10021.ds) AS ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS ds__quarter
@@ -445,7 +445,7 @@ FROM (
                 , EXTRACT(dow FROM users_latest_src_10021.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM users_latest_src_10021.ds) AS ds__extract_doy
                 , users_latest_src_10021.home_state_latest
-                , users_latest_src_10021.ds AS user__ds__day
+                , DATE_TRUNC('day', users_latest_src_10021.ds) AS user__ds__day
                 , DATE_TRUNC('week', users_latest_src_10021.ds) AS user__ds__week
                 , DATE_TRUNC('month', users_latest_src_10021.ds) AS user__ds__month
                 , DATE_TRUNC('quarter', users_latest_src_10021.ds) AS user__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
@@ -144,7 +144,7 @@ FROM (
               , bookings_source_src_10015.booking_value AS average_booking_value
               , bookings_source_src_10015.booking_value AS booking_payments
               , bookings_source_src_10015.is_instant
-              , bookings_source_src_10015.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS ds__quarter
@@ -156,7 +156,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS paid_at__quarter
@@ -181,7 +181,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10015.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10015.is_instant AS booking__is_instant
-              , bookings_source_src_10015.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds) AS booking__ds__quarter
@@ -193,7 +193,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10015.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10015.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10015.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10015.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10015.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10015.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10015.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day', 'listing']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10015

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
@@ -28,7 +28,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -40,7 +40,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -52,7 +52,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -65,7 +65,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -77,7 +77,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -89,7 +89,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -122,7 +122,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -134,7 +134,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -149,7 +149,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -161,7 +161,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
@@ -196,7 +196,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -208,7 +208,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -223,7 +223,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -235,7 +235,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
@@ -99,7 +99,7 @@ FROM (
             -- Read Elements From Semantic Model 'account_month_txns'
             SELECT
               account_month_txns_src_10010.txn_count
-              , account_month_txns_src_10010.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
@@ -111,7 +111,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
@@ -124,7 +124,7 @@ FROM (
               , EXTRACT(dow FROM account_month_txns_src_10010.ds) AS ds__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds) AS ds__extract_doy
               , account_month_txns_src_10010.account_month
-              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -136,7 +136,7 @@ FROM (
               , EXTRACT(day FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_day
               , EXTRACT(dow FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__extract_doy
-              , account_month_txns_src_10010.ds AS account_id__ds__day
+              , DATE_TRUNC('day', account_month_txns_src_10010.ds) AS account_id__ds__day
               , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
               , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
               , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
@@ -226,7 +226,7 @@ FROM (
             -- Read Elements From Semantic Model 'bridge_table'
             SELECT
               bridge_table_src_10011.extra_dim
-              , bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__quarter
@@ -239,7 +239,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS account_id__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS account_id__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__quarter
@@ -252,7 +252,7 @@ FROM (
               , EXTRACT(dow FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bridge_table_src_10011.ds_partitioned) AS account_id__ds_partitioned__extract_doy
               , bridge_table_src_10011.extra_dim AS bridge_account__extra_dim
-              , bridge_table_src_10011.ds_partitioned AS bridge_account__ds_partitioned__day
+              , DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__day
               , DATE_TRUNC('week', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__week
               , DATE_TRUNC('month', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__month
               , DATE_TRUNC('quarter', bridge_table_src_10011.ds_partitioned) AS bridge_account__ds_partitioned__quarter
@@ -337,7 +337,7 @@ FROM (
               SELECT
                 customer_table_src_10013.customer_name
                 , customer_table_src_10013.customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS ds_partitioned__quarter
@@ -351,7 +351,7 @@ FROM (
                 , EXTRACT(doy FROM customer_table_src_10013.ds_partitioned) AS ds_partitioned__extract_doy
                 , customer_table_src_10013.customer_name AS customer_id__customer_name
                 , customer_table_src_10013.customer_atomic_weight AS customer_id__customer_atomic_weight
-                , customer_table_src_10013.ds_partitioned AS customer_id__ds_partitioned__day
+                , DATE_TRUNC('day', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__day
                 , DATE_TRUNC('week', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__week
                 , DATE_TRUNC('month', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__month
                 , DATE_TRUNC('quarter', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
@@ -12,7 +12,7 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['customer_id__customer_name', 'ds_partitioned__day', 'account_id']
   SELECT
-    bridge_table_src_10011.ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) AS ds_partitioned__day
     , bridge_table_src_10011.account_id AS account_id
     , customer_table_src_10013.customer_name AS customer_id__customer_name
   FROM ***************************.bridge_table bridge_table_src_10011
@@ -22,14 +22,14 @@ LEFT OUTER JOIN (
     (
       bridge_table_src_10011.customer_id = customer_table_src_10013.customer_id
     ) AND (
-      bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
+      DATE_TRUNC('day', bridge_table_src_10011.ds_partitioned) = DATE_TRUNC('day', customer_table_src_10013.ds_partitioned)
     )
 ) subq_18
 ON
   (
     account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_10010.ds_partitioned) = subq_18.ds_partitioned__day
   )
 GROUP BY
   subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
@@ -249,7 +249,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -261,7 +261,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -273,7 +273,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -286,7 +286,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -298,7 +298,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -310,7 +310,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -505,7 +505,7 @@ CROSS JOIN (
               1 AS listings
               , listings_latest_src_10004.capacity AS largest_listing
               , listings_latest_src_10004.capacity AS smallest_listing
-              , listings_latest_src_10004.created_at AS ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -517,7 +517,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-              , listings_latest_src_10004.created_at AS created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -532,7 +532,7 @@ CROSS JOIN (
               , listings_latest_src_10004.country AS country_latest
               , listings_latest_src_10004.is_lux AS is_lux_latest
               , listings_latest_src_10004.capacity AS capacity_latest
-              , listings_latest_src_10004.created_at AS listing__ds__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -544,7 +544,7 @@ CROSS JOIN (
               , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
               , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
               , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-              , listings_latest_src_10004.created_at AS listing__created_at__day
+              , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
               , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
               , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
               , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001
-  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_17
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
@@ -26,5 +26,5 @@ CROSS JOIN (
   SELECT
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-  WHERE created_at BETWEEN '2020-01-01' AND '2020-01-01'
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
 ) subq_23

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0.sql
@@ -162,7 +162,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -174,7 +174,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -186,7 +186,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -199,7 +199,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -211,7 +211,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -223,7 +223,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -391,7 +391,7 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , bookings_source_src_10001.ds AS ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -403,7 +403,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -415,7 +415,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -428,7 +428,7 @@ FROM (
                   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , bookings_source_src_10001.ds AS booking__ds__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -440,7 +440,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -452,7 +452,7 @@ FROM (
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -632,7 +632,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -644,7 +644,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -656,7 +656,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -669,7 +669,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -681,7 +681,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -693,7 +693,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -871,7 +871,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -883,7 +883,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -895,7 +895,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -908,7 +908,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -920,7 +920,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -932,7 +932,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0_optimized.sql
@@ -32,7 +32,7 @@ FROM (
           -- Pass Only Elements:
           --   ['referred_bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_25
@@ -51,7 +51,7 @@ FROM (
           -- Pass Only Elements:
           --   ['bookings', 'metric_time__day']
           SELECT
-            ds AS metric_time__day
+            DATE_TRUNC('day', ds) AS metric_time__day
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_10001
         ) subq_30
@@ -82,7 +82,7 @@ FROM (
       -- Pass Only Elements:
       --   ['instant_bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_37
@@ -111,7 +111,7 @@ FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time__day']
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_42

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
@@ -150,7 +150,7 @@ FROM (
               , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
               , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
               , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds AS ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -162,7 +162,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -174,7 +174,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -187,7 +187,7 @@ FROM (
               , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
               , bookings_source_src_10001.is_instant AS booking__is_instant
-              , bookings_source_src_10001.ds AS booking__ds__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -199,7 +199,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-              , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
               , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
               , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -211,7 +211,7 @@ FROM (
               , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
               , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
               , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , bookings_source_src_10001.paid_at AS booking__paid_at__day
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
               , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
               , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
               , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -482,7 +482,7 @@ FROM (
                 , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                 , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                 , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds AS ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -494,7 +494,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -506,7 +506,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -519,7 +519,7 @@ FROM (
                 , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                 , bookings_source_src_10001.is_instant AS booking__is_instant
-                , bookings_source_src_10001.ds AS booking__ds__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -531,7 +531,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                 , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
                 , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -543,7 +543,7 @@ FROM (
                 , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
                 , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                 , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                , bookings_source_src_10001.paid_at AS booking__paid_at__day
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                 , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
                 , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
                 , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       SELECT
-        ds AS metric_time__day
+        DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_10001
     ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0.sql
@@ -40,7 +40,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -52,7 +52,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -64,7 +64,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -77,7 +77,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -89,7 +89,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -101,7 +101,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_order_by_node__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'ds__day']
   SELECT
-    ds AS ds__day
+    DATE_TRUNC('day', ds) AS ds__day
     , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_10001

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0.sql
@@ -101,7 +101,7 @@ FROM (
             -- Read Elements From Semantic Model 'id_verifications'
             SELECT
               1 AS identity_verifications
-              , id_verifications_src_10003.ds AS ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
@@ -113,7 +113,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
@@ -126,7 +126,7 @@ FROM (
               , EXTRACT(dow FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds_partitioned) AS ds_partitioned__extract_doy
               , id_verifications_src_10003.verification_type
-              , id_verifications_src_10003.ds AS verification__ds__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds) AS verification__ds__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
@@ -138,7 +138,7 @@ FROM (
               , EXTRACT(day FROM id_verifications_src_10003.ds) AS verification__ds__extract_day
               , EXTRACT(dow FROM id_verifications_src_10003.ds) AS verification__ds__extract_dow
               , EXTRACT(doy FROM id_verifications_src_10003.ds) AS verification__ds__extract_doy
-              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned__day
+              , DATE_TRUNC('day', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__day
               , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
               , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
               , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
@@ -168,7 +168,7 @@ FROM (
         FROM (
           -- Read Elements From Semantic Model 'users_ds_source'
           SELECT
-            users_ds_source_src_10007.ds AS ds__day
+            DATE_TRUNC('day', users_ds_source_src_10007.ds) AS ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS ds__quarter
@@ -180,7 +180,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS ds__extract_doy
-            , users_ds_source_src_10007.created_at AS created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS created_at__quarter
@@ -192,7 +192,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__quarter
@@ -205,7 +205,7 @@ FROM (
             , EXTRACT(dow FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds_partitioned) AS ds_partitioned__extract_doy
             , users_ds_source_src_10007.home_state
-            , users_ds_source_src_10007.ds AS user__ds__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds) AS user__ds__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds) AS user__ds__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds) AS user__ds__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds) AS user__ds__quarter
@@ -217,7 +217,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.ds) AS user__ds__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.ds) AS user__ds__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.ds) AS user__ds__extract_doy
-            , users_ds_source_src_10007.created_at AS user__created_at__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.created_at) AS user__created_at__day
             , DATE_TRUNC('week', users_ds_source_src_10007.created_at) AS user__created_at__week
             , DATE_TRUNC('month', users_ds_source_src_10007.created_at) AS user__created_at__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.created_at) AS user__created_at__quarter
@@ -229,7 +229,7 @@ FROM (
             , EXTRACT(day FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_day
             , EXTRACT(dow FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_dow
             , EXTRACT(doy FROM users_ds_source_src_10007.created_at) AS user__created_at__extract_doy
-            , users_ds_source_src_10007.ds_partitioned AS user__ds_partitioned__day
+            , DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__day
             , DATE_TRUNC('week', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__week
             , DATE_TRUNC('month', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__month
             , DATE_TRUNC('quarter', users_ds_source_src_10007.ds_partitioned) AS user__ds_partitioned__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Pass Only Elements:
   --   ['identity_verifications', 'ds_partitioned__day', 'user']
   SELECT
-    ds_partitioned AS ds_partitioned__day
+    DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
@@ -23,7 +23,7 @@ ON
   (
     subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_10.ds_partitioned__day = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned__day = DATE_TRUNC('day', users_ds_source_src_10007.ds_partitioned)
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -77,7 +77,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -90,7 +90,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -71,7 +71,7 @@ INNER JOIN (
   -- Read Elements From Semantic Model 'accounts_source'
   -- Filter row on MIN(ds__day)
   SELECT
-    MIN(ds) AS ds__day__complete
+    MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
 ) subq_5
 ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MAX(ds__day)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds__day__complete
+    , MAX(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -37,7 +37,7 @@ FROM (
     accounts_source_src_10000.account_balance
     , accounts_source_src_10000.account_balance AS total_account_balance_first_day
     , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-    , accounts_source_src_10000.ds AS ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
     , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
     , accounts_source_src_10000.account_type
-    , accounts_source_src_10000.ds AS account__ds__day
+    , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
     , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
     , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
     , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter
@@ -78,7 +78,7 @@ INNER JOIN (
       accounts_source_src_10000.account_balance
       , accounts_source_src_10000.account_balance AS total_account_balance_first_day
       , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-      , accounts_source_src_10000.ds AS ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
@@ -91,7 +91,7 @@ INNER JOIN (
       , EXTRACT(dow FROM accounts_source_src_10000.ds) AS ds__extract_dow
       , EXTRACT(doy FROM accounts_source_src_10000.ds) AS ds__extract_doy
       , accounts_source_src_10000.account_type
-      , accounts_source_src_10000.ds AS account__ds__day
+      , DATE_TRUNC('day', accounts_source_src_10000.ds) AS account__ds__day
       , DATE_TRUNC('week', accounts_source_src_10000.ds) AS account__ds__week
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS account__ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS account__ds__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     account_balance
     , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
-    , ds AS ds__day
+    , DATE_TRUNC('day', ds) AS ds__day
     , DATE_TRUNC('week', ds) AS ds__week
     , DATE_TRUNC('month', ds) AS ds__month
     , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -50,7 +50,7 @@ FROM (
     , EXTRACT(dow FROM ds) AS ds__extract_dow
     , EXTRACT(doy FROM ds) AS ds__extract_doy
     , account_type
-    , ds AS account__ds__day
+    , DATE_TRUNC('day', ds) AS account__ds__day
     , DATE_TRUNC('week', ds) AS account__ds__week
     , DATE_TRUNC('month', ds) AS account__ds__month
     , DATE_TRUNC('quarter', ds) AS account__ds__quarter
@@ -72,7 +72,7 @@ INNER JOIN (
   -- Filter row on MIN(ds__day)
   SELECT
     DATE_TRUNC('week', ds) AS ds__week
-    , MIN(ds) AS ds__day__complete
+    , MIN(DATE_TRUNC('day', ds)) AS ds__day__complete
   FROM ***************************.fct_accounts accounts_source_src_10000
   GROUP BY
     DATE_TRUNC('week', ds)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_simple_query_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_simple_query_with_date_part__plan0.sql
@@ -139,7 +139,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -151,7 +151,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -163,7 +163,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -200,7 +200,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_simple_query_with_multiple_date_parts__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_simple_query_with_multiple_date_parts__plan0.sql
@@ -164,7 +164,7 @@ FROM (
           , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
           , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
           , bookings_source_src_10001.is_instant
-          , bookings_source_src_10001.ds AS ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -176,7 +176,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -188,7 +188,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -201,7 +201,7 @@ FROM (
           , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
           , bookings_source_src_10001.is_instant AS booking__is_instant
-          , bookings_source_src_10001.ds AS booking__ds__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -213,7 +213,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-          , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+          , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
           , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
           , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -225,7 +225,7 @@ FROM (
           , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
           , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
           , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-          , bookings_source_src_10001.paid_at AS booking__paid_at__day
+          , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
           , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
           , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
           , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_single_join_node__plan0.sql
@@ -26,7 +26,7 @@ FROM (
       , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
       , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
       , bookings_source_src_10001.is_instant
-      , bookings_source_src_10001.ds AS ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -38,7 +38,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -50,7 +50,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -63,7 +63,7 @@ FROM (
       , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
       , bookings_source_src_10001.is_instant AS booking__is_instant
-      , bookings_source_src_10001.ds AS booking__ds__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -75,7 +75,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-      , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
       , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
       , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -87,7 +87,7 @@ FROM (
       , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
       , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
       , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-      , bookings_source_src_10001.paid_at AS booking__paid_at__day
+      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
       , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
       , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
       , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -120,7 +120,7 @@ LEFT OUTER JOIN (
       1 AS listings
       , listings_latest_src_10004.capacity AS largest_listing
       , listings_latest_src_10004.capacity AS smallest_listing
-      , listings_latest_src_10004.created_at AS ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
@@ -132,7 +132,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS ds__extract_doy
-      , listings_latest_src_10004.created_at AS created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
@@ -147,7 +147,7 @@ LEFT OUTER JOIN (
       , listings_latest_src_10004.country AS country_latest
       , listings_latest_src_10004.is_lux AS is_lux_latest
       , listings_latest_src_10004.capacity AS capacity_latest
-      , listings_latest_src_10004.created_at AS listing__ds__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__ds__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
@@ -159,7 +159,7 @@ LEFT OUTER JOIN (
       , EXTRACT(day FROM listings_latest_src_10004.created_at) AS listing__ds__extract_day
       , EXTRACT(dow FROM listings_latest_src_10004.created_at) AS listing__ds__extract_dow
       , EXTRACT(doy FROM listings_latest_src_10004.created_at) AS listing__ds__extract_doy
-      , listings_latest_src_10004.created_at AS listing__created_at__day
+      , DATE_TRUNC('day', listings_latest_src_10004.created_at) AS listing__created_at__day
       , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
       , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
       , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0.sql
@@ -15,7 +15,7 @@ SELECT
   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
   , bookings_source_src_10001.is_instant
-  , bookings_source_src_10001.ds AS ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
   , bookings_source_src_10001.is_instant AS booking__is_instant
-  , bookings_source_src_10001.ds AS booking__ds__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-  , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , bookings_source_src_10001.paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_source_node__plan0_optimized.sql
@@ -15,7 +15,7 @@ SELECT
   , booking_value AS approximate_continuous_booking_value_p99
   , booking_value AS approximate_discrete_booking_value_p99
   , is_instant
-  , ds AS ds__day
+  , DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -27,7 +27,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -39,7 +39,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -52,7 +52,7 @@ SELECT
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
   , is_instant AS booking__is_instant
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -64,7 +64,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -76,7 +76,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_semantic_model__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_semantic_model__plan0.xml
@@ -559,25 +559,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -607,25 +607,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -655,25 +655,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -707,25 +707,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -755,25 +755,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -803,25 +803,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1420,25 +1420,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1468,25 +1468,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1516,25 +1516,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1568,25 +1568,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1616,25 +1616,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1664,25 +1664,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -142,25 +142,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -190,25 +190,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -238,25 +238,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -290,25 +290,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -338,25 +338,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -386,25 +386,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -497,25 +497,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
-                        <!-- col3 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -545,25 +545,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'created_at__day'}                       -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'column_alias': 'created_at__day'}                 -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -605,25 +605,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
-                        <!-- col30 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                        <!-- col30 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'column_alias': 'listing__ds__day'}                -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col32 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col33 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col34 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col35 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -653,25 +653,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                        <!-- col42 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                        <!-- col42 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                        <!--    'column_alias': 'listing__created_at__day'}        -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col44 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col45 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col46 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col47 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -638,25 +638,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -686,25 +686,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -734,25 +734,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -786,25 +786,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -834,25 +834,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -882,25 +882,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1287,25 +1287,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
-                                        <!-- col3 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col3 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1335,25 +1335,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'created_at__day'}                       -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                        <!--    'column_alias': 'created_at__day'}                 -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1395,25 +1395,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
-                                        <!-- col30 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                                        <!-- col30 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                        <!--    'column_alias': 'listing__ds__day'}                -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col32 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col33 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col34 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col35 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1443,25 +1443,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                        <!-- col42 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                                        <!-- col42 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                        <!--    'column_alias': 'listing__created_at__day'}        -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col44 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col45 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col46 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col47 =                                                  -->
                                         <!--   {'class': 'SqlSelectColumn',                           -->
@@ -1908,25 +1908,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                                 -->
                                         <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
                                         <!--    'column_alias': 'views'}                                    -->
-                                        <!-- col1 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col1 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col2 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col3 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col6 =                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1956,25 +1956,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10188),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col13 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col13 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col14 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10136),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col15 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10137),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10138),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10139),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col18 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2004,25 +2004,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10195),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col25 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
-                                        <!--    'column_alias': 'view__ds__day'}                         -->
+                                        <!-- col25 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10140),  -->
+                                        <!--    'column_alias': 'view__ds__day'}                   -->
                                         <!-- col26 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10141),  -->
                                         <!--    'column_alias': 'view__ds__week'}                  -->
                                         <!-- col27 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10142),  -->
                                         <!--    'column_alias': 'view__ds__month'}                 -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10143),  -->
                                         <!--    'column_alias': 'view__ds__quarter'}               -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
                                         <!--    'column_alias': 'view__ds__year'}                  -->
                                         <!-- col30 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2052,25 +2052,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10202),  -->
                                         <!--    'column_alias': 'view__ds__extract_doy'}         -->
-                                        <!-- col37 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10090),  -->
-                                        <!--    'column_alias': 'view__ds_partitioned__day'}             -->
+                                        <!-- col37 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                                        <!--    'column_alias': 'view__ds_partitioned__day'}       -->
                                         <!-- col38 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
                                         <!--    'column_alias': 'view__ds_partitioned__week'}      -->
                                         <!-- col39 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
                                         <!--    'column_alias': 'view__ds_partitioned__month'}     -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
                                         <!--    'column_alias': 'view__ds_partitioned__quarter'}   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
                                         <!--    'column_alias': 'view__ds_partitioned__year'}      -->
                                         <!-- col42 =                                                   -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
@@ -2449,25 +2449,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
-                                        <!-- col3 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col3 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2497,25 +2497,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'created_at__day'}                       -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                        <!--    'column_alias': 'created_at__day'}                 -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2557,25 +2557,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
-                                        <!-- col30 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                                        <!-- col30 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                        <!--    'column_alias': 'listing__ds__day'}                -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col32 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col33 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col34 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col35 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2605,25 +2605,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                        <!-- col42 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                                        <!-- col42 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                        <!--    'column_alias': 'listing__created_at__day'}        -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col44 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col45 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col46 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col47 =                                                  -->
                                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -154,25 +154,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -202,25 +202,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -250,25 +250,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -302,25 +302,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -350,25 +350,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -398,25 +398,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -509,25 +509,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
-                        <!-- col3 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -557,25 +557,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'created_at__day'}                       -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'column_alias': 'created_at__day'}                 -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -617,25 +617,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
-                        <!-- col30 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                        <!-- col30 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'column_alias': 'listing__ds__day'}                -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col32 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col33 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col34 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col35 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -665,25 +665,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                        <!-- col42 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                        <!-- col42 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                        <!--    'column_alias': 'listing__created_at__day'}        -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col44 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col45 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col46 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col47 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -142,25 +142,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -190,25 +190,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -238,25 +238,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -290,25 +290,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -338,25 +338,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -386,25 +386,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -497,25 +497,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
-                        <!-- col3 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -545,25 +545,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'created_at__day'}                       -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'column_alias': 'created_at__day'}                 -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -605,25 +605,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
-                        <!-- col30 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                        <!-- col30 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'column_alias': 'listing__ds__day'}                -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col32 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col33 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col34 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col35 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -653,25 +653,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                        <!-- col42 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                        <!-- col42 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                        <!--    'column_alias': 'listing__created_at__day'}        -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col44 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col45 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col46 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col47 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
@@ -112,25 +112,25 @@
                     <!--   {'class': 'SqlSelectColumn',                              -->
                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                     <!--    'column_alias': 'is_instant'}                            -->
-                    <!-- col15 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                    <!--    'column_alias': 'ds__day'}                               -->
+                    <!-- col15 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                    <!--    'column_alias': 'ds__day'}                         -->
                     <!-- col16 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                     <!--    'column_alias': 'ds__week'}                        -->
                     <!-- col17 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                     <!--    'column_alias': 'ds__month'}                       -->
                     <!-- col18 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                     <!--    'column_alias': 'ds__quarter'}                     -->
                     <!-- col19 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                     <!--    'column_alias': 'ds__year'}                        -->
                     <!-- col20 =                                             -->
                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -160,25 +160,25 @@
                     <!--   {'class': 'SqlSelectColumn',                      -->
                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                    <!-- col27 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                    <!-- col27 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                     <!-- col28 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                     <!-- col29 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                     <!-- col30 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                     <!-- col31 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                     <!-- col32 =                                             -->
                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -208,25 +208,25 @@
                     <!--   {'class': 'SqlSelectColumn',                      -->
                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                    <!-- col39 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                    <!--    'column_alias': 'paid_at__day'}                          -->
+                    <!-- col39 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                    <!--    'column_alias': 'paid_at__day'}                    -->
                     <!-- col40 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                     <!--    'column_alias': 'paid_at__week'}                   -->
                     <!-- col41 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                     <!--    'column_alias': 'paid_at__month'}                  -->
                     <!-- col42 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                     <!--    'column_alias': 'paid_at__quarter'}                -->
                     <!-- col43 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                     <!--    'column_alias': 'paid_at__year'}                   -->
                     <!-- col44 =                                             -->
                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -260,25 +260,25 @@
                     <!--   {'class': 'SqlSelectColumn',                              -->
                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                    <!-- col52 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                    <!-- col52 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                    <!--    'column_alias': 'booking__ds__day'}                -->
                     <!-- col53 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                     <!--    'column_alias': 'booking__ds__week'}               -->
                     <!-- col54 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                     <!--    'column_alias': 'booking__ds__month'}              -->
                     <!-- col55 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                     <!-- col56 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                     <!--    'column_alias': 'booking__ds__year'}               -->
                     <!-- col57 =                                             -->
                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -308,25 +308,25 @@
                     <!--   {'class': 'SqlSelectColumn',                      -->
                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                    <!-- col64 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                    <!-- col64 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                     <!-- col65 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                     <!-- col66 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                     <!-- col67 =                                                 -->
                     <!--   {'class': 'SqlSelectColumn',                          -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                     <!-- col68 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                     <!-- col69 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -356,25 +356,25 @@
                     <!--   {'class': 'SqlSelectColumn',                              -->
                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                    <!-- col76 =                                                     -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                    <!-- col76 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                        -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                     <!-- col77 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                     <!-- col78 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                     <!-- col79 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                     <!-- col80 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                     <!-- col81 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
@@ -212,25 +212,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
-                        <!-- col1 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col1 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -260,25 +260,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col13 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                        <!--    'column_alias': 'company__ds__day'}                      -->
+                        <!-- col13 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                        <!--    'column_alias': 'company__ds__day'}                -->
                         <!-- col14 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                         <!--    'column_alias': 'company__ds__week'}               -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                         <!--    'column_alias': 'company__ds__month'}              -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                         <!--    'column_alias': 'company__ds__quarter'}            -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                         <!--    'column_alias': 'company__ds__year'}               -->
                         <!-- col18 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
@@ -212,25 +212,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
-                        <!-- col1 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col1 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -260,25 +260,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col13 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                        <!--    'column_alias': 'company__ds__day'}                      -->
+                        <!-- col13 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                        <!--    'column_alias': 'company__ds__day'}                -->
                         <!-- col14 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                         <!--    'column_alias': 'company__ds__week'}               -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                         <!--    'column_alias': 'company__ds__month'}              -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                         <!--    'column_alias': 'company__ds__quarter'}            -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                         <!--    'column_alias': 'company__ds__year'}               -->
                         <!-- col18 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
@@ -196,25 +196,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
-                        <!-- col1 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col1 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -244,25 +244,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col13 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                        <!--    'column_alias': 'company__ds__day'}                      -->
+                        <!-- col13 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                        <!--    'column_alias': 'company__ds__day'}                -->
                         <!-- col14 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                         <!--    'column_alias': 'company__ds__week'}               -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                         <!--    'column_alias': 'company__ds__month'}              -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                         <!--    'column_alias': 'company__ds__quarter'}            -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                         <!--    'column_alias': 'company__ds__year'}               -->
                         <!-- col18 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
@@ -212,25 +212,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                         <!--    'column_alias': 'txn_revenue'}                           -->
-                        <!-- col1 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col1 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col2 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col3 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col6 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -260,25 +260,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col13 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                        <!--    'column_alias': 'company__ds__day'}                      -->
+                        <!-- col13 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                        <!--    'column_alias': 'company__ds__day'}                -->
                         <!-- col14 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                         <!--    'column_alias': 'company__ds__week'}               -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                         <!--    'column_alias': 'company__ds__month'}              -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                         <!--    'column_alias': 'company__ds__quarter'}            -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                         <!--    'column_alias': 'company__ds__year'}               -->
                         <!-- col18 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
@@ -374,25 +374,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                             <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col1 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col5 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col6 =                                              -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -422,25 +422,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col13 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                            <!--    'column_alias': 'company__ds__day'}                      -->
+                            <!-- col13 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                            <!--    'column_alias': 'company__ds__day'}                -->
                             <!-- col14 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                             <!--    'column_alias': 'company__ds__week'}               -->
                             <!-- col15 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                             <!--    'column_alias': 'company__ds__month'}              -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                             <!--    'column_alias': 'company__ds__quarter'}            -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                             <!--    'column_alias': 'company__ds__year'}               -->
                             <!-- col18 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
@@ -374,25 +374,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10068),  -->
                             <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10069),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col1 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col5 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col6 =                                              -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -422,25 +422,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10118),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col13 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10070),  -->
-                            <!--    'column_alias': 'company__ds__day'}                      -->
+                            <!-- col13 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                            <!--    'column_alias': 'company__ds__day'}                -->
                             <!-- col14 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
                             <!--    'column_alias': 'company__ds__week'}               -->
                             <!-- col15 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
                             <!--    'column_alias': 'company__ds__month'}              -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
                             <!--    'column_alias': 'company__ds__quarter'}            -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
                             <!--    'column_alias': 'company__ds__year'}               -->
                             <!-- col18 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1429,25 +1429,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1477,25 +1477,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1525,25 +1525,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1577,25 +1577,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1625,25 +1625,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1673,25 +1673,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1831,25 +1831,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1879,25 +1879,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1927,25 +1927,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1979,25 +1979,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2027,25 +2027,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2075,25 +2075,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain_and_granularity__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1831,25 +1831,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1879,25 +1879,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1927,25 +1927,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1979,25 +1979,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2027,25 +2027,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2075,25 +2075,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1831,25 +1831,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1879,25 +1879,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1927,25 +1927,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1979,25 +1979,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2027,25 +2027,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2075,25 +2075,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_granularity__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1831,25 +1831,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1879,25 +1879,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1927,25 +1927,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1979,25 +1979,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2027,25 +2027,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2075,25 +2075,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
@@ -970,25 +970,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1018,25 +1018,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1066,25 +1066,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1118,25 +1118,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1166,25 +1166,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1214,25 +1214,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -2234,25 +2234,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2282,25 +2282,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2330,25 +2330,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2382,25 +2382,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2430,25 +2430,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2478,25 +2478,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.xml
@@ -970,25 +970,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1018,25 +1018,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1066,25 +1066,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1118,25 +1118,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1166,25 +1166,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1214,25 +1214,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -2234,25 +2234,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2282,25 +2282,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2330,25 +2330,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2382,25 +2382,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2430,25 +2430,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2478,25 +2478,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_offset_cumulative_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_offset_cumulative_metric__plan0.xml
@@ -1393,25 +1393,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1441,25 +1441,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1489,25 +1489,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1541,25 +1541,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1589,25 +1589,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1637,25 +1637,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_offset_metric_with_one_input_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_offset_metric_with_one_input_metric__plan0.xml
@@ -947,25 +947,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -995,25 +995,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1043,25 +1043,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1095,25 +1095,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1143,25 +1143,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1191,25 +1191,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
@@ -594,25 +594,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -642,25 +642,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -690,25 +690,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -742,25 +742,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -790,25 +790,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -838,25 +838,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1243,25 +1243,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
-                                        <!-- col3 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col3 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1291,25 +1291,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'created_at__day'}                       -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                        <!--    'column_alias': 'created_at__day'}                 -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1351,25 +1351,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
-                                        <!-- col30 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                                        <!-- col30 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                        <!--    'column_alias': 'listing__ds__day'}                -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col32 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col33 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col34 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col35 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1399,25 +1399,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                        <!-- col42 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                                        <!-- col42 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                        <!--    'column_alias': 'listing__created_at__day'}        -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col44 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col45 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col46 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col47 =                                                  -->
                                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
@@ -73,25 +73,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
             <!--    'column_alias': 'is_instant'}                            -->
-            <!-- col15 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
+            <!-- col15 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
             <!-- col16 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col20 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -121,25 +121,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
             <!--    'column_alias': 'ds__extract_doy'}               -->
-            <!-- col27 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+            <!-- col27 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'column_alias': 'ds_partitioned__day'}             -->
             <!-- col28 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
             <!--    'column_alias': 'ds_partitioned__week'}            -->
             <!-- col29 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
             <!--    'column_alias': 'ds_partitioned__month'}           -->
             <!-- col30 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
             <!-- col31 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col32 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -169,25 +169,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-            <!-- col39 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-            <!--    'column_alias': 'paid_at__day'}                          -->
+            <!-- col39 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'column_alias': 'paid_at__day'}                    -->
             <!-- col40 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
             <!--    'column_alias': 'paid_at__week'}                   -->
             <!-- col41 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
             <!--    'column_alias': 'paid_at__month'}                  -->
             <!-- col42 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
             <!--    'column_alias': 'paid_at__quarter'}                -->
             <!-- col43 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
             <!--    'column_alias': 'paid_at__year'}                   -->
             <!-- col44 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -221,25 +221,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
             <!--    'column_alias': 'booking__is_instant'}                   -->
-            <!-- col52 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-            <!--    'column_alias': 'booking__ds__day'}                      -->
+            <!-- col52 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'column_alias': 'booking__ds__day'}                -->
             <!-- col53 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
             <!--    'column_alias': 'booking__ds__week'}               -->
             <!-- col54 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
             <!--    'column_alias': 'booking__ds__month'}              -->
             <!-- col55 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
             <!--    'column_alias': 'booking__ds__quarter'}            -->
             <!-- col56 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
             <!--    'column_alias': 'booking__ds__year'}               -->
             <!-- col57 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -269,25 +269,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-            <!-- col64 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+            <!-- col64 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
             <!-- col65 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
             <!-- col66 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
             <!-- col67 =                                                 -->
             <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
             <!-- col68 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
             <!-- col69 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -317,25 +317,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-            <!-- col76 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+            <!-- col76 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+            <!--    'column_alias': 'booking__paid_at__day'}           -->
             <!-- col77 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
             <!--    'column_alias': 'booking__paid_at__week'}          -->
             <!-- col78 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
             <!--    'column_alias': 'booking__paid_at__month'}         -->
             <!-- col79 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
             <!-- col80 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
             <!--    'column_alias': 'booking__paid_at__year'}          -->
             <!-- col81 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -91,25 +91,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -139,25 +139,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col27 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                <!-- col27 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'column_alias': 'ds_partitioned__day'}             -->
                 <!-- col28 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                 <!-- col29 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                 <!-- col30 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col32 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -187,25 +187,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                <!-- col39 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                <!--    'column_alias': 'paid_at__day'}                          -->
+                <!-- col39 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'column_alias': 'paid_at__day'}                    -->
                 <!-- col40 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                 <!--    'column_alias': 'paid_at__week'}                   -->
                 <!-- col41 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                 <!--    'column_alias': 'paid_at__month'}                  -->
                 <!-- col42 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                 <!--    'column_alias': 'paid_at__quarter'}                -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                 <!--    'column_alias': 'paid_at__year'}                   -->
                 <!-- col44 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -239,25 +239,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                <!-- col52 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                <!--    'column_alias': 'booking__ds__day'}                      -->
+                <!-- col52 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'column_alias': 'booking__ds__day'}                -->
                 <!-- col53 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                 <!--    'column_alias': 'booking__ds__week'}               -->
                 <!-- col54 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                 <!--    'column_alias': 'booking__ds__month'}              -->
                 <!-- col55 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                 <!-- col56 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                 <!--    'column_alias': 'booking__ds__year'}               -->
                 <!-- col57 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -287,25 +287,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                <!-- col64 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                <!-- col64 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                 <!-- col65 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                 <!-- col66 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                 <!-- col67 =                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                 <!-- col68 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                 <!-- col69 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -335,25 +335,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                <!-- col76 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                <!-- col76 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                <!--    'column_alias': 'booking__paid_at__day'}           -->
                 <!-- col77 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                 <!-- col78 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                 <!-- col79 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                 <!-- col80 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                 <!-- col81 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
@@ -615,25 +615,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -663,25 +663,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -711,25 +711,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -763,25 +763,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -811,25 +811,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -859,25 +859,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1264,25 +1264,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                         <!--    'column_alias': 'smallest_listing'}                      -->
-                                        <!-- col3 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col3 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col4 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col5 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col6 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col7 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col8 =                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1312,25 +1312,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                        <!--    'column_alias': 'created_at__day'}                       -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                        <!--    'column_alias': 'created_at__day'}                 -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                         <!--    'column_alias': 'created_at__week'}                -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                         <!--    'column_alias': 'created_at__month'}               -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                         <!--    'column_alias': 'created_at__quarter'}             -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                         <!--    'column_alias': 'created_at__year'}                -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1372,25 +1372,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                         <!--    'column_alias': 'capacity_latest'}                       -->
-                                        <!-- col30 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                                        <!-- col30 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                        <!--    'column_alias': 'listing__ds__day'}                -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                         <!--    'column_alias': 'listing__ds__week'}               -->
                                         <!-- col32 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                         <!--    'column_alias': 'listing__ds__month'}              -->
                                         <!-- col33 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                                         <!-- col34 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                         <!--    'column_alias': 'listing__ds__year'}               -->
                                         <!-- col35 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1420,25 +1420,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                        <!-- col42 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                                        <!-- col42 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                        <!--    'column_alias': 'listing__created_at__day'}        -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                         <!--    'column_alias': 'listing__created_at__week'}       -->
                                         <!-- col44 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                         <!--    'column_alias': 'listing__created_at__month'}      -->
                                         <!-- col45 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                         <!-- col46 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                         <!--    'column_alias': 'listing__created_at__year'}       -->
                                         <!-- col47 =                                                  -->
                                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
@@ -567,25 +567,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10135),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col7 =                                                      -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10136),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10195),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col8 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10196),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col9 =                                                -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10197),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col10 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10198),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col11 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10199),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col12 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -615,25 +615,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10279),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col19 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10137),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col19 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10200),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col20 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10201),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col21 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10202),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col22 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10203),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col23 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10204),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col24 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -663,25 +663,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10286),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col31 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10138),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col31 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10205),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col32 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10206),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col33 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10207),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col34 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10208),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col35 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10209),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col36 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -715,25 +715,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10139),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col44 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10140),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col44 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10210),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col45 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10211),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col46 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10212),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col47 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10213),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col48 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10214),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col49 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -763,25 +763,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10300),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col56 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10141),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col56 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10215),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col57 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10172),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10216),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col58 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10173),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10217),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col59 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10174),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10218),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col60 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10175),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10219),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col61 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -811,25 +811,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10307),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col68 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10142),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col68 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10220),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col69 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10176),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10221),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col70 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10177),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10222),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col71 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10178),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10223),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col72 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10179),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10224),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col73 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -933,19 +933,19 @@
                                     <!--    'column_alias': 'window_start__day'}                     -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10180),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10225),  -->
                                     <!--    'column_alias': 'window_start__week'}              -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10181),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10226),  -->
                                     <!--    'column_alias': 'window_start__month'}             -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10182),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10227),  -->
                                     <!--    'column_alias': 'window_start__quarter'}           -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10183),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10228),  -->
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -981,19 +981,19 @@
                                     <!--    'column_alias': 'window_end__day'}                       -->
                                     <!-- col13 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10184),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10229),  -->
                                     <!--    'column_alias': 'window_end__week'}                -->
                                     <!-- col14 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10185),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10230),  -->
                                     <!--    'column_alias': 'window_end__month'}               -->
                                     <!-- col15 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10186),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10231),  -->
                                     <!--    'column_alias': 'window_end__quarter'}             -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10187),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10232),  -->
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col17 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1041,19 +1041,19 @@
                                     <!--    'column_alias': 'listing__window_start__day'}            -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10188),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10233),  -->
                                     <!--    'column_alias': 'listing__window_start__week'}     -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10189),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10234),  -->
                                     <!--    'column_alias': 'listing__window_start__month'}    -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10190),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10235),  -->
                                     <!--    'column_alias': 'listing__window_start__quarter'}  -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10191),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10236),  -->
                                     <!--    'column_alias': 'listing__window_start__year'}     -->
                                     <!-- col32 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                             -->
@@ -1089,19 +1089,19 @@
                                     <!--    'column_alias': 'listing__window_end__day'}              -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10192),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10237),  -->
                                     <!--    'column_alias': 'listing__window_end__week'}       -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10193),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10238),  -->
                                     <!--    'column_alias': 'listing__window_end__month'}      -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10194),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10239),  -->
                                     <!--    'column_alias': 'listing__window_end__quarter'}    -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10195),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10240),  -->
                                     <!--    'column_alias': 'listing__window_end__year'}       -->
                                     <!-- col44 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -586,25 +586,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -634,25 +634,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -682,25 +682,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -734,25 +734,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -782,25 +782,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -830,25 +830,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -586,25 +586,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -634,25 +634,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -682,25 +682,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -734,25 +734,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -782,25 +782,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -830,25 +830,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -586,25 +586,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -634,25 +634,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -682,25 +682,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -734,25 +734,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -782,25 +782,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -830,25 +830,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
@@ -545,25 +545,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -593,25 +593,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -641,25 +641,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -693,25 +693,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -741,25 +741,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -789,25 +789,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_entity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_entity__plan0.xml
@@ -352,25 +352,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
-                        <!-- col3 =                                                      -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col5 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col6 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col7 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                              -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -400,25 +400,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                        <!--    'column_alias': 'created_at__day'}                       -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                        <!--    'column_alias': 'created_at__day'}                 -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                         <!--    'column_alias': 'created_at__week'}                -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                         <!--    'column_alias': 'created_at__month'}               -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                         <!--    'column_alias': 'created_at__quarter'}             -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -460,25 +460,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
-                        <!-- col30 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                        <!--    'column_alias': 'listing__ds__day'}                      -->
+                        <!-- col30 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                        <!--    'column_alias': 'listing__ds__day'}                -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                         <!--    'column_alias': 'listing__ds__week'}               -->
                         <!-- col32 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                         <!--    'column_alias': 'listing__ds__month'}              -->
                         <!-- col33 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                         <!--    'column_alias': 'listing__ds__quarter'}            -->
                         <!-- col34 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col35 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -508,25 +508,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                         <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                        <!-- col42 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                        <!--    'column_alias': 'listing__created_at__day'}              -->
+                        <!-- col42 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                        <!--    'column_alias': 'listing__created_at__day'}        -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                         <!--    'column_alias': 'listing__created_at__week'}       -->
                         <!-- col44 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                         <!--    'column_alias': 'listing__created_at__month'}      -->
                         <!-- col45 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                         <!--    'column_alias': 'listing__created_at__quarter'}    -->
                         <!-- col46 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col47 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
@@ -106,25 +106,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -154,25 +154,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col27 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                <!-- col27 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'column_alias': 'ds_partitioned__day'}             -->
                 <!-- col28 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                 <!-- col29 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                 <!-- col30 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col32 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -202,25 +202,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                <!-- col39 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                <!--    'column_alias': 'paid_at__day'}                          -->
+                <!-- col39 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'column_alias': 'paid_at__day'}                    -->
                 <!-- col40 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                 <!--    'column_alias': 'paid_at__week'}                   -->
                 <!-- col41 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                 <!--    'column_alias': 'paid_at__month'}                  -->
                 <!-- col42 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                 <!--    'column_alias': 'paid_at__quarter'}                -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                 <!--    'column_alias': 'paid_at__year'}                   -->
                 <!-- col44 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -254,25 +254,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                <!-- col52 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                <!--    'column_alias': 'booking__ds__day'}                      -->
+                <!-- col52 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'column_alias': 'booking__ds__day'}                -->
                 <!-- col53 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                 <!--    'column_alias': 'booking__ds__week'}               -->
                 <!-- col54 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                 <!--    'column_alias': 'booking__ds__month'}              -->
                 <!-- col55 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                 <!-- col56 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                 <!--    'column_alias': 'booking__ds__year'}               -->
                 <!-- col57 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -302,25 +302,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                <!-- col64 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                <!-- col64 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                 <!-- col65 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                 <!-- col66 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                 <!-- col67 =                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                 <!-- col68 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                 <!-- col69 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -350,25 +350,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                <!-- col76 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                <!-- col76 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                <!--    'column_alias': 'booking__paid_at__day'}           -->
                 <!-- col77 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                 <!-- col78 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                 <!-- col79 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                 <!-- col80 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                 <!-- col81 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
@@ -661,25 +661,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                                 <!--    'column_alias': 'is_instant'}                            -->
-                                                <!-- col15 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                                <!--    'column_alias': 'ds__day'}                               -->
+                                                <!-- col15 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                                <!--    'column_alias': 'ds__day'}                         -->
                                                 <!-- col16 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col20 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -709,25 +709,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                                <!-- col27 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                                <!-- col27 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                                 <!-- col28 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                                 <!-- col29 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                                 <!-- col30 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                                 <!-- col31 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                                 <!-- col32 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -757,25 +757,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                                <!-- col39 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                                <!-- col39 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                                <!--    'column_alias': 'paid_at__day'}                    -->
                                                 <!-- col40 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                                 <!-- col41 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                                 <!-- col42 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                                 <!-- col43 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                                 <!-- col44 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -809,25 +809,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                                <!-- col52 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                                <!-- col52 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                                <!--    'column_alias': 'booking__ds__day'}                -->
                                                 <!-- col53 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                                 <!-- col54 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                                 <!-- col55 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                                 <!-- col56 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                                 <!-- col57 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -857,25 +857,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                                <!-- col64 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                                <!-- col64 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                                 <!-- col65 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                                 <!-- col66 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                                 <!-- col67 =                                                 -->
                                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                                 <!-- col68 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                                 <!-- col69 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -905,25 +905,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                                <!-- col76 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                                <!-- col76 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                                 <!-- col77 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                                 <!-- col78 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                                 <!-- col79 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                                 <!-- col80 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                                 <!-- col81 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1310,25 +1310,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                                 <!--    'column_alias': 'smallest_listing'}                      -->
-                                                <!-- col3 =                                                      -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                                <!--    'column_alias': 'ds__day'}                               -->
+                                                <!-- col3 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                                <!--    'column_alias': 'ds__day'}                         -->
                                                 <!-- col4 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col5 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col6 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col7 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col8 =                                              -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1358,25 +1358,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                                <!-- col15 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                                <!--    'column_alias': 'created_at__day'}                       -->
+                                                <!-- col15 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                                <!--    'column_alias': 'created_at__day'}                 -->
                                                 <!-- col16 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                                 <!--    'column_alias': 'created_at__week'}                -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                                 <!--    'column_alias': 'created_at__month'}               -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                                 <!--    'column_alias': 'created_at__year'}                -->
                                                 <!-- col20 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1418,25 +1418,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                                 <!--    'column_alias': 'capacity_latest'}                       -->
-                                                <!-- col30 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                                <!--    'column_alias': 'listing__ds__day'}                      -->
+                                                <!-- col30 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                                <!--    'column_alias': 'listing__ds__day'}                -->
                                                 <!-- col31 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                                 <!-- col32 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                                 <!-- col33 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                                 <!-- col34 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                                 <!-- col35 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1466,25 +1466,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                                <!-- col42 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                                <!--    'column_alias': 'listing__created_at__day'}              -->
+                                                <!-- col42 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                                <!--    'column_alias': 'listing__created_at__day'}        -->
                                                 <!-- col43 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                                 <!-- col44 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                                 <!-- col45 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                                 <!-- col46 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                                 <!-- col47 =                                                  -->
                                                 <!--   {'class': 'SqlSelectColumn',                           -->
@@ -2170,25 +2170,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                                 <!--    'column_alias': 'is_instant'}                            -->
-                                                <!-- col15 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                                <!--    'column_alias': 'ds__day'}                               -->
+                                                <!-- col15 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                                <!--    'column_alias': 'ds__day'}                         -->
                                                 <!-- col16 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col20 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2218,25 +2218,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                                <!-- col27 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                                <!-- col27 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                                 <!-- col28 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                                 <!-- col29 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                                 <!-- col30 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                                 <!-- col31 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                                 <!-- col32 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2266,25 +2266,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                                <!-- col39 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                                <!-- col39 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                                <!--    'column_alias': 'paid_at__day'}                    -->
                                                 <!-- col40 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                                 <!-- col41 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                                 <!-- col42 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                                 <!-- col43 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                                 <!-- col44 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2318,25 +2318,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                                <!-- col52 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                                <!-- col52 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                                <!--    'column_alias': 'booking__ds__day'}                -->
                                                 <!-- col53 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                                 <!-- col54 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                                 <!-- col55 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                                 <!-- col56 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                                 <!-- col57 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2366,25 +2366,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                                <!-- col64 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                                <!-- col64 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                                 <!-- col65 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                                 <!-- col66 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                                 <!-- col67 =                                                 -->
                                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                                 <!-- col68 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                                 <!-- col69 =                                                      -->
                                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2414,25 +2414,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                                <!-- col76 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                                <!-- col76 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                                 <!-- col77 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                                 <!-- col78 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                                 <!-- col79 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                                 <!-- col80 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                                 <!-- col81 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -2819,25 +2819,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                                 <!--    'column_alias': 'smallest_listing'}                      -->
-                                                <!-- col3 =                                                      -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                                <!--    'column_alias': 'ds__day'}                               -->
+                                                <!-- col3 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                                <!--    'column_alias': 'ds__day'}                         -->
                                                 <!-- col4 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                                 <!--    'column_alias': 'ds__week'}                        -->
                                                 <!-- col5 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                                 <!--    'column_alias': 'ds__month'}                       -->
                                                 <!-- col6 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                                 <!-- col7 =                                                -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                                 <!--    'column_alias': 'ds__year'}                        -->
                                                 <!-- col8 =                                              -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2867,25 +2867,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                                <!-- col15 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                                <!--    'column_alias': 'created_at__day'}                       -->
+                                                <!-- col15 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                                <!--    'column_alias': 'created_at__day'}                 -->
                                                 <!-- col16 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                                 <!--    'column_alias': 'created_at__week'}                -->
                                                 <!-- col17 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                                 <!--    'column_alias': 'created_at__month'}               -->
                                                 <!-- col18 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                                 <!-- col19 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                                 <!--    'column_alias': 'created_at__year'}                -->
                                                 <!-- col20 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2927,25 +2927,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                                 <!--    'column_alias': 'capacity_latest'}                       -->
-                                                <!-- col30 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                                <!--    'column_alias': 'listing__ds__day'}                      -->
+                                                <!-- col30 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                                <!--    'column_alias': 'listing__ds__day'}                -->
                                                 <!-- col31 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                                 <!-- col32 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                                 <!-- col33 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                                 <!-- col34 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                                 <!-- col35 =                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2975,25 +2975,25 @@
                                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                                <!-- col42 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                                <!--    'column_alias': 'listing__created_at__day'}              -->
+                                                <!-- col42 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                                <!--    'column_alias': 'listing__created_at__day'}        -->
                                                 <!-- col43 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                                 <!-- col44 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                                 <!-- col45 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                                 <!-- col46 =                                               -->
                                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                                 <!-- col47 =                                                  -->
                                                 <!--   {'class': 'SqlSelectColumn',                           -->
@@ -3596,25 +3596,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3644,25 +3644,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3692,25 +3692,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3744,25 +3744,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3792,25 +3792,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -3840,25 +3840,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
@@ -605,25 +605,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -653,25 +653,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -701,25 +701,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -753,25 +753,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -801,25 +801,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -849,25 +849,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1468,25 +1468,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1516,25 +1516,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1564,25 +1564,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1616,25 +1616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1664,25 +1664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1712,25 +1712,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
@@ -582,25 +582,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -630,25 +630,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -678,25 +678,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -730,25 +730,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -778,25 +778,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -826,25 +826,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.xml
@@ -544,25 +544,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -592,25 +592,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -640,25 +640,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -692,25 +692,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -740,25 +740,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -788,25 +788,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1209,25 +1209,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                 <!--    'column_alias': 'smallest_listing'}                      -->
-                                <!-- col3 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col3 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col8 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1257,25 +1257,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'created_at__day'}                       -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                <!--    'column_alias': 'created_at__day'}                 -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                 <!--    'column_alias': 'created_at__week'}                -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                 <!--    'column_alias': 'created_at__month'}               -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                 <!--    'column_alias': 'created_at__year'}                -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1317,25 +1317,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                 <!--    'column_alias': 'capacity_latest'}                       -->
-                                <!-- col30 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                <!--    'column_alias': 'listing__ds__day'}                      -->
+                                <!-- col30 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                <!--    'column_alias': 'listing__ds__day'}                -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                 <!-- col32 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                 <!-- col33 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                 <!-- col34 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                 <!-- col35 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1365,25 +1365,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                <!-- col42 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                <!--    'column_alias': 'listing__created_at__day'}              -->
+                                <!-- col42 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                <!--    'column_alias': 'listing__created_at__day'}        -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                 <!-- col44 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                 <!-- col45 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                 <!-- col46 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                 <!-- col47 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
@@ -546,25 +546,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10135),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10136),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col7 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10195),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10196),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10197),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10198),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10199),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col12 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -594,25 +594,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10279),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col19 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10137),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10200),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10201),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10202),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col22 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10203),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col23 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10204),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col24 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -642,25 +642,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10286),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col31 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10138),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col31 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10205),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col32 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10206),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col33 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10207),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col34 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10208),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col35 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10209),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col36 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -694,25 +694,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10139),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col44 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10140),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col44 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10210),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col45 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10211),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col46 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10212),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col47 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10213),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col48 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10214),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col49 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -742,25 +742,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10300),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col56 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10141),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col56 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10215),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col57 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10172),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10216),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col58 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10173),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10217),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col59 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10174),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10218),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col60 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10175),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10219),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col61 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -790,25 +790,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10307),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col68 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10142),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col68 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10220),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col69 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10176),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10221),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col70 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10177),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10222),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col71 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10178),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10223),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col72 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10179),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10224),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col73 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1203,19 +1203,19 @@
                                 <!--    'column_alias': 'window_start__day'}                     -->
                                 <!-- col1 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10180),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10225),  -->
                                 <!--    'column_alias': 'window_start__week'}              -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10181),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10226),  -->
                                 <!--    'column_alias': 'window_start__month'}             -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10182),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10227),  -->
                                 <!--    'column_alias': 'window_start__quarter'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10183),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10228),  -->
                                 <!--    'column_alias': 'window_start__year'}              -->
                                 <!-- col5 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1251,19 +1251,19 @@
                                 <!--    'column_alias': 'window_end__day'}                       -->
                                 <!-- col13 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10184),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10229),  -->
                                 <!--    'column_alias': 'window_end__week'}                -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10185),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10230),  -->
                                 <!--    'column_alias': 'window_end__month'}               -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10186),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10231),  -->
                                 <!--    'column_alias': 'window_end__quarter'}             -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10187),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10232),  -->
                                 <!--    'column_alias': 'window_end__year'}                -->
                                 <!-- col17 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1311,19 +1311,19 @@
                                 <!--    'column_alias': 'listing__window_start__day'}            -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10188),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10233),  -->
                                 <!--    'column_alias': 'listing__window_start__week'}     -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10189),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10234),  -->
                                 <!--    'column_alias': 'listing__window_start__month'}    -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10190),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10235),  -->
                                 <!--    'column_alias': 'listing__window_start__quarter'}  -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10191),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10236),  -->
                                 <!--    'column_alias': 'listing__window_start__year'}     -->
                                 <!-- col32 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
@@ -1359,19 +1359,19 @@
                                 <!--    'column_alias': 'listing__window_end__day'}              -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10192),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10237),  -->
                                 <!--    'column_alias': 'listing__window_end__week'}       -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10193),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10238),  -->
                                 <!--    'column_alias': 'listing__window_end__month'}      -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10194),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10239),  -->
                                 <!--    'column_alias': 'listing__window_end__quarter'}    -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10195),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10240),  -->
                                 <!--    'column_alias': 'listing__window_end__year'}       -->
                                 <!-- col44 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
@@ -1577,25 +1577,25 @@
                                 <SqlSelectStatementNode>
                                     <!-- description = Read Elements From Semantic Model 'users_latest' -->
                                     <!-- node_id = ss_10021 -->
-                                    <!-- col0 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10192),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col0 =                                                -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10281),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10236),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10282),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10237),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10283),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10238),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10284),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10239),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10285),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col5 =                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1629,25 +1629,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10193),  -->
                                     <!--    'column_alias': 'home_state_latest'}                     -->
-                                    <!-- col13 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10194),  -->
-                                    <!--    'column_alias': 'user__ds__day'}                         -->
+                                    <!-- col13 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10286),  -->
+                                    <!--    'column_alias': 'user__ds__day'}                   -->
                                     <!-- col14 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10240),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10287),  -->
                                     <!--    'column_alias': 'user__ds__week'}                  -->
                                     <!-- col15 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10241),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10288),  -->
                                     <!--    'column_alias': 'user__ds__month'}                 -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10242),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10289),  -->
                                     <!--    'column_alias': 'user__ds__quarter'}               -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10243),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10290),  -->
                                     <!--    'column_alias': 'user__ds__year'}                  -->
                                     <!-- col18 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
@@ -546,25 +546,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10135),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10136),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col7 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10195),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col8 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10196),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col9 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10197),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col10 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10198),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col11 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10199),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col12 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -594,25 +594,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10279),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col19 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10137),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10200),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col20 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10201),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col21 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10202),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col22 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10203),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col23 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10204),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col24 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -642,25 +642,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10286),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col31 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10138),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col31 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10205),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col32 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10206),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col33 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10207),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col34 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10208),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col35 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10209),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col36 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -694,25 +694,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10139),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col44 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10140),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col44 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10210),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col45 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10211),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col46 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10212),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col47 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10213),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col48 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10214),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col49 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -742,25 +742,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10300),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col56 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10141),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col56 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10215),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col57 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10172),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10216),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col58 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10173),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10217),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col59 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10174),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10218),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col60 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10175),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10219),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col61 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -790,25 +790,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10307),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col68 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10142),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col68 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10220),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col69 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10176),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10221),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col70 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10177),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10222),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col71 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10178),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10223),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col72 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10179),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10224),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col73 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1323,19 +1323,19 @@
                                     <!--    'column_alias': 'window_start__day'}                     -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10196),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10241),  -->
                                     <!--    'column_alias': 'window_start__week'}              -->
                                     <!-- col2 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10197),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10242),  -->
                                     <!--    'column_alias': 'window_start__month'}             -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10198),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10243),  -->
                                     <!--    'column_alias': 'window_start__quarter'}           -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10199),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10244),  -->
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1371,19 +1371,19 @@
                                     <!--    'column_alias': 'window_end__day'}                       -->
                                     <!-- col13 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10200),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10245),  -->
                                     <!--    'column_alias': 'window_end__week'}                -->
                                     <!-- col14 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10201),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10246),  -->
                                     <!--    'column_alias': 'window_end__month'}               -->
                                     <!-- col15 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10202),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10247),  -->
                                     <!--    'column_alias': 'window_end__quarter'}             -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10203),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10248),  -->
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col17 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1423,19 +1423,19 @@
                                     <!--    'column_alias': 'lux_listing__window_start__day'}        -->
                                     <!-- col26 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                         -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10204),   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10249),   -->
                                     <!--    'column_alias': 'lux_listing__window_start__week'}  -->
                                     <!-- col27 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10205),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10250),    -->
                                     <!--    'column_alias': 'lux_listing__window_start__month'}  -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10206),      -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10251),      -->
                                     <!--    'column_alias': 'lux_listing__window_start__quarter'}  -->
                                     <!-- col29 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                         -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10207),   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10252),   -->
                                     <!--    'column_alias': 'lux_listing__window_start__year'}  -->
                                     <!-- col30 =                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                 -->
@@ -1471,19 +1471,19 @@
                                     <!--    'column_alias': 'lux_listing__window_end__day'}          -->
                                     <!-- col38 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10208),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10253),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__week'}   -->
                                     <!-- col39 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10209),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10254),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__month'}  -->
                                     <!-- col40 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10210),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10255),    -->
                                     <!--    'column_alias': 'lux_listing__window_end__quarter'}  -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10211),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10256),  -->
                                     <!--    'column_alias': 'lux_listing__window_end__year'}   -->
                                     <!-- col42 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -110,25 +110,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -158,25 +158,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col27 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                <!-- col27 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'column_alias': 'ds_partitioned__day'}             -->
                 <!-- col28 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                 <!-- col29 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                 <!-- col30 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col32 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -206,25 +206,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                <!-- col39 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                <!--    'column_alias': 'paid_at__day'}                          -->
+                <!-- col39 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'column_alias': 'paid_at__day'}                    -->
                 <!-- col40 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                 <!--    'column_alias': 'paid_at__week'}                   -->
                 <!-- col41 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                 <!--    'column_alias': 'paid_at__month'}                  -->
                 <!-- col42 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                 <!--    'column_alias': 'paid_at__quarter'}                -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                 <!--    'column_alias': 'paid_at__year'}                   -->
                 <!-- col44 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -258,25 +258,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                <!-- col52 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                <!--    'column_alias': 'booking__ds__day'}                      -->
+                <!-- col52 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'column_alias': 'booking__ds__day'}                -->
                 <!-- col53 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                 <!--    'column_alias': 'booking__ds__week'}               -->
                 <!-- col54 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                 <!--    'column_alias': 'booking__ds__month'}              -->
                 <!-- col55 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                 <!-- col56 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                 <!--    'column_alias': 'booking__ds__year'}               -->
                 <!-- col57 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -306,25 +306,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                <!-- col64 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                <!-- col64 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                 <!-- col65 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                 <!-- col66 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                 <!-- col67 =                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                 <!-- col68 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                 <!-- col69 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -354,25 +354,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                <!-- col76 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                <!-- col76 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                <!--    'column_alias': 'booking__paid_at__day'}           -->
                 <!-- col77 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                 <!-- col78 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                 <!-- col79 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                 <!-- col80 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                 <!-- col81 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -465,25 +465,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col3 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -513,25 +513,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'created_at__day'}                       -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                <!--    'column_alias': 'created_at__day'}                 -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -573,25 +573,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
-                <!-- col30 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                <!--    'column_alias': 'listing__ds__day'}                      -->
+                <!-- col30 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                <!--    'column_alias': 'listing__ds__day'}                -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col32 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col33 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col34 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col35 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -621,25 +621,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                <!-- col42 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                <!--    'column_alias': 'listing__created_at__day'}              -->
+                <!-- col42 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                <!--    'column_alias': 'listing__created_at__day'}        -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col44 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col45 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col46 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col47 =                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
@@ -732,25 +732,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col3 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -780,25 +780,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'created_at__day'}                       -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                <!--    'column_alias': 'created_at__day'}                 -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -840,25 +840,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
-                <!-- col30 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                <!--    'column_alias': 'listing__ds__day'}                      -->
+                <!-- col30 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                <!--    'column_alias': 'listing__ds__day'}                -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col32 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col33 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col34 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col35 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -888,25 +888,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                <!-- col42 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                <!--    'column_alias': 'listing__created_at__day'}              -->
+                <!-- col42 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                <!--    'column_alias': 'listing__created_at__day'}        -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col44 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col45 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col46 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col47 =                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
@@ -362,25 +362,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10095),  -->
                                 <!--    'column_alias': 'txn_count'}                             -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10096),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col1 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10120),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10121),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10122),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10123),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col6 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -410,25 +410,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10216),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col13 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10097),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10156),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10157),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10158),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10159),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col18 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -462,25 +462,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
                                 <!--    'column_alias': 'account_month'}                         -->
-                                <!-- col26 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned__day'}       -->
+                                <!-- col26 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                         -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10160),   -->
+                                <!--    'column_alias': 'account_id__ds_partitioned__day'}  -->
                                 <!-- col27 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10128),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10161),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
                                 <!-- col28 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10129),     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10162),     -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
                                 <!-- col29 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10130),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10163),       -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
                                 <!-- col30 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10131),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10164),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
                                 <!-- col31 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
@@ -510,25 +510,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10230),             -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__extract_doy'}  -->
-                                <!-- col38 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                <!--    'column_alias': 'account_id__ds__day'}                   -->
+                                <!-- col38 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10165),  -->
+                                <!--    'column_alias': 'account_id__ds__day'}             -->
                                 <!-- col39 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10132),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10166),  -->
                                 <!--    'column_alias': 'account_id__ds__week'}            -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10133),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10167),  -->
                                 <!--    'column_alias': 'account_id__ds__month'}           -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10134),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10168),  -->
                                 <!--    'column_alias': 'account_id__ds__quarter'}         -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10135),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10169),  -->
                                 <!--    'column_alias': 'account_id__ds__year'}            -->
                                 <!-- col43 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -845,25 +845,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10103),  -->
                                 <!--    'column_alias': 'extra_dim'}                             -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10104),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col1 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10170),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10136),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10171),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10137),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10172),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10138),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10173),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10139),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10174),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col6 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -897,25 +897,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10105),  -->
                                 <!--    'column_alias': 'account_id__extra_dim'}                 -->
-                                <!-- col14 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned__day'}       -->
+                                <!-- col14 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                         -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10175),   -->
+                                <!--    'column_alias': 'account_id__ds_partitioned__day'}  -->
                                 <!-- col15 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10140),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10176),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
                                 <!-- col16 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10141),     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10177),     -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
                                 <!-- col17 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10142),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10178),       -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
                                 <!-- col18 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10143),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10179),    -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
                                 <!-- col19 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                  -->
@@ -949,25 +949,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                                 <!--    'column_alias': 'bridge_account__extra_dim'}             -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10108),  -->
-                                <!--    'column_alias': 'bridge_account__ds_partitioned__day'}   -->
+                                <!-- col27 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                             -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10180),       -->
+                                <!--    'column_alias': 'bridge_account__ds_partitioned__day'}  -->
                                 <!-- col28 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10181),        -->
                                 <!--    'column_alias': 'bridge_account__ds_partitioned__week'}  -->
                                 <!-- col29 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),         -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10182),         -->
                                 <!--    'column_alias': 'bridge_account__ds_partitioned__month'}  -->
                                 <!-- col30 =                                                        -->
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),           -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10183),           -->
                                 <!--    'column_alias': 'bridge_account__ds_partitioned__quarter'}  -->
                                 <!-- col31 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10184),        -->
                                 <!--    'column_alias': 'bridge_account__ds_partitioned__year'}  -->
                                 <!-- col32 =                                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                                      -->
@@ -1187,25 +1187,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
                                     <!--    'column_alias': 'customer_atomic_weight'}                -->
-                                    <!-- col2 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10123),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10185),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10186),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col4 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10187),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col5 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10188),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10189),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col7 =                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1243,25 +1243,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10125),  -->
                                     <!--    'column_alias': 'customer_id__customer_atomic_weight'}   -->
-                                    <!-- col16 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                                    <!--    'column_alias': 'customer_id__ds_partitioned__day'}      -->
+                                    <!-- col16 =                                                 -->
+                                    <!--   {'class': 'SqlSelectColumn',                          -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10190),    -->
+                                    <!--    'column_alias': 'customer_id__ds_partitioned__day'}  -->
                                     <!-- col17 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10152),     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10191),     -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__week'}  -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10153),      -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10192),      -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__month'}  -->
                                     <!-- col19 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10154),        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10193),        -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__quarter'}  -->
                                     <!-- col20 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10155),     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10194),     -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned__year'}  -->
                                     <!-- col21 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
@@ -961,25 +961,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1009,25 +1009,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1057,25 +1057,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1109,25 +1109,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1157,25 +1157,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1205,25 +1205,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1921,25 +1921,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                                 <!--    'column_alias': 'smallest_listing'}                      -->
-                                <!-- col3 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col3 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col7 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col8 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1969,25 +1969,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                                <!--    'column_alias': 'created_at__day'}                       -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                                <!--    'column_alias': 'created_at__day'}                 -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                                 <!--    'column_alias': 'created_at__week'}                -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                                 <!--    'column_alias': 'created_at__month'}               -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                                 <!--    'column_alias': 'created_at__quarter'}             -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                                 <!--    'column_alias': 'created_at__year'}                -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2029,25 +2029,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                                 <!--    'column_alias': 'capacity_latest'}                       -->
-                                <!-- col30 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                                <!--    'column_alias': 'listing__ds__day'}                      -->
+                                <!-- col30 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                                <!--    'column_alias': 'listing__ds__day'}                -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                                 <!--    'column_alias': 'listing__ds__week'}               -->
                                 <!-- col32 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                                 <!--    'column_alias': 'listing__ds__month'}              -->
                                 <!-- col33 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                                 <!-- col34 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                                 <!--    'column_alias': 'listing__ds__year'}               -->
                                 <!-- col35 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2077,25 +2077,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                                <!-- col42 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                                <!--    'column_alias': 'listing__created_at__day'}              -->
+                                <!-- col42 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                                <!--    'column_alias': 'listing__created_at__day'}        -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                                 <!--    'column_alias': 'listing__created_at__week'}       -->
                                 <!-- col44 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                                 <!--    'column_alias': 'listing__created_at__month'}      -->
                                 <!-- col45 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                                 <!-- col46 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                                 <!--    'column_alias': 'listing__created_at__year'}       -->
                                 <!-- col47 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -614,25 +614,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -662,25 +662,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -710,25 +710,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -762,25 +762,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -810,25 +810,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -858,25 +858,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1475,25 +1475,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                         <!--    'column_alias': 'is_instant'}                            -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                        <!--    'column_alias': 'ds__day'}                               -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds__day'}                         -->
                                         <!-- col16 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                         <!--    'column_alias': 'ds__week'}                        -->
                                         <!-- col17 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                         <!--    'column_alias': 'ds__month'}                       -->
                                         <!-- col18 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                         <!--    'column_alias': 'ds__quarter'}                     -->
                                         <!-- col19 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                         <!--    'column_alias': 'ds__year'}                        -->
                                         <!-- col20 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1523,25 +1523,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                                        <!-- col27 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                        <!-- col27 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                                         <!-- col28 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                                         <!-- col29 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                                         <!-- col30 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                         <!-- col31 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                                         <!-- col32 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1571,25 +1571,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                        <!-- col39 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                        <!--    'column_alias': 'paid_at__day'}                          -->
+                                        <!-- col39 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'column_alias': 'paid_at__day'}                    -->
                                         <!-- col40 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                         <!--    'column_alias': 'paid_at__week'}                   -->
                                         <!-- col41 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                         <!--    'column_alias': 'paid_at__month'}                  -->
                                         <!-- col42 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                         <!--    'column_alias': 'paid_at__quarter'}                -->
                                         <!-- col43 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                         <!--    'column_alias': 'paid_at__year'}                   -->
                                         <!-- col44 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1623,25 +1623,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                                        <!-- col52 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                                        <!-- col52 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'column_alias': 'booking__ds__day'}                -->
                                         <!-- col53 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                         <!--    'column_alias': 'booking__ds__week'}               -->
                                         <!-- col54 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                         <!--    'column_alias': 'booking__ds__month'}              -->
                                         <!-- col55 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                                         <!-- col56 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                         <!--    'column_alias': 'booking__ds__year'}               -->
                                         <!-- col57 =                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1671,25 +1671,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                      -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                        <!-- col64 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                        <!-- col64 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                         <!-- col65 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                         <!-- col66 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                         <!-- col67 =                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                          -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                         <!-- col68 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                         <!-- col69 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1719,25 +1719,25 @@
                                         <!--   {'class': 'SqlSelectColumn',                              -->
                                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                        <!-- col76 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                        <!-- col76 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                                         <!-- col77 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                                         <!-- col78 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                                         <!-- col79 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                         <!-- col80 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
-                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                                         <!-- col81 =                                               -->
                                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -2338,25 +2338,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2386,25 +2386,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2434,25 +2434,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2486,25 +2486,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2534,25 +2534,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2582,25 +2582,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -3199,25 +3199,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3247,25 +3247,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3295,25 +3295,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3347,25 +3347,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -3395,25 +3395,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -3443,25 +3443,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_offset_window_with_date_part__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_offset_window_with_date_part__plan0.xml
@@ -568,25 +568,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                 <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col18 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col20 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -616,25 +616,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col27 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col32 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -664,25 +664,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                <!-- col39 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                <!--    'column_alias': 'paid_at__day'}                          -->
+                                <!-- col39 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'column_alias': 'paid_at__day'}                    -->
                                 <!-- col40 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                 <!--    'column_alias': 'paid_at__week'}                   -->
                                 <!-- col41 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                 <!--    'column_alias': 'paid_at__month'}                  -->
                                 <!-- col42 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                 <!--    'column_alias': 'paid_at__quarter'}                -->
                                 <!-- col43 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                 <!--    'column_alias': 'paid_at__year'}                   -->
                                 <!-- col44 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -716,25 +716,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                                <!-- col52 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                <!--    'column_alias': 'booking__ds__day'}                      -->
+                                <!-- col52 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'column_alias': 'booking__ds__day'}                -->
                                 <!-- col53 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                 <!--    'column_alias': 'booking__ds__week'}               -->
                                 <!-- col54 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                 <!--    'column_alias': 'booking__ds__month'}              -->
                                 <!-- col55 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                                 <!-- col56 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                 <!--    'column_alias': 'booking__ds__year'}               -->
                                 <!-- col57 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -764,25 +764,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                <!-- col64 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                <!-- col64 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                 <!-- col65 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                 <!-- col66 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                 <!-- col67 =                                                 -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                 <!-- col68 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                 <!-- col69 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -812,25 +812,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                <!-- col76 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                <!-- col76 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'booking__paid_at__day'}           -->
                                 <!-- col77 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                                 <!-- col78 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                                 <!-- col79 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                 <!-- col80 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                                 <!-- col81 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1831,25 +1831,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                                     <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds__day'}                               -->
+                                    <!-- col15 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds__day'}                         -->
                                     <!-- col16 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                                     <!--    'column_alias': 'ds__week'}                        -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                                     <!--    'column_alias': 'ds__month'}                       -->
                                     <!-- col18 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                                     <!--    'column_alias': 'ds__quarter'}                     -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col20 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1879,25 +1879,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                                     <!--    'column_alias': 'ds__extract_doy'}               -->
-                                    <!-- col27 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                                    <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'ds_partitioned__day'}             -->
                                     <!-- col28 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}            -->
                                     <!-- col29 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}           -->
                                     <!-- col30 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                     <!-- col31 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col32 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1927,25 +1927,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                                     <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                                    <!-- col39 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                                    <!--    'column_alias': 'paid_at__day'}                          -->
+                                    <!-- col39 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'column_alias': 'paid_at__day'}                    -->
                                     <!-- col40 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                                     <!--    'column_alias': 'paid_at__week'}                   -->
                                     <!-- col41 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                                     <!--    'column_alias': 'paid_at__month'}                  -->
                                     <!-- col42 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                                     <!--    'column_alias': 'paid_at__quarter'}                -->
                                     <!-- col43 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                                     <!--    'column_alias': 'paid_at__year'}                   -->
                                     <!-- col44 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1979,25 +1979,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                                     <!--    'column_alias': 'booking__is_instant'}                   -->
-                                    <!-- col52 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                                    <!--    'column_alias': 'booking__ds__day'}                      -->
+                                    <!-- col52 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'column_alias': 'booking__ds__day'}                -->
                                     <!-- col53 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                                     <!--    'column_alias': 'booking__ds__week'}               -->
                                     <!-- col54 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                                     <!--    'column_alias': 'booking__ds__month'}              -->
                                     <!-- col55 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                                     <!--    'column_alias': 'booking__ds__quarter'}            -->
                                     <!-- col56 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                                     <!--    'column_alias': 'booking__ds__year'}               -->
                                     <!-- col57 =                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                      -->
@@ -2027,25 +2027,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                      -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                                     <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                                    <!-- col64 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                                    <!-- col64 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                                     <!-- col65 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                                     <!-- col66 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                                     <!-- col67 =                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                                     <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                                     <!-- col68 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                                     <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                                     <!-- col69 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                               -->
@@ -2075,25 +2075,25 @@
                                     <!--   {'class': 'SqlSelectColumn',                              -->
                                     <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                                     <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                                    <!-- col76 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                                    <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                                    <!-- col76 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                    <!--    'column_alias': 'booking__paid_at__day'}           -->
                                     <!-- col77 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                                     <!--    'column_alias': 'booking__paid_at__week'}          -->
                                     <!-- col78 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                                     <!--    'column_alias': 'booking__paid_at__month'}         -->
                                     <!-- col79 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                                     <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                                     <!-- col80 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                                     <!--    'column_alias': 'booking__paid_at__year'}          -->
                                     <!-- col81 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -148,25 +148,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -196,25 +196,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -244,25 +244,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -296,25 +296,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -344,25 +344,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -392,25 +392,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
@@ -370,25 +370,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
                                 <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
                                 <!--    'column_alias': 'identity_verifications'}                   -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10041),  -->
-                                <!--    'column_alias': 'ds__day'}                               -->
+                                <!-- col1 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
+                                <!--    'column_alias': 'ds__day'}                         -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
                                 <!--    'column_alias': 'ds__week'}                        -->
                                 <!-- col3 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
                                 <!--    'column_alias': 'ds__month'}                       -->
                                 <!-- col4 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
                                 <!--    'column_alias': 'ds__quarter'}                     -->
                                 <!-- col5 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
                                 <!--    'column_alias': 'ds__year'}                        -->
                                 <!-- col6 =                                              -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -418,25 +418,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                      -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10062),  -->
                                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                                <!-- col13 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),  -->
-                                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                <!--    'column_alias': 'ds_partitioned__day'}             -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                                 <!-- col15 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                                 <!-- col16 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                                 <!-- col17 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col18 =                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -470,25 +470,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                              -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),  -->
                                 <!--    'column_alias': 'verification_type'}                     -->
-                                <!-- col26 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10044),  -->
-                                <!--    'column_alias': 'verification__ds__day'}                 -->
+                                <!-- col26 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                <!--    'column_alias': 'verification__ds__day'}           -->
                                 <!-- col27 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
                                 <!--    'column_alias': 'verification__ds__week'}          -->
                                 <!-- col28 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
                                 <!--    'column_alias': 'verification__ds__month'}         -->
                                 <!-- col29 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
                                 <!--    'column_alias': 'verification__ds__quarter'}       -->
                                 <!-- col30 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
                                 <!--    'column_alias': 'verification__ds__year'}          -->
                                 <!-- col31 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -518,25 +518,25 @@
                                 <!--   {'class': 'SqlSelectColumn',                       -->
                                 <!--    'expr': SqlExtractExpression(node_id=ex_10076),   -->
                                 <!--    'column_alias': 'verification__ds__extract_doy'}  -->
-                                <!-- col38 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10045),  -->
-                                <!--    'column_alias': 'verification__ds_partitioned__day'}     -->
+                                <!-- col38 =                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                           -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),     -->
+                                <!--    'column_alias': 'verification__ds_partitioned__day'}  -->
                                 <!-- col39 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),      -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),      -->
                                 <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
                                 <!-- col40 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),       -->
                                 <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
                                 <!-- col41 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),         -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),         -->
                                 <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
                                 <!-- col42 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),      -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),      -->
                                 <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
                                 <!-- col43 =                                                           -->
                                 <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -614,25 +614,25 @@
                         <SqlSelectStatementNode>
                             <!-- description = Read Elements From Semantic Model 'users_ds_source' -->
                             <!-- node_id = ss_10007 -->
-                            <!-- col0 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col0 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10090),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col1 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10091),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col2 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10092),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col3 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10093),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col4 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10094),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col5 =                                              -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -662,25 +662,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10132),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col12 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10074),  -->
-                            <!--    'column_alias': 'created_at__day'}                       -->
+                            <!-- col12 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10095),  -->
+                            <!--    'column_alias': 'created_at__day'}                 -->
                             <!-- col13 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10096),  -->
                             <!--    'column_alias': 'created_at__week'}                -->
                             <!-- col14 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10097),  -->
                             <!--    'column_alias': 'created_at__month'}               -->
                             <!-- col15 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10098),  -->
                             <!--    'column_alias': 'created_at__quarter'}             -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10099),  -->
                             <!--    'column_alias': 'created_at__year'}                -->
                             <!-- col17 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -710,25 +710,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10139),  -->
                             <!--    'column_alias': 'created_at__extract_doy'}       -->
-                            <!-- col24 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10075),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col24 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10100),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col25 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10080),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10101),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col26 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10081),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10102),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col27 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10082),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10103),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10083),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col29 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -762,25 +762,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10076),  -->
                             <!--    'column_alias': 'home_state'}                            -->
-                            <!-- col37 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10077),  -->
-                            <!--    'column_alias': 'user__ds__day'}                         -->
+                            <!-- col37 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),  -->
+                            <!--    'column_alias': 'user__ds__day'}                   -->
                             <!-- col38 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10084),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),  -->
                             <!--    'column_alias': 'user__ds__week'}                  -->
                             <!-- col39 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10085),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),  -->
                             <!--    'column_alias': 'user__ds__month'}                 -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10086),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),  -->
                             <!--    'column_alias': 'user__ds__quarter'}               -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10087),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),  -->
                             <!--    'column_alias': 'user__ds__year'}                  -->
                             <!-- col42 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -810,25 +810,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10153),  -->
                             <!--    'column_alias': 'user__ds__extract_doy'}         -->
-                            <!-- col49 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10078),  -->
-                            <!--    'column_alias': 'user__created_at__day'}                 -->
+                            <!-- col49 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),  -->
+                            <!--    'column_alias': 'user__created_at__day'}           -->
                             <!-- col50 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10088),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),  -->
                             <!--    'column_alias': 'user__created_at__week'}          -->
                             <!-- col51 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10089),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),  -->
                             <!--    'column_alias': 'user__created_at__month'}         -->
                             <!-- col52 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10090),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),  -->
                             <!--    'column_alias': 'user__created_at__quarter'}       -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10091),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),  -->
                             <!--    'column_alias': 'user__created_at__year'}          -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -858,25 +858,25 @@
                             <!--   {'class': 'SqlSelectColumn',                       -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10160),   -->
                             <!--    'column_alias': 'user__created_at__extract_doy'}  -->
-                            <!-- col61 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10079),  -->
-                            <!--    'column_alias': 'user__ds_partitioned__day'}             -->
+                            <!-- col61 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),  -->
+                            <!--    'column_alias': 'user__ds_partitioned__day'}       -->
                             <!-- col62 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10092),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
                             <!--    'column_alias': 'user__ds_partitioned__week'}      -->
                             <!-- col63 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10093),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
                             <!--    'column_alias': 'user__ds_partitioned__month'}     -->
                             <!-- col64 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10094),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
                             <!--    'column_alias': 'user__ds_partitioned__quarter'}   -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10095),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
                             <!--    'column_alias': 'user__ds_partitioned__year'}      -->
                             <!-- col66 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
@@ -149,25 +149,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
             <!--    'column_alias': 'current_account_balance_by_user'}       -->
-            <!-- col3 =                                                      -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
-            <!-- col4 =                                                -->
+            <!-- col3 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col5 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col6 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col7 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col8 =                                              -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -201,25 +201,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
             <!--    'column_alias': 'account_type'}                          -->
-            <!-- col16 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-            <!--    'column_alias': 'account__ds__day'}                      -->
+            <!-- col16 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'column_alias': 'account__ds__day'}                -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
             <!--    'column_alias': 'account__ds__week'}               -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
             <!--    'column_alias': 'account__ds__month'}              -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
             <!--    'column_alias': 'account__ds__quarter'}            -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
             <!--    'column_alias': 'account__ds__year'}               -->
             <!-- col21 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -293,25 +293,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
                 <!--    'column_alias': 'current_account_balance_by_user'}       -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
-                <!-- col4 =                                                -->
+                <!-- col3 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
+                <!-- col4 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -345,25 +345,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
                 <!--    'column_alias': 'account_type'}                          -->
-                <!-- col16 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-                <!--    'column_alias': 'account__ds__day'}                      -->
+                <!-- col16 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'column_alias': 'account__ds__day'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
                 <!--    'column_alias': 'account__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
                 <!--    'column_alias': 'account__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
                 <!--    'column_alias': 'account__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
                 <!--    'column_alias': 'account__ds__year'}               -->
                 <!-- col21 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -149,25 +149,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
             <!--    'column_alias': 'current_account_balance_by_user'}       -->
-            <!-- col3 =                                                      -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
-            <!-- col4 =                                                -->
+            <!-- col3 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col5 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col6 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col7 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col8 =                                              -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -201,25 +201,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
             <!--    'column_alias': 'account_type'}                          -->
-            <!-- col16 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-            <!--    'column_alias': 'account__ds__day'}                      -->
+            <!-- col16 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'column_alias': 'account__ds__day'}                -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
             <!--    'column_alias': 'account__ds__week'}               -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
             <!--    'column_alias': 'account__ds__month'}              -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
             <!--    'column_alias': 'account__ds__quarter'}            -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
             <!--    'column_alias': 'account__ds__year'}               -->
             <!-- col21 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -301,25 +301,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
                 <!--    'column_alias': 'current_account_balance_by_user'}       -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
-                <!-- col4 =                                                -->
+                <!-- col3 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
+                <!-- col4 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -353,25 +353,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
                 <!--    'column_alias': 'account_type'}                          -->
-                <!-- col16 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-                <!--    'column_alias': 'account__ds__day'}                      -->
+                <!-- col16 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'column_alias': 'account__ds__day'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
                 <!--    'column_alias': 'account__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
                 <!--    'column_alias': 'account__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
                 <!--    'column_alias': 'account__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
                 <!--    'column_alias': 'account__ds__year'}               -->
                 <!-- col21 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -149,25 +149,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
             <!--    'column_alias': 'current_account_balance_by_user'}       -->
-            <!-- col3 =                                                      -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
-            <!-- col4 =                                                -->
+            <!-- col3 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
             <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col5 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col6 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col7 =                                                -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col8 =                                              -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -201,25 +201,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
             <!--    'column_alias': 'account_type'}                          -->
-            <!-- col16 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-            <!--    'column_alias': 'account__ds__day'}                      -->
+            <!-- col16 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'column_alias': 'account__ds__day'}                -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
             <!--    'column_alias': 'account__ds__week'}               -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
             <!--    'column_alias': 'account__ds__month'}              -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
             <!--    'column_alias': 'account__ds__quarter'}            -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
             <!--    'column_alias': 'account__ds__year'}               -->
             <!-- col21 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -301,25 +301,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
                 <!--    'column_alias': 'current_account_balance_by_user'}       -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
-                <!-- col4 =                                                -->
+                <!-- col3 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
                 <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
+                <!-- col4 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -353,25 +353,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10004),  -->
                 <!--    'column_alias': 'account_type'}                          -->
-                <!-- col16 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10005),  -->
-                <!--    'column_alias': 'account__ds__day'}                      -->
+                <!-- col16 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'column_alias': 'account__ds__day'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
                 <!--    'column_alias': 'account__ds__week'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
                 <!--    'column_alias': 'account__ds__month'}              -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
                 <!--    'column_alias': 'account__ds__quarter'}            -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
                 <!--    'column_alias': 'account__ds__year'}               -->
                 <!-- col21 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_simple_query_with_date_part__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_simple_query_with_date_part__plan0.xml
@@ -532,25 +532,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -580,25 +580,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -628,25 +628,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -680,25 +680,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -728,25 +728,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -776,25 +776,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_simple_query_with_multiple_date_parts__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_simple_query_with_multiple_date_parts__plan0.xml
@@ -635,25 +635,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
-                        <!-- col15 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                        <!--    'column_alias': 'ds__day'}                               -->
+                        <!-- col15 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'column_alias': 'ds__day'}                         -->
                         <!-- col16 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                         <!--    'column_alias': 'ds__week'}                        -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                         <!--    'column_alias': 'ds__month'}                       -->
                         <!-- col18 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                         <!--    'column_alias': 'ds__quarter'}                     -->
                         <!-- col19 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col20 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -683,25 +683,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                         <!--    'column_alias': 'ds__extract_doy'}               -->
-                        <!-- col27 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                        <!-- col27 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'column_alias': 'ds_partitioned__day'}             -->
                         <!-- col28 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}            -->
                         <!-- col29 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}           -->
                         <!-- col30 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                         <!-- col31 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col32 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -731,25 +731,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                        <!-- col39 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                        <!--    'column_alias': 'paid_at__day'}                          -->
+                        <!-- col39 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'column_alias': 'paid_at__day'}                    -->
                         <!-- col40 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                         <!--    'column_alias': 'paid_at__week'}                   -->
                         <!-- col41 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                         <!--    'column_alias': 'paid_at__month'}                  -->
                         <!-- col42 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                         <!--    'column_alias': 'paid_at__quarter'}                -->
                         <!-- col43 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                         <!--    'column_alias': 'paid_at__year'}                   -->
                         <!-- col44 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -783,25 +783,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                         <!--    'column_alias': 'booking__is_instant'}                   -->
-                        <!-- col52 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                        <!--    'column_alias': 'booking__ds__day'}                      -->
+                        <!-- col52 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'column_alias': 'booking__ds__day'}                -->
                         <!-- col53 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                         <!--    'column_alias': 'booking__ds__week'}               -->
                         <!-- col54 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                         <!--    'column_alias': 'booking__ds__month'}              -->
                         <!-- col55 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                         <!--    'column_alias': 'booking__ds__quarter'}            -->
                         <!-- col56 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                         <!--    'column_alias': 'booking__ds__year'}               -->
                         <!-- col57 =                                             -->
                         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -831,25 +831,25 @@
                         <!--   {'class': 'SqlSelectColumn',                      -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                        <!-- col64 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                        <!-- col64 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                         <!-- col65 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                         <!-- col66 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                         <!-- col67 =                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                          -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                         <!-- col68 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                         <!-- col69 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -879,25 +879,25 @@
                         <!--   {'class': 'SqlSelectColumn',                              -->
                         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                        <!-- col76 =                                                     -->
-                        <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                        <!-- col76 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                        <!--    'column_alias': 'booking__paid_at__day'}           -->
                         <!-- col77 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                         <!--    'column_alias': 'booking__paid_at__week'}          -->
                         <!-- col78 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                         <!--    'column_alias': 'booking__paid_at__month'}         -->
                         <!-- col79 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                         <!-- col80 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
-                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                         <!--    'column_alias': 'booking__paid_at__year'}          -->
                         <!-- col81 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
@@ -96,25 +96,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -144,25 +144,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col27 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                <!-- col27 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'column_alias': 'ds_partitioned__day'}             -->
                 <!-- col28 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                 <!--    'column_alias': 'ds_partitioned__week'}            -->
                 <!-- col29 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                 <!--    'column_alias': 'ds_partitioned__month'}           -->
                 <!-- col30 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                 <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col32 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -192,25 +192,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                 <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                <!-- col39 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                <!--    'column_alias': 'paid_at__day'}                          -->
+                <!-- col39 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'column_alias': 'paid_at__day'}                    -->
                 <!-- col40 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                 <!--    'column_alias': 'paid_at__week'}                   -->
                 <!-- col41 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                 <!--    'column_alias': 'paid_at__month'}                  -->
                 <!-- col42 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                 <!--    'column_alias': 'paid_at__quarter'}                -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                 <!--    'column_alias': 'paid_at__year'}                   -->
                 <!-- col44 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -244,25 +244,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                 <!--    'column_alias': 'booking__is_instant'}                   -->
-                <!-- col52 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                <!--    'column_alias': 'booking__ds__day'}                      -->
+                <!-- col52 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'column_alias': 'booking__ds__day'}                -->
                 <!-- col53 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                 <!--    'column_alias': 'booking__ds__week'}               -->
                 <!-- col54 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                 <!--    'column_alias': 'booking__ds__month'}              -->
                 <!-- col55 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                 <!--    'column_alias': 'booking__ds__quarter'}            -->
                 <!-- col56 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                 <!--    'column_alias': 'booking__ds__year'}               -->
                 <!-- col57 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -292,25 +292,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                 <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                <!-- col64 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                <!-- col64 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                 <!-- col65 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                 <!-- col66 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                 <!-- col67 =                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                 <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                 <!-- col68 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                 <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                 <!-- col69 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                               -->
@@ -340,25 +340,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                 <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                <!-- col76 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                <!-- col76 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                <!--    'column_alias': 'booking__paid_at__day'}           -->
                 <!-- col77 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                 <!--    'column_alias': 'booking__paid_at__week'}          -->
                 <!-- col78 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                 <!--    'column_alias': 'booking__paid_at__month'}         -->
                 <!-- col79 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                 <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                 <!-- col80 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                 <!--    'column_alias': 'booking__paid_at__year'}          -->
                 <!-- col81 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -451,25 +451,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
-                <!-- col3 =                                                      -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),  -->
-                <!--    'column_alias': 'ds__day'}                               -->
+                <!-- col3 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'column_alias': 'ds__day'}                         -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
                 <!--    'column_alias': 'ds__week'}                        -->
                 <!-- col5 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
                 <!--    'column_alias': 'ds__month'}                       -->
                 <!-- col6 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
                 <!--    'column_alias': 'ds__quarter'}                     -->
                 <!-- col7 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10064),  -->
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -499,25 +499,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10090),  -->
                 <!--    'column_alias': 'ds__extract_doy'}               -->
-                <!-- col15 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
-                <!--    'column_alias': 'created_at__day'}                       -->
+                <!-- col15 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10065),  -->
+                <!--    'column_alias': 'created_at__day'}                 -->
                 <!-- col16 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10066),  -->
                 <!--    'column_alias': 'created_at__week'}                -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10067),  -->
                 <!--    'column_alias': 'created_at__month'}               -->
                 <!-- col18 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10068),  -->
                 <!--    'column_alias': 'created_at__quarter'}             -->
                 <!-- col19 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10069),  -->
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col20 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -559,25 +559,25 @@
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
-                <!-- col30 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),  -->
-                <!--    'column_alias': 'listing__ds__day'}                      -->
+                <!-- col30 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10070),  -->
+                <!--    'column_alias': 'listing__ds__day'}                -->
                 <!-- col31 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10071),  -->
                 <!--    'column_alias': 'listing__ds__week'}               -->
                 <!-- col32 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10072),  -->
                 <!--    'column_alias': 'listing__ds__month'}              -->
                 <!-- col33 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10073),  -->
                 <!--    'column_alias': 'listing__ds__quarter'}            -->
                 <!-- col34 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10074),  -->
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col35 =                                             -->
                 <!--   {'class': 'SqlSelectColumn',                      -->
@@ -607,25 +607,25 @@
                 <!--   {'class': 'SqlSelectColumn',                      -->
                 <!--    'expr': SqlExtractExpression(node_id=ex_10104),  -->
                 <!--    'column_alias': 'listing__ds__extract_doy'}      -->
-                <!-- col42 =                                                     -->
-                <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),  -->
-                <!--    'column_alias': 'listing__created_at__day'}              -->
+                <!-- col42 =                                               -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10075),  -->
+                <!--    'column_alias': 'listing__created_at__day'}        -->
                 <!-- col43 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10076),  -->
                 <!--    'column_alias': 'listing__created_at__week'}       -->
                 <!-- col44 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10077),  -->
                 <!--    'column_alias': 'listing__created_at__month'}      -->
                 <!-- col45 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10078),  -->
                 <!--    'column_alias': 'listing__created_at__quarter'}    -->
                 <!-- col46 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
-                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10079),  -->
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col47 =                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                           -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
@@ -62,25 +62,25 @@
         <!--   {'class': 'SqlSelectColumn',                              -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
         <!--    'column_alias': 'is_instant'}                            -->
-        <!-- col15 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-        <!--    'column_alias': 'ds__day'}                               -->
+        <!-- col15 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+        <!--    'column_alias': 'ds__day'}                         -->
         <!-- col16 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
         <!--    'column_alias': 'ds__week'}                        -->
         <!-- col17 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
         <!--    'column_alias': 'ds__month'}                       -->
         <!-- col18 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
         <!--    'column_alias': 'ds__quarter'}                     -->
         <!-- col19 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
         <!--    'column_alias': 'ds__year'}                        -->
         <!-- col20 =                                             -->
         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -110,25 +110,25 @@
         <!--   {'class': 'SqlSelectColumn',                      -->
         <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
         <!--    'column_alias': 'ds__extract_doy'}               -->
-        <!-- col27 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-        <!--    'column_alias': 'ds_partitioned__day'}                   -->
+        <!-- col27 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+        <!--    'column_alias': 'ds_partitioned__day'}             -->
         <!-- col28 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
         <!--    'column_alias': 'ds_partitioned__week'}            -->
         <!-- col29 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
         <!--    'column_alias': 'ds_partitioned__month'}           -->
         <!-- col30 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
         <!--    'column_alias': 'ds_partitioned__quarter'}         -->
         <!-- col31 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
         <!--    'column_alias': 'ds_partitioned__year'}            -->
         <!-- col32 =                                             -->
         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -158,25 +158,25 @@
         <!--   {'class': 'SqlSelectColumn',                      -->
         <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
         <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-        <!-- col39 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-        <!--    'column_alias': 'paid_at__day'}                          -->
+        <!-- col39 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+        <!--    'column_alias': 'paid_at__day'}                    -->
         <!-- col40 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
         <!--    'column_alias': 'paid_at__week'}                   -->
         <!-- col41 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
         <!--    'column_alias': 'paid_at__month'}                  -->
         <!-- col42 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
         <!--    'column_alias': 'paid_at__quarter'}                -->
         <!-- col43 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
         <!--    'column_alias': 'paid_at__year'}                   -->
         <!-- col44 =                                             -->
         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -210,25 +210,25 @@
         <!--   {'class': 'SqlSelectColumn',                              -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
         <!--    'column_alias': 'booking__is_instant'}                   -->
-        <!-- col52 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-        <!--    'column_alias': 'booking__ds__day'}                      -->
+        <!-- col52 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+        <!--    'column_alias': 'booking__ds__day'}                -->
         <!-- col53 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
         <!--    'column_alias': 'booking__ds__week'}               -->
         <!-- col54 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
         <!--    'column_alias': 'booking__ds__month'}              -->
         <!-- col55 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
         <!--    'column_alias': 'booking__ds__quarter'}            -->
         <!-- col56 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
         <!--    'column_alias': 'booking__ds__year'}               -->
         <!-- col57 =                                             -->
         <!--   {'class': 'SqlSelectColumn',                      -->
@@ -258,25 +258,25 @@
         <!--   {'class': 'SqlSelectColumn',                      -->
         <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
         <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-        <!-- col64 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-        <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+        <!-- col64 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+        <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
         <!-- col65 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
         <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
         <!-- col66 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
         <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
         <!-- col67 =                                                 -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
         <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
         <!-- col68 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
         <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
         <!-- col69 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                               -->
@@ -306,25 +306,25 @@
         <!--   {'class': 'SqlSelectColumn',                              -->
         <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
         <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-        <!-- col76 =                                                     -->
-        <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-        <!--    'column_alias': 'booking__paid_at__day'}                 -->
+        <!-- col76 =                                               -->
+        <!--   {'class': 'SqlSelectColumn',                        -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+        <!--    'column_alias': 'booking__paid_at__day'}           -->
         <!-- col77 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
         <!--    'column_alias': 'booking__paid_at__week'}          -->
         <!-- col78 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
         <!--    'column_alias': 'booking__paid_at__month'}         -->
         <!-- col79 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
         <!--    'column_alias': 'booking__paid_at__quarter'}       -->
         <!-- col80 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
-        <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+        <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
         <!--    'column_alias': 'booking__paid_at__year'}          -->
         <!-- col81 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC(ds, day) AS ds__day
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC(paid_at, day) AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dayofweek FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(dayofyear FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC(ds, day) AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS booking__ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC(paid_at, day) AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dayofweek FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(dayofyear FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC(paid_at, day) AS metric_time__day
   , DATE_TRUNC(paid_at, isoweek) AS metric_time__week
   , DATE_TRUNC(paid_at, month) AS metric_time__month
   , DATE_TRUNC(paid_at, quarter) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
     , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
     , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
     , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
     , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
     , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
     , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
     , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC(ds, day) AS ds__day
   , DATE_TRUNC(ds, isoweek) AS ds__week
   , DATE_TRUNC(ds, month) AS ds__month
   , DATE_TRUNC(ds, quarter) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC(paid_at, day) AS paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS paid_at__week
   , DATE_TRUNC(paid_at, month) AS paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dayofweek FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(dayofyear FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC(ds, day) AS booking__ds__day
   , DATE_TRUNC(ds, isoweek) AS booking__ds__week
   , DATE_TRUNC(ds, month) AS booking__ds__month
   , DATE_TRUNC(ds, quarter) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dayofweek FROM ds) AS booking__ds__extract_dow
   , EXTRACT(dayofyear FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC(ds_partitioned, day) AS booking__ds_partitioned__day
   , DATE_TRUNC(ds_partitioned, isoweek) AS booking__ds_partitioned__week
   , DATE_TRUNC(ds_partitioned, month) AS booking__ds_partitioned__month
   , DATE_TRUNC(ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dayofweek FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(dayofyear FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC(paid_at, day) AS booking__paid_at__day
   , DATE_TRUNC(paid_at, isoweek) AS booking__paid_at__week
   , DATE_TRUNC(paid_at, month) AS booking__paid_at__month
   , DATE_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dayofweek FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(dayofyear FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC(ds, day) AS metric_time__day
   , DATE_TRUNC(ds, isoweek) AS metric_time__week
   , DATE_TRUNC(ds, month) AS metric_time__month
   , DATE_TRUNC(ds, quarter) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
             , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
             , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
             , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
             , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
             , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
             , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
             , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,7 +30,7 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC(paid_at, day) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC('day', paid_at) AS metric_time__day
   , DATE_TRUNC('week', paid_at) AS metric_time__week
   , DATE_TRUNC('month', paid_at) AS metric_time__month
   , DATE_TRUNC('quarter', paid_at) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
   , DATE_TRUNC('quarter', ds) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC('day', paid_at) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    paid_at
+    DATE_TRUNC('day', paid_at)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC('day', paid_at) AS metric_time__day
   , DATE_TRUNC('week', paid_at) AS metric_time__week
   , DATE_TRUNC('month', paid_at) AS metric_time__month
   , DATE_TRUNC('quarter', paid_at) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
   , DATE_TRUNC('quarter', ds) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC('day', paid_at) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    paid_at
+    DATE_TRUNC('day', paid_at)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC('day', paid_at) AS metric_time__day
   , DATE_TRUNC('week', paid_at) AS metric_time__week
   , DATE_TRUNC('month', paid_at) AS metric_time__month
   , DATE_TRUNC('quarter', paid_at) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
   , DATE_TRUNC('quarter', ds) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC('day', paid_at) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    paid_at
+    DATE_TRUNC('day', paid_at)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC('day', paid_at) AS metric_time__day
   , DATE_TRUNC('week', paid_at) AS metric_time__week
   , DATE_TRUNC('month', paid_at) AS metric_time__month
   , DATE_TRUNC('quarter', paid_at) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
   , DATE_TRUNC('quarter', ds) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC('day', paid_at) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    paid_at
+    DATE_TRUNC('day', paid_at)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.sql
@@ -111,7 +111,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -123,7 +123,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -148,7 +148,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_non_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'paid_at'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , paid_at AS metric_time__day
+  , DATE_TRUNC('day', paid_at) AS metric_time__day
   , DATE_TRUNC('week', paid_at) AS metric_time__week
   , DATE_TRUNC('month', paid_at) AS metric_time__month
   , DATE_TRUNC('quarter', paid_at) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0.sql
@@ -123,7 +123,7 @@ FROM (
     , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
     , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
     , bookings_source_src_10001.is_instant
-    , bookings_source_src_10001.ds AS ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -135,7 +135,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -147,7 +147,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -160,7 +160,7 @@ FROM (
     , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
     , bookings_source_src_10001.is_instant AS booking__is_instant
-    , bookings_source_src_10001.ds AS booking__ds__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -172,7 +172,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-    , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
     , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
     , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -184,7 +184,7 @@ FROM (
     , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
     , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
     , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-    , bookings_source_src_10001.paid_at AS booking__paid_at__day
+    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
     , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
     , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
     , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_metric_time_dimension_transform_node_using_primary_time__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Read Elements From Semantic Model 'bookings_source'
 -- Metric Time Dimension 'ds'
 SELECT
-  ds AS ds__day
+  DATE_TRUNC('day', ds) AS ds__day
   , DATE_TRUNC('week', ds) AS ds__week
   , DATE_TRUNC('month', ds) AS ds__month
   , DATE_TRUNC('quarter', ds) AS ds__quarter
@@ -13,7 +13,7 @@ SELECT
   , EXTRACT(day FROM ds) AS ds__extract_day
   , EXTRACT(dow FROM ds) AS ds__extract_dow
   , EXTRACT(doy FROM ds) AS ds__extract_doy
-  , ds_partitioned AS ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
@@ -25,7 +25,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS ds_partitioned__extract_doy
-  , paid_at AS paid_at__day
+  , DATE_TRUNC('day', paid_at) AS paid_at__day
   , DATE_TRUNC('week', paid_at) AS paid_at__week
   , DATE_TRUNC('month', paid_at) AS paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS paid_at__quarter
@@ -37,7 +37,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS paid_at__extract_doy
-  , ds AS booking__ds__day
+  , DATE_TRUNC('day', ds) AS booking__ds__day
   , DATE_TRUNC('week', ds) AS booking__ds__week
   , DATE_TRUNC('month', ds) AS booking__ds__month
   , DATE_TRUNC('quarter', ds) AS booking__ds__quarter
@@ -49,7 +49,7 @@ SELECT
   , EXTRACT(day FROM ds) AS booking__ds__extract_day
   , EXTRACT(dow FROM ds) AS booking__ds__extract_dow
   , EXTRACT(doy FROM ds) AS booking__ds__extract_doy
-  , ds_partitioned AS booking__ds_partitioned__day
+  , DATE_TRUNC('day', ds_partitioned) AS booking__ds_partitioned__day
   , DATE_TRUNC('week', ds_partitioned) AS booking__ds_partitioned__week
   , DATE_TRUNC('month', ds_partitioned) AS booking__ds_partitioned__month
   , DATE_TRUNC('quarter', ds_partitioned) AS booking__ds_partitioned__quarter
@@ -61,7 +61,7 @@ SELECT
   , EXTRACT(day FROM ds_partitioned) AS booking__ds_partitioned__extract_day
   , EXTRACT(dow FROM ds_partitioned) AS booking__ds_partitioned__extract_dow
   , EXTRACT(doy FROM ds_partitioned) AS booking__ds_partitioned__extract_doy
-  , paid_at AS booking__paid_at__day
+  , DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   , DATE_TRUNC('week', paid_at) AS booking__paid_at__week
   , DATE_TRUNC('month', paid_at) AS booking__paid_at__month
   , DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
@@ -73,7 +73,7 @@ SELECT
   , EXTRACT(day FROM paid_at) AS booking__paid_at__extract_day
   , EXTRACT(dow FROM paid_at) AS booking__paid_at__extract_dow
   , EXTRACT(doy FROM paid_at) AS booking__paid_at__extract_doy
-  , ds AS metric_time__day
+  , DATE_TRUNC('day', ds) AS metric_time__day
   , DATE_TRUNC('week', ds) AS metric_time__week
   , DATE_TRUNC('month', ds) AS metric_time__month
   , DATE_TRUNC('quarter', ds) AS metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -145,7 +145,7 @@ FROM (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -157,7 +157,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -169,7 +169,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -182,7 +182,7 @@ FROM (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -194,7 +194,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -206,7 +206,7 @@ FROM (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
@@ -362,7 +362,7 @@ FULL OUTER JOIN (
             , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
             , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
             , bookings_source_src_10001.is_instant
-            , bookings_source_src_10001.ds AS ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
@@ -374,7 +374,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
@@ -386,7 +386,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
@@ -399,7 +399,7 @@ FULL OUTER JOIN (
             , EXTRACT(dow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
             , bookings_source_src_10001.is_instant AS booking__is_instant
-            , bookings_source_src_10001.ds AS booking__ds__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
@@ -411,7 +411,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-            , bookings_source_src_10001.ds_partitioned AS booking__ds_partitioned__day
+            , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
             , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
             , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
@@ -423,7 +423,7 @@ FULL OUTER JOIN (
             , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
             , EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
             , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-            , bookings_source_src_10001.paid_at AS booking__paid_at__day
+            , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
             , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
             , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
             , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_10001
   ) subq_12
@@ -30,11 +30,11 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    paid_at AS metric_time__day
+    DATE_TRUNC('day', paid_at) AS metric_time__day
     , SUM(booking_value) AS booking_payments
   FROM ***************************.fct_bookings bookings_source_src_10001
   GROUP BY
-    paid_at
+    DATE_TRUNC('day', paid_at)
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -439,25 +439,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
             <!--    'column_alias': 'is_instant'}                            -->
-            <!-- col15 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
+            <!-- col15 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
             <!-- col16 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col20 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -487,25 +487,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
             <!--    'column_alias': 'ds__extract_doy'}               -->
-            <!-- col27 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+            <!-- col27 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'column_alias': 'ds_partitioned__day'}             -->
             <!-- col28 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
             <!--    'column_alias': 'ds_partitioned__week'}            -->
             <!-- col29 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
             <!--    'column_alias': 'ds_partitioned__month'}           -->
             <!-- col30 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
             <!-- col31 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col32 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -535,25 +535,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-            <!-- col39 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-            <!--    'column_alias': 'paid_at__day'}                          -->
+            <!-- col39 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'column_alias': 'paid_at__day'}                    -->
             <!-- col40 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
             <!--    'column_alias': 'paid_at__week'}                   -->
             <!-- col41 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
             <!--    'column_alias': 'paid_at__month'}                  -->
             <!-- col42 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
             <!--    'column_alias': 'paid_at__quarter'}                -->
             <!-- col43 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
             <!--    'column_alias': 'paid_at__year'}                   -->
             <!-- col44 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -587,25 +587,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
             <!--    'column_alias': 'booking__is_instant'}                   -->
-            <!-- col52 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-            <!--    'column_alias': 'booking__ds__day'}                      -->
+            <!-- col52 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'column_alias': 'booking__ds__day'}                -->
             <!-- col53 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
             <!--    'column_alias': 'booking__ds__week'}               -->
             <!-- col54 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
             <!--    'column_alias': 'booking__ds__month'}              -->
             <!-- col55 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
             <!--    'column_alias': 'booking__ds__quarter'}            -->
             <!-- col56 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
             <!--    'column_alias': 'booking__ds__year'}               -->
             <!-- col57 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -635,25 +635,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-            <!-- col64 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+            <!-- col64 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
             <!-- col65 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
             <!-- col66 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
             <!-- col67 =                                                 -->
             <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
             <!-- col68 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
             <!-- col69 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -683,25 +683,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-            <!-- col76 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+            <!-- col76 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+            <!--    'column_alias': 'booking__paid_at__day'}           -->
             <!-- col77 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
             <!--    'column_alias': 'booking__paid_at__week'}          -->
             <!-- col78 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
             <!--    'column_alias': 'booking__paid_at__month'}         -->
             <!-- col79 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
             <!-- col80 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
             <!--    'column_alias': 'booking__paid_at__year'}          -->
             <!-- col81 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -487,25 +487,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
             <!--    'column_alias': 'is_instant'}                            -->
-            <!-- col15 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-            <!--    'column_alias': 'ds__day'}                               -->
+            <!-- col15 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'column_alias': 'ds__day'}                         -->
             <!-- col16 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
             <!--    'column_alias': 'ds__week'}                        -->
             <!-- col17 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
             <!--    'column_alias': 'ds__month'}                       -->
             <!-- col18 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
             <!--    'column_alias': 'ds__quarter'}                     -->
             <!-- col19 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col20 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -535,25 +535,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
             <!--    'column_alias': 'ds__extract_doy'}               -->
-            <!-- col27 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+            <!-- col27 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'column_alias': 'ds_partitioned__day'}             -->
             <!-- col28 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
             <!--    'column_alias': 'ds_partitioned__week'}            -->
             <!-- col29 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
             <!--    'column_alias': 'ds_partitioned__month'}           -->
             <!-- col30 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
             <!-- col31 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col32 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -583,25 +583,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-            <!-- col39 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-            <!--    'column_alias': 'paid_at__day'}                          -->
+            <!-- col39 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'column_alias': 'paid_at__day'}                    -->
             <!-- col40 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
             <!--    'column_alias': 'paid_at__week'}                   -->
             <!-- col41 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
             <!--    'column_alias': 'paid_at__month'}                  -->
             <!-- col42 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
             <!--    'column_alias': 'paid_at__quarter'}                -->
             <!-- col43 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
             <!--    'column_alias': 'paid_at__year'}                   -->
             <!-- col44 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -635,25 +635,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
             <!--    'column_alias': 'booking__is_instant'}                   -->
-            <!-- col52 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-            <!--    'column_alias': 'booking__ds__day'}                      -->
+            <!-- col52 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'column_alias': 'booking__ds__day'}                -->
             <!-- col53 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
             <!--    'column_alias': 'booking__ds__week'}               -->
             <!-- col54 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
             <!--    'column_alias': 'booking__ds__month'}              -->
             <!-- col55 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
             <!--    'column_alias': 'booking__ds__quarter'}            -->
             <!-- col56 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
             <!--    'column_alias': 'booking__ds__year'}               -->
             <!-- col57 =                                             -->
             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -683,25 +683,25 @@
             <!--   {'class': 'SqlSelectColumn',                      -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-            <!-- col64 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+            <!-- col64 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
             <!-- col65 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
             <!-- col66 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
             <!-- col67 =                                                 -->
             <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
             <!-- col68 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
             <!-- col69 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -731,25 +731,25 @@
             <!--   {'class': 'SqlSelectColumn',                              -->
             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-            <!-- col76 =                                                     -->
-            <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+            <!-- col76 =                                               -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+            <!--    'column_alias': 'booking__paid_at__day'}           -->
             <!-- col77 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
             <!--    'column_alias': 'booking__paid_at__week'}          -->
             <!-- col78 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
             <!--    'column_alias': 'booking__paid_at__month'}         -->
             <!-- col79 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
             <!-- col80 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
-            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
             <!--    'column_alias': 'booking__paid_at__year'}          -->
             <!-- col81 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -559,25 +559,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -607,25 +607,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -655,25 +655,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -707,25 +707,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -755,25 +755,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -803,25 +803,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -1372,25 +1372,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),  -->
                             <!--    'column_alias': 'is_instant'}                            -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                            <!--    'column_alias': 'ds__day'}                               -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds__day'}                         -->
                             <!-- col16 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
                             <!--    'column_alias': 'ds__week'}                        -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
                             <!--    'column_alias': 'ds__month'}                       -->
                             <!-- col18 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
                             <!--    'column_alias': 'ds__quarter'}                     -->
                             <!-- col19 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col20 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1420,25 +1420,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10020),  -->
                             <!--    'column_alias': 'ds__extract_doy'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
-                            <!--    'column_alias': 'ds_partitioned__day'}                   -->
+                            <!-- col27 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'ds_partitioned__day'}             -->
                             <!-- col28 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}            -->
                             <!-- col29 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}           -->
                             <!-- col30 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}         -->
                             <!-- col31 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col32 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1468,25 +1468,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10027),  -->
                             <!--    'column_alias': 'ds_partitioned__extract_doy'}   -->
-                            <!-- col39 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10023),  -->
-                            <!--    'column_alias': 'paid_at__day'}                          -->
+                            <!-- col39 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'column_alias': 'paid_at__day'}                    -->
                             <!-- col40 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
                             <!--    'column_alias': 'paid_at__week'}                   -->
                             <!-- col41 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
                             <!--    'column_alias': 'paid_at__month'}                  -->
                             <!-- col42 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
                             <!--    'column_alias': 'paid_at__quarter'}                -->
                             <!-- col43 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
                             <!--    'column_alias': 'paid_at__year'}                   -->
                             <!-- col44 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1520,25 +1520,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10024),  -->
                             <!--    'column_alias': 'booking__is_instant'}                   -->
-                            <!-- col52 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10025),  -->
-                            <!--    'column_alias': 'booking__ds__day'}                      -->
+                            <!-- col52 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'column_alias': 'booking__ds__day'}                -->
                             <!-- col53 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),  -->
                             <!--    'column_alias': 'booking__ds__week'}               -->
                             <!-- col54 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
                             <!--    'column_alias': 'booking__ds__month'}              -->
                             <!-- col55 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
                             <!--    'column_alias': 'booking__ds__quarter'}            -->
                             <!-- col56 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
                             <!--    'column_alias': 'booking__ds__year'}               -->
                             <!-- col57 =                                             -->
                             <!--   {'class': 'SqlSelectColumn',                      -->
@@ -1568,25 +1568,25 @@
                             <!--   {'class': 'SqlSelectColumn',                      -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10041),  -->
                             <!--    'column_alias': 'booking__ds__extract_doy'}      -->
-                            <!-- col64 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                            <!--    'column_alias': 'booking__ds_partitioned__day'}          -->
+                            <!-- col64 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'column_alias': 'booking__ds_partitioned__day'}    -->
                             <!-- col65 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__week'}   -->
                             <!-- col66 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__month'}  -->
                             <!-- col67 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),    -->
                             <!--    'column_alias': 'booking__ds_partitioned__quarter'}  -->
                             <!-- col68 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
                             <!--    'column_alias': 'booking__ds_partitioned__year'}   -->
                             <!-- col69 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
@@ -1616,25 +1616,25 @@
                             <!--   {'class': 'SqlSelectColumn',                              -->
                             <!--    'expr': SqlExtractExpression(node_id=ex_10048),          -->
                             <!--    'column_alias': 'booking__ds_partitioned__extract_doy'}  -->
-                            <!-- col76 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
-                            <!--    'column_alias': 'booking__paid_at__day'}                 -->
+                            <!-- col76 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                            <!--    'column_alias': 'booking__paid_at__day'}           -->
                             <!-- col77 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
                             <!--    'column_alias': 'booking__paid_at__week'}          -->
                             <!-- col78 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
                             <!--    'column_alias': 'booking__paid_at__month'}         -->
                             <!-- col79 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
                             <!--    'column_alias': 'booking__paid_at__quarter'}       -->
                             <!-- col80 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
                             <!--    'column_alias': 'booking__paid_at__year'}          -->
                             <!-- col81 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuery/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuery/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC(ds, day) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuery/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuery/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC(ds, day) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Databricks/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Databricks/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Databricks/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Databricks/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDB/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDB/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDB/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDB/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Postgres/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Postgres/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Postgres/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Postgres/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Redshift/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Redshift/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Redshift/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Redshift/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Snowflake/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Snowflake/test_render_query__query0.sql
@@ -9,7 +9,7 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'metric_time__day']
   SELECT
-    ds AS metric_time__day
+    DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_1
 ) subq_2

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Snowflake/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/Snowflake/test_render_write_to_table_query__query0.sql
@@ -10,7 +10,7 @@ CREATE TABLE ***************************.test_table AS (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
     SELECT
-      ds AS metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_1
   ) subq_2


### PR DESCRIPTION
MetricFlow's initial time dimension select statement rendering
was built on the assumption that the granularity configred for a given
time dimension would always match the granularity of the values stored.
For example, if a time dimension was defined with granularity DAY, we
assumed that the values in the warehouse would always correspond to
daily granularity data, and would never be offset from a day boundary.

This assumption is flawed for a variety of reasons - yearly or quarterly
granularities might use different offset boundaries, users may
misconfigure dimensions or allow offset values into the dataset which
could be safely corrected, etc.

This change updates our rendering to apply the date_trunc operation on
the base time dimension column, just as we do for the other, coarser
granularities. The one exception is for the base granularity column
for validity window time dimensions, which must retain their underlying
granularity in order to remain viable as validity window boundaries
for any DAILY granularity contexts, as we do not support smaller than
daily granularities at this time.

Note this may cause queries with start and end time constraints to
no longer trigger partition pruning, an issue which will be addressed
in subsequent updates.