### PR TITLE
Case insensitivity for query params

### DIFF
--- a/.changes/unreleased/Fixes-20231010-144137.yaml
+++ b/.changes/unreleased/Fixes-20231010-144137.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Enables case insensitivity for various query params.
+time: 2023-10-10T14:41:37.181704-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "802"

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -681,7 +681,7 @@ class MetricFlowQueryParser:
             structured_names = [StructuredLinkableSpecName.from_name(name) for name in group_by_names]
         elif group_by:
             for group_by_obj in group_by:
-                parsed_name = StructuredLinkableSpecName.from_name(group_by_obj.name)
+                parsed_name = StructuredLinkableSpecName.from_name(group_by_obj.name.lower())
                 structured_name = StructuredLinkableSpecName(
                     entity_link_names=parsed_name.entity_link_names,
                     element_name=parsed_name.element_name,
@@ -832,6 +832,7 @@ class MetricFlowQueryParser:
             time_granularity: Optional[TimeGranularity] = None
             date_part: Optional[DatePart] = None
             if isinstance(order, str):
+                order = order.lower()
                 # Note: date part cannot be requested via string parameter.
                 descending = False
                 if order.startswith("-"):
@@ -841,7 +842,7 @@ class MetricFlowQueryParser:
                 time_granularity = parsed_name.time_granularity
             else:
                 descending = order.descending
-                parsed_name = StructuredLinkableSpecName.from_name(order.order_by.name)
+                parsed_name = StructuredLinkableSpecName.from_name(order.order_by.name.lower())
                 if isinstance(order.order_by, TimeDimensionQueryParameter):
                     time_granularity = order.order_by.grain
                     date_part = order.order_by.date_part

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -190,6 +190,66 @@ def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # 
     )
 
 
+def test_query_parser_case_insensitivity(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+    # String params
+    query_spec = bookings_query_parser.parse_and_validate_query(
+        metric_names=["BOOKINGS"],
+        group_by_names=["BOOKING__IS_INSTANT", "LISTING", MTD.upper()],
+        order_by_names=[MTD.upper(), "-BOOKINGS"],
+    )
+
+    assert query_spec.metric_specs == (MetricSpec(element_name="bookings"),)
+    assert query_spec.dimension_specs == (
+        DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),
+    )
+    assert query_spec.time_dimension_specs == (
+        TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
+    )
+    assert query_spec.entity_specs == (EntitySpec(element_name="listing", entity_links=()),)
+    assert query_spec.order_by_specs == (
+        OrderBySpec(
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
+            descending=False,
+        ),
+        OrderBySpec(
+            instance_spec=MetricSpec(element_name="bookings"),
+            descending=True,
+        ),
+    )
+
+    # Object params
+    Metric = namedtuple("Metric", ["name", "descending"])
+    metric = Metric("BOOKINGS", False)
+    group_by = (
+        DimensionOrEntityParameter("BOOKING__IS_INSTANT"),
+        DimensionOrEntityParameter("LISTING"),
+        TimeDimensionParameter(MTD.upper()),
+    )
+    order_by = (
+        OrderByParameter(order_by=TimeDimensionParameter(MTD.upper())),
+        OrderByParameter(order_by=MetricParameter("BOOKINGS"), descending=True),
+    )
+    query_spec = bookings_query_parser.parse_and_validate_query(metrics=[metric], group_by=group_by, order_by=order_by)
+    assert query_spec.metric_specs == (MetricSpec(element_name="bookings"),)
+    assert query_spec.dimension_specs == (
+        DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),
+    )
+    assert query_spec.time_dimension_specs == (
+        TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
+    )
+    assert query_spec.entity_specs == (EntitySpec(element_name="listing", entity_links=()),)
+    assert query_spec.order_by_specs == (
+        OrderBySpec(
+            instance_spec=TimeDimensionSpec(element_name=MTD, entity_links=(), time_granularity=TimeGranularity.DAY),
+            descending=False,
+        ),
+        OrderBySpec(
+            instance_spec=MetricSpec(element_name="bookings"),
+            descending=True,
+        ),
+    )
+
+
 def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
     Metric = namedtuple("Metric", ["name", "descending"])
     metric = Metric("bookings", False)


### PR DESCRIPTION
### Description
Support case-insensitive params in `group_by` and `order_by` parameters.
A [community member recently ran into a bug](https://getdbt.slack.com/archives/C046L0VTVR6/p1696602554947709) where they uppercased a dimension in the `group_by`, which worked, but then the same syntax didn't work in the `order_by`. This should fix that issue.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
