### PR TITLE
Bug fix: source node evaluation

### DIFF
--- a/.changes/unreleased/Fixes-20231009-195312.yaml
+++ b/.changes/unreleased/Fixes-20231009-195312.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Prioritize source nodes based on correct cost
+time: 2023-10-09T19:53:12.491719-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "801"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -553,6 +553,7 @@ class DataflowPlanBuilder:
             # this is going to be the lowest cost solution.
             if len(evaluation.join_recipes) == 0:
                 logger.info("Not evaluating other nodes since we found one that doesn't require joins")
+                break
 
         logger.info(f"Found {len(node_to_evaluation)} candidate measure nodes.")
 


### PR DESCRIPTION
### Description
Fixes a bug in how we determine which source node to use. Previously, we were choosing a plan based on source node cost. Source nodes can only be `ReadSqlSourceNode` or `MetricTimeDimensionTransformNode`, so they all have `DefaultCost(num_joins=0, num_aggregations=0)`. That means we were just arbitrarily choosing a source node that could satisfy the query. Here, the logic changes to use the number of joins in each node's `LinkableInstanceSatisfiabilityEvaluation`, so we choose the dataflow plan with the lowest number of joins.
Note that this fixes a bug that came up in the process of enabling querying dimensions without metrics.

Also: we have a log that says `Not evaluating other nodes since we found one that doesn't require joins`, but we don't stop evaluating nodes at that point. I added a break to the loop to fix that, too.
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
