### PR TITLE
Update sql-engine-test workflow to remove label on completion.

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   snowflake-tests:
     environment: DW_INTEGRATION_TESTS
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Run Tests With Other SQL Engines' }}
     name: Snowflake Tests
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
   redshift-tests:
     environment: DW_INTEGRATION_TESTS
     name: Redshift Tests
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Run Tests With Other SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
@@ -56,7 +56,7 @@ jobs:
   bigquery-tests:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery Tests
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Run Tests With Other SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
@@ -75,7 +75,7 @@ jobs:
   databricks-tests:
     environment: DW_INTEGRATION_TESTS
     name: Databricks Tests
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Run Tests With Other SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
@@ -90,3 +90,14 @@ jobs:
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "test-databricks"
+
+  remove-label:
+    name: Remove Label After Running Tests
+    runs-on: ubuntu-latest
+    needs: [ snowflake-tests, redshift-tests, bigquery-tests, databricks-tests ]
+    if: github.event.action == 'labeled' && github.event.label.name == 'Run Tests With Other SQL Engines'
+    steps:
+      - name: Remove Label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'Run Tests With Other SQL Engines'


### PR DESCRIPTION
### Description

Currently, when iterating on a PR, the PR author would need to remove and then re-add the label to rerun the SQL-engine tests. This PR updates the Github Action workflow to remove the label for running the SQL engine tests after the tests are complete. 

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
