### PR TITLE
Update minimum typing-extensions version to 4.4

### DIFF
--- a/.changes/unreleased/Dependencies-20231026-151457.yaml
+++ b/.changes/unreleased/Dependencies-20231026-151457.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update typing-extensions minimum version to 4.4
+time: 2023-10-26T15:14:57.44532-07:00
+custom:
+  Author: tlento
+  PR: "823"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "ruamel.yaml~=0.17.21",
   "rudder-sdk-python~=1.0.3",
   "tabulate>=0.8.9",
-  "typing_extensions>=4.0.0",
+  "typing_extensions~=4.4.0",
   "update-checker~=0.18.0",
 ]
 


### PR DESCRIPTION
The `@override` decorator was added to typing-extensions with version
4.4, but our minimum version is 4.0, which means there are scenarios
where this will suddenly start throwing errors.

Since we require 4.4, let's make that true in the build directive.
