### PR TITLE
Remove error for date part with non-metric time dimension

### DIFF
--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -813,7 +813,7 @@ class MetricFlowQueryParser:
         for time_dimension_spec in time_dimension_specs:
             time_dimension_spec_without_date_part = time_dimension_spec
             if time_dimension_spec.date_part:
-                # TODO: remove line below & add date_part specs to validation paths.
+                # TODO: remove this workaround & add date_part specs to validation paths.
                 time_dimension_spec_without_date_part = TimeDimensionSpec(
                     element_name=time_dimension_spec.element_name,
                     entity_links=time_dimension_spec.entity_links,

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -811,13 +811,20 @@ class MetricFlowQueryParser:
                 invalid_linkable_specs.append(entity_spec)
 
         for time_dimension_spec in time_dimension_specs:
+            time_dimension_spec_without_date_part = time_dimension_spec
+            if time_dimension_spec.date_part:
+                # TODO: remove line below & add date_part specs to validation paths.
+                time_dimension_spec_without_date_part = TimeDimensionSpec(
+                    element_name=time_dimension_spec.element_name,
+                    entity_links=time_dimension_spec.entity_links,
+                    time_granularity=time_dimension_spec.time_granularity,
+                    aggregation_state=time_dimension_spec.aggregation_state,
+                )
             if (
-                time_dimension_spec not in valid_linkable_specs
+                time_dimension_spec_without_date_part not in valid_linkable_specs
                 # Because the metric time dimension is a virtual dimension that's not in the model, it won't be included
                 # in valid_linkable_specs.
                 and time_dimension_spec.reference != DataSet.metric_time_dimension_reference()
-                # TODO: remove line below & add date_part specs to validation paths.
-                and not time_dimension_spec.date_part
             ):
                 invalid_linkable_specs.append(time_dimension_spec)
 

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -816,6 +816,8 @@ class MetricFlowQueryParser:
                 # Because the metric time dimension is a virtual dimension that's not in the model, it won't be included
                 # in valid_linkable_specs.
                 and time_dimension_spec.reference != DataSet.metric_time_dimension_reference()
+                # TODO: remove line below & add date_part specs to validation paths.
+                and not time_dimension_spec.date_part
             ):
                 invalid_linkable_specs.append(time_dimension_spec)
 

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1058,6 +1058,19 @@ integration_test:
     GROUP BY {{ render_extract("ds", DatePart.YEAR) }};
 ---
 integration_test:
+  name: simple_query_with_date_part_not_metric_time
+  description: Test query using date_part
+  model: SIMPLE_MODEL
+  metrics: ["bookings"]
+  group_by_objs: [{"name": "booking__ds", "date_part": "year"}]
+  check_query: |
+    SELECT
+      SUM(1) AS bookings
+      , {{ render_extract("ds", DatePart.YEAR) }} AS booking__ds__extract_year
+    FROM {{ source_schema }}.fct_bookings
+    GROUP BY {{ render_extract("ds", DatePart.YEAR) }};
+---
+integration_test:
   name: simple_query_with_multiple_date_parts
   description: Test query using multiple date_parts
   model: SIMPLE_MODEL


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Found a bug where date part queries error for any time dimension that isn't `metric_time`. This wasn't caught because all of our tests used `metric_time` (in both MF and MFS) - lesson learned! This creates an instant bug if you try to use any time dimension besides `metric_time` in our Tableau integration.
This is not the ideal fix. Ideally we'll need to put `date_part` in the validation path the way that `time_granularity` is, but we don't have time to do that before the fix needs to ship.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
