### PR TITLE
Surface underlying error message in where parameter

### DIFF
--- a/.changes/unreleased/Under the Hood-20231006-095540.yaml
+++ b/.changes/unreleased/Under the Hood-20231006-095540.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Expose underlying where clause error message
+time: 2023-10-06T09:55:40.737735-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -384,7 +384,9 @@ class MetricFlowQueryParser:
                     column_association_resolver=self._column_association_resolver,
                 ).create_from_where_filter(where_filter)
             except ParseWhereFilterException as e:
-                raise InvalidQueryException(f"Error parsing the where filter: {where_filter.where_sql_template}") from e
+                raise InvalidQueryException(
+                    f"Error parsing the where filter: {where_filter.where_sql_template}. {e}"
+                ) from e
 
             where_spec_set = QueryTimeLinkableSpecSet.create_from_linkable_spec_set(where_filter_spec.linkable_spec_set)
             requested_linkable_specs_with_requested_filter_specs = QueryTimeLinkableSpecSet.combine(


### PR DESCRIPTION
### Description

This surfaces the underlying error message from the where clause. This is helpful in situations like this https://dbt-labs.slack.com/archives/C03KHQRQUBX/p1696602586211399

