### PR TITLE
Mark Tests That Generate SQL-Engine-Specific Snapshots

### DIFF
--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -155,6 +155,7 @@ def test_list_entities(capsys: pytest.CaptureFixture, cli_runner: MetricFlowCliR
     assert "host" in resp.output
 
 
+@pytest.mark.sql_engine_snapshot
 def test_saved_query(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
@@ -179,6 +180,7 @@ def test_saved_query(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_saved_query_with_where(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
@@ -211,6 +213,7 @@ def test_saved_query_with_where(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_saved_query_with_limit(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -28,6 +28,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MO
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.sql_engine_snapshot
 def test_simple_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -60,6 +61,7 @@ def test_simple_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_primary_entity_dimension(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -92,6 +94,7 @@ def test_primary_entity_dimension(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_joined_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -129,6 +132,7 @@ def test_joined_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_order_by_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -166,6 +170,7 @@ def test_order_by_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_limit_rows_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -194,6 +199,7 @@ def test_limit_rows_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multiple_metrics_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -227,6 +233,7 @@ def test_multiple_metrics_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_single_semantic_model_ratio_metrics_plan(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -260,6 +267,7 @@ def test_single_semantic_model_ratio_metrics_plan(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multi_semantic_model_ratio_metrics_plan(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -293,6 +301,7 @@ def test_multi_semantic_model_ratio_metrics_plan(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multihop_join_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -328,6 +337,7 @@ def test_multihop_join_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_where_constrained_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -370,6 +380,7 @@ def test_where_constrained_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_where_constrained_plan_time_dimension(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -412,6 +423,7 @@ def test_where_constrained_plan_time_dimension(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_where_constrained_with_common_linkable_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -454,6 +466,7 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multihop_join_plan_ambiguous_dim(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -476,6 +489,7 @@ def test_multihop_join_plan_ambiguous_dim(  # noqa: D
         )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_window(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -504,6 +518,7 @@ def test_cumulative_metric_with_window(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -531,6 +546,7 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -558,6 +574,7 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_distinct_values_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -605,6 +622,7 @@ def test_distinct_values_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_distinct_values_plan_with_join(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -653,6 +671,7 @@ def test_distinct_values_plan_with_join(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_constraint_plan(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -681,6 +700,7 @@ def test_measure_constraint_plan(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_reused_measure_plan(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -709,6 +729,7 @@ def test_measure_constraint_with_reused_measure_plan(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_common_semantic_model(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -739,6 +760,7 @@ def test_common_semantic_model(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_window(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -766,6 +788,7 @@ def test_derived_metric_offset_window(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_to_grain(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -793,6 +816,7 @@ def test_derived_metric_offset_to_grain(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_with_granularity(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -819,6 +843,7 @@ def test_derived_metric_offset_with_granularity(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_offset_cumulative_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 
 from metricflow.dag.id_generation import OPTIMIZED_DATAFLOW_PLAN_PREFIX, IdGeneratorRegistry
@@ -28,6 +29,7 @@ def make_dataflow_plan(node: BaseOutput) -> DataflowPlan:  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_read_sql_source_combination(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -56,6 +58,7 @@ def test_read_sql_source_combination(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_filter_combination(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
@@ -150,6 +151,7 @@ def check_optimization(  # noqa: D
     assert source_counter.count_source_nodes(optimized_dataflow_plan) == expected_num_sources_in_optimized
 
 
+@pytest.mark.sql_engine_snapshot
 def test_2_metrics_from_1_semantic_model(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -175,6 +177,7 @@ def test_2_metrics_from_1_semantic_model(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_2_metrics_from_2_semantic_models(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -194,6 +197,7 @@ def test_2_metrics_from_2_semantic_models(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_3_metrics_from_2_semantic_models(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -217,6 +221,7 @@ def test_3_metrics_from_2_semantic_models(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_constrained_metric_not_combined(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -252,6 +257,7 @@ def test_constrained_metric_not_combined(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -274,6 +280,7 @@ def test_derived_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -297,6 +304,7 @@ def test_nested_derived_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_non_derived_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -328,6 +336,7 @@ def test_derived_metric_with_non_derived_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/dataset/test_convert_semantic_model.py
+++ b/metricflow/test/dataset/test_convert_semantic_model.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.references import SemanticModelReference
 
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.snapshot_utils import assert_spec_set_snapshot_equal
@@ -15,6 +15,7 @@ from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.sql_engine_snapshot
 def test_convert_table_semantic_model_without_measures(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -40,6 +41,7 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_convert_table_semantic_model_with_measures(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -72,11 +74,11 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_convert_query_semantic_model(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
     sql_client: SqlClient,
-    default_sql_plan_renderer: SqlQueryPlanRenderer,
     consistent_id_object_repository: ConsistentIdObjectRepository,
 ) -> None:
     bookings_data_set = consistent_id_object_repository.simple_model_data_sets["revenue"]

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -68,6 +68,18 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     )
 
 
+# Name of the pytest marker for tests that generate SQL-engine specific snapshots.
+SQL_ENGINE_SNAPSHOT_MARKER_NAME = "sql_engine_snapshot"
+
+
+def pytest_configure(config: _pytest.config.Config) -> None:
+    """Hook as specified by the pytest API for configuration."""
+    config.addinivalue_line(
+        name="markers",
+        line=f"{SQL_ENGINE_SNAPSHOT_MARKER_NAME}: mark tests as generating a snapshot specific to a SQL engine",
+    )
+
+
 @pytest.fixture(scope="session")
 def mf_test_session_state(  # noqa: D
     request: FixtureRequest,

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -80,6 +80,16 @@ def pytest_configure(config: _pytest.config.Config) -> None:
     )
 
 
+def check_sql_engine_snapshot_marker(request: FixtureRequest) -> None:
+    """Raises an error if the given test request does not have the sql-engine-test marker set."""
+    mark_names = set(mark.name for mark in request.node.iter_markers(name=SQL_ENGINE_SNAPSHOT_MARKER_NAME))
+    if SQL_ENGINE_SNAPSHOT_MARKER_NAME not in mark_names:
+        raise ValueError(
+            f"This test needs to be marked with '{SQL_ENGINE_SNAPSHOT_MARKER_NAME}' to keep track of all tests that "
+            f"generate SQL-engine specific snapshots."
+        )
+
+
 @pytest.fixture(scope="session")
 def mf_test_session_state(  # noqa: D
     request: FixtureRequest,

--- a/metricflow/test/integration/test_rendered_query.py
+++ b/metricflow/test/integration/test_rendered_query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 
 from metricflow.dataflow.sql_table import SqlTable
@@ -12,6 +13,7 @@ from metricflow.test.snapshot_utils import assert_snapshot_text_equal, make_sche
 _EXCLUDE_TABLE_ALIAS_REGEX = "^.*_src.*$"
 
 
+@pytest.mark.sql_engine_snapshot
 def test_render_query(  # noqa: D
     request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, it_helpers: IntegrationTestHelpers
 ) -> None:
@@ -37,6 +39,7 @@ def test_render_query(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_render_write_to_table_query(  # noqa: D
     request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, it_helpers: IntegrationTestHelpers
 ) -> None:

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -204,6 +204,7 @@ def test_validate_measures(  # noqa: D
     assert len(issues.all_issues) == 2
 
 
+@pytest.mark.sql_engine_snapshot
 def test_build_metric_tasks(  # noqa: D
     request: FixtureRequest,
     data_warehouse_validation_model: PydanticSemanticManifest,

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.references import TimeDimensionReference
 
@@ -14,6 +15,7 @@ from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_an
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 
 
+@pytest.mark.sql_engine_snapshot
 def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -35,6 +37,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -57,6 +60,7 @@ def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_simple_query_with_metric_time_dimension(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from _pytest.fixtures import FixtureRequest
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
@@ -34,6 +35,7 @@ def make_execution_plan_converter(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_joined_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -72,6 +74,7 @@ def test_joined_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_small_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -108,6 +111,7 @@ def test_small_combined_metrics_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -146,6 +150,7 @@ def test_combined_metrics_plan(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multihop_joined_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -136,6 +136,7 @@ def convert_and_check(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_source_node(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -155,6 +156,7 @@ def test_source_node(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_filter_node(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -180,6 +182,7 @@ def test_filter_node(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_filter_with_where_constraint_node(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -221,6 +224,7 @@ def test_filter_with_where_constraint_node(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_aggregation_node(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -266,6 +270,7 @@ def test_measure_aggregation_node(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_single_join_node(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -321,6 +326,7 @@ def test_single_join_node(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multi_join_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -379,6 +385,7 @@ def test_multi_join_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -442,6 +449,7 @@ def test_compute_metrics_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_simple_expr(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -517,6 +525,7 @@ def test_compute_metrics_node_simple_expr(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_without_offset(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -580,6 +589,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -644,6 +654,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_with_offset_to_grain(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -709,6 +720,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_ratio_from_single_semantic_model(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -774,6 +786,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_ratio_from_multiple_semantic_models(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -813,6 +826,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_order_by_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -876,6 +890,7 @@ def test_order_by_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multihop_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -908,6 +923,7 @@ def test_multihop_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_filter_with_where_constraint_on_join_dim(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -948,6 +964,7 @@ def test_filter_with_where_constraint_on_join_dim(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_constrain_time_range_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -992,6 +1009,7 @@ def test_constrain_time_range_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1024,6 +1042,7 @@ def test_cumulative_metric(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_time_constraint(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1059,6 +1078,7 @@ def test_cumulative_metric_with_time_constraint(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_ds(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1085,6 +1105,7 @@ def test_cumulative_metric_no_ds(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1117,6 +1138,7 @@ def test_cumulative_metric_no_window(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_with_time_constraint(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1152,6 +1174,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_grain_to_date(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1184,6 +1207,7 @@ def test_cumulative_metric_grain_to_date(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_partitioned_join(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1214,6 +1238,7 @@ def test_partitioned_join(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_limit_rows(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1244,6 +1269,7 @@ def test_limit_rows(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_distinct_values(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1288,6 +1314,7 @@ def test_distinct_values(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_local_dimension_using_local_entity(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1316,6 +1343,7 @@ def test_local_dimension_using_local_entity(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1344,6 +1372,7 @@ def test_semi_additive_join_node(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node_with_queried_group_by(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1375,6 +1404,7 @@ def test_semi_additive_join_node_with_queried_group_by(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node_with_grouping(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1407,6 +1437,7 @@ def test_semi_additive_join_node_with_grouping(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_constraint(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1430,6 +1461,7 @@ def test_measure_constraint(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_reused_measure(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1453,6 +1485,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1476,6 +1509,7 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1499,6 +1533,7 @@ def test_derived_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1522,6 +1557,7 @@ def test_nested_derived_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_join_to_scd_dimension(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1560,6 +1596,7 @@ def test_join_to_scd_dimension(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multi_hop_through_scd_dimension(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1585,6 +1622,7 @@ def test_multi_hop_through_scd_dimension(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multi_hop_to_scd_dimension(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1610,6 +1648,7 @@ def test_multi_hop_to_scd_dimension(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_multiple_metrics_no_dimensions(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1635,6 +1674,7 @@ def test_multiple_metrics_no_dimensions(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1657,6 +1697,7 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_common_semantic_model(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1680,6 +1721,7 @@ def test_common_semantic_model(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1703,6 +1745,7 @@ def test_derived_metric_with_offset_window(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_to_grain(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1726,6 +1769,7 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1749,6 +1793,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_offset_metric_with_one_input_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1772,6 +1817,7 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1795,6 +1841,7 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1818,6 +1865,7 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1841,6 +1889,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_derived_offset_cumulative_metric(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1864,6 +1913,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_simple_query_with_date_part(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1889,6 +1939,7 @@ def test_simple_query_with_date_part(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_simple_query_with_multiple_date_parts(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -1919,6 +1970,7 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_offset_window_with_date_part(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/snapshot_utils.py
+++ b/metricflow/test/snapshot_utils.py
@@ -19,7 +19,7 @@ from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementSet
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.specs import InstanceSpecSet
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState, check_sql_engine_snapshot_marker
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +261,9 @@ def assert_object_snapshot_equal(  # type: ignore[misc]
     sql_client: Optional[SqlClient] = None,
 ) -> None:
     """For tests to compare large objects, this can be used to snapshot a text representation of the object."""
+    if sql_client is not None:
+        check_sql_engine_snapshot_marker(request)
+
     assert_snapshot_text_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -6,7 +6,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.sql_plan import SqlQueryPlan, SqlQueryPlanNode, SqlSelectStatementNode
 from metricflow.sql.sql_plan_to_text import sql_query_plan_as_text
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState, check_sql_engine_snapshot_marker
 from metricflow.test.snapshot_utils import (
     assert_plan_snapshot_text_equal,
     make_schema_replacement_function,
@@ -58,6 +58,8 @@ def assert_rendered_sql_from_plan_equal(
     sql_client: SqlClient,
 ) -> None:
     """Similar to assert_rendered_sql_equal, but takes in a SQL query plan."""
+    check_sql_engine_snapshot_marker(request)
+
     rendered_sql = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_query_plan).sql
 
     assert_plan_snapshot_text_equal(

--- a/metricflow/test/sql/test_engine_specific_rendering.py
+++ b/metricflow/test/sql/test_engine_specific_rendering.py
@@ -28,6 +28,7 @@ from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 
 
+@pytest.mark.sql_engine_snapshot
 def test_cast_to_timestamp(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -70,6 +71,7 @@ def test_cast_to_timestamp(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_generate_uuid(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -103,6 +105,7 @@ def test_generate_uuid(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_continuous_percentile_expr(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -151,6 +154,7 @@ def test_continuous_percentile_expr(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_discrete_percentile_expr(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -199,6 +203,7 @@ def test_discrete_percentile_expr(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_approximate_continuous_percentile_expr(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -247,6 +252,7 @@ def test_approximate_continuous_percentile_expr(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_approximate_discrete_percentile_expr(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,

--- a/metricflow/test/sql/test_sql_plan_render.py
+++ b/metricflow/test/sql/test_sql_plan_render.py
@@ -8,7 +8,6 @@ from _pytest.fixtures import FixtureRequest
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from metricflow.sql.sql_exprs import (
     SqlAggregateFunctionExpression,
     SqlColumnReference,
@@ -32,11 +31,7 @@ from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def default_sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D
-    return DefaultSqlQueryPlanRenderer()
-
-
+@pytest.mark.sql_engine_snapshot
 def test_component_rendering(
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -223,6 +218,7 @@ def test_component_rendering(
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_render_where(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -263,6 +259,7 @@ def test_render_where(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_render_order_by(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -312,6 +309,7 @@ def test_render_order_by(  # noqa: D
     )
 
 
+@pytest.mark.sql_engine_snapshot
 def test_render_limit(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,


### PR DESCRIPTION
### Description

This PR adds a custom pytest marker to mark tests that generate SQL-engine-specific snapshots. This helps to ensures that the `generate_snapshots.py` script generates snapshots for all relevant tests.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
