### PR TITLE
Support dundered granularity syntax with object params

### DIFF
--- a/.changes/unreleased/Features-20231010-172053.yaml
+++ b/.changes/unreleased/Features-20231010-172053.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable dundered granularity in object parameters.
+time: 2023-10-10T17:20:53.123738-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "803"

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -518,7 +518,7 @@ class MetricFlowQueryParser:
                 or order_by_spec.instance_spec in linkable_specs.time_dimension_specs
                 or order_by_spec.instance_spec in linkable_specs.entity_specs
             ):
-                raise InvalidQueryException(f"Order by item {order_by_spec} not in the query")
+                raise InvalidQueryException(f"Order by item {order_by_spec.instance_spec} not in the query")
 
     def _validate_date_part(
         self, metric_references: Sequence[MetricReference], time_dimension_specs: Sequence[TimeDimensionSpec]
@@ -686,8 +686,8 @@ class MetricFlowQueryParser:
                     entity_link_names=parsed_name.entity_link_names,
                     element_name=parsed_name.element_name,
                     time_granularity=group_by_obj.grain
-                    if isinstance(group_by_obj, TimeDimensionQueryParameter)
-                    else None,
+                    if isinstance(group_by_obj, TimeDimensionQueryParameter) and group_by_obj.grain
+                    else parsed_name.time_granularity,
                     date_part=group_by_obj.date_part if isinstance(group_by_obj, TimeDimensionQueryParameter) else None,
                 )
                 structured_names.append(structured_name)
@@ -844,10 +844,8 @@ class MetricFlowQueryParser:
                 descending = order.descending
                 parsed_name = StructuredLinkableSpecName.from_name(order.order_by.name.lower())
                 if isinstance(order.order_by, TimeDimensionQueryParameter):
-                    time_granularity = order.order_by.grain
+                    time_granularity = order.order_by.grain or parsed_name.time_granularity
                     date_part = order.order_by.date_part
-                if parsed_name.time_granularity and parsed_name.time_granularity != time_granularity:
-                    raise InvalidQueryException("Must use object syntax to request a time granularity.")
 
             if MetricReference(element_name=parsed_name.element_name) in self._known_metric_names:
                 if time_granularity:

--- a/metricflow/specs/query_param_implementations.py
+++ b/metricflow/specs/query_param_implementations.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
-from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.protocols.query_parameter import InputOrderByParameter
 from metricflow.time.date_part import DatePart
 
@@ -17,11 +16,6 @@ class TimeDimensionParameter:
     name: str
     grain: Optional[TimeGranularity] = None
     date_part: Optional[DatePart] = None
-
-    def __post_init__(self) -> None:  # noqa: D
-        parsed_name = StructuredLinkableSpecName.from_name(self.name)
-        if parsed_name.time_granularity:
-            raise ValueError("Must use object syntax for `grain` parameter if `date_part` is requested.")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Description
Allow users to pass dundered granularity syntax even in object parameters. Originally, I intentionally disallowed this. But it creates a weird inconsistency across parameters that users were running into, so it seems better to allow it.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
