### PR TITLE
Use FULL OUTER JOIN when combining derived metrics

### DIFF
--- a/.changes/unreleased/Breaking Changes-20231102-182815.yaml
+++ b/.changes/unreleased/Breaking Changes-20231102-182815.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Use FULL OUTER JOIN to combine input metrics for derived metrics. This is a change from using INNER JOIN and may result in changes in output.
+time: 2023-11-02T18:28:15.181064-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "841"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -248,7 +248,7 @@ class DataflowPlanBuilder:
                         queried_linkable_specs=queried_linkable_specs,
                         where_constraint=where_constraint,
                         time_range_constraint=time_range_constraint,
-                        combine_metrics_join_type=SqlJoinType.INNER,
+                        combine_metrics_join_type=SqlJoinType.FULL_OUTER,
                     ),
                     metric_specs=[metric_spec],
                 )

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -8,8 +8,8 @@ FROM (
   SELECT
     COALESCE(subq_9.ds__day, subq_19.ds__day) AS ds__day
     , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest) AS listing__country_latest
-    , subq_9.bookings AS bookings
-    , subq_19.views AS views
+    , MAX(subq_9.bookings) AS bookings
+    , MAX(subq_19.views) AS views
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -387,7 +387,7 @@ FROM (
         , subq_7.listing__country_latest
     ) subq_8
   ) subq_9
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.ds__day
@@ -689,20 +689,11 @@ FROM (
   ) subq_19
   ON
     (
-      (
-        subq_9.listing__country_latest = subq_19.listing__country_latest
-      ) OR (
-        (
-          subq_9.listing__country_latest IS NULL
-        ) AND (
-          subq_19.listing__country_latest IS NULL
-        )
-      )
+      subq_9.listing__country_latest = subq_19.listing__country_latest
     ) AND (
-      (
-        subq_9.ds__day = subq_19.ds__day
-      ) OR (
-        (subq_9.ds__day IS NULL) AND (subq_19.ds__day IS NULL)
-      )
+      subq_9.ds__day = subq_19.ds__day
     )
+  GROUP BY
+    COALESCE(subq_9.ds__day, subq_19.ds__day)
+    , COALESCE(subq_9.listing__country_latest, subq_19.listing__country_latest)
 ) subq_20

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -1,82 +1,80 @@
--- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_30.ds__day, subq_40.ds__day) AS ds__day
-  , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
-  , CAST(subq_30.bookings AS DOUBLE) / CAST(NULLIF(subq_40.views, 0) AS DOUBLE) AS bookings_per_view
+  ds__day
+  , listing__country_latest
+  , CAST(bookings AS DOUBLE) / CAST(NULLIF(views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements:
-  --   ['bookings', 'listing__country_latest', 'ds__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Combine Metrics
   SELECT
-    subq_23.ds__day AS ds__day
-    , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_23.bookings) AS bookings
+    COALESCE(subq_30.ds__day, subq_40.ds__day) AS ds__day
+    , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest) AS listing__country_latest
+    , MAX(subq_30.bookings) AS bookings
+    , MAX(subq_40.views) AS views
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Join Standard Outputs
     -- Pass Only Elements:
-    --   ['bookings', 'ds__day', 'listing']
+    --   ['bookings', 'listing__country_latest', 'ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS ds__day
-      , listing_id AS listing
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_23
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_10004
-  ON
-    subq_23.listing = listings_latest_src_10004.listing_id
-  GROUP BY
-    subq_23.ds__day
-    , listings_latest_src_10004.country
-) subq_30
-INNER JOIN (
-  -- Join Standard Outputs
-  -- Pass Only Elements:
-  --   ['views', 'listing__country_latest', 'ds__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    subq_33.ds__day AS ds__day
-    , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_33.views) AS views
-  FROM (
-    -- Read Elements From Semantic Model 'views_source'
-    -- Metric Time Dimension 'ds'
+      subq_23.ds__day AS ds__day
+      , listings_latest_src_10004.country AS listing__country_latest
+      , SUM(subq_23.bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'ds__day', 'listing']
+      SELECT
+        DATE_TRUNC('day', ds) AS ds__day
+        , listing_id AS listing
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_23
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_10004
+    ON
+      subq_23.listing = listings_latest_src_10004.listing_id
+    GROUP BY
+      subq_23.ds__day
+      , listings_latest_src_10004.country
+  ) subq_30
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
     -- Pass Only Elements:
-    --   ['views', 'ds__day', 'listing']
+    --   ['views', 'listing__country_latest', 'ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS ds__day
-      , listing_id AS listing
-      , 1 AS views
-    FROM ***************************.fct_views views_source_src_10009
-  ) subq_33
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_10004
+      subq_33.ds__day AS ds__day
+      , listings_latest_src_10004.country AS listing__country_latest
+      , SUM(subq_33.views) AS views
+    FROM (
+      -- Read Elements From Semantic Model 'views_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['views', 'ds__day', 'listing']
+      SELECT
+        DATE_TRUNC('day', ds) AS ds__day
+        , listing_id AS listing
+        , 1 AS views
+      FROM ***************************.fct_views views_source_src_10009
+    ) subq_33
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_10004
+    ON
+      subq_33.listing = listings_latest_src_10004.listing_id
+    GROUP BY
+      subq_33.ds__day
+      , listings_latest_src_10004.country
+  ) subq_40
   ON
-    subq_33.listing = listings_latest_src_10004.listing_id
-  GROUP BY
-    subq_33.ds__day
-    , listings_latest_src_10004.country
-) subq_40
-ON
-  (
     (
       subq_30.listing__country_latest = subq_40.listing__country_latest
-    ) OR (
-      (
-        subq_30.listing__country_latest IS NULL
-      ) AND (
-        subq_40.listing__country_latest IS NULL
-      )
-    )
-  ) AND (
-    (
+    ) AND (
       subq_30.ds__day = subq_40.ds__day
-    ) OR (
-      (subq_30.ds__day IS NULL) AND (subq_40.ds__day IS NULL)
     )
-  )
+  GROUP BY
+    COALESCE(subq_30.ds__day, subq_40.ds__day)
+    , COALESCE(subq_30.listing__country_latest, subq_40.listing__country_latest)
+) subq_41

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_7.metric_time__day, subq_15.metric_time__day) AS metric_time__day
-    , subq_7.bookings_fill_nulls_with_0 AS bookings_fill_nulls_with_0
-    , subq_15.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_7.bookings_fill_nulls_with_0) AS bookings_fill_nulls_with_0
+    , MAX(subq_15.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -238,7 +238,7 @@ FROM (
         subq_4.metric_time__day = subq_3.metric_time__day
     ) subq_6
   ) subq_7
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time__day
@@ -555,13 +555,7 @@ FROM (
     ) subq_14
   ) subq_15
   ON
-    (
-      subq_7.metric_time__day = subq_15.metric_time__day
-    ) OR (
-      (
-        subq_7.metric_time__day IS NULL
-      ) AND (
-        subq_15.metric_time__day IS NULL
-      )
-    )
+    subq_7.metric_time__day = subq_15.metric_time__day
+  GROUP BY
+    COALESCE(subq_7.metric_time__day, subq_15.metric_time__day)
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , subq_24.bookings_fill_nulls_with_0 AS bookings_fill_nulls_with_0
-    , subq_32.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_24.bookings_fill_nulls_with_0) AS bookings_fill_nulls_with_0
+    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -41,7 +41,7 @@ FROM (
         subq_22.ds = subq_20.metric_time__day
     ) subq_23
   ) subq_24
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
@@ -65,13 +65,7 @@ FROM (
       subq_28.ds
   ) subq_32
   ON
-    (
-      subq_24.metric_time__day = subq_32.metric_time__day
-    ) OR (
-      (
-        subq_24.metric_time__day IS NULL
-      ) AND (
-        subq_32.metric_time__day IS NULL
-      )
-    )
+    subq_24.metric_time__day = subq_32.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__day, subq_9.metric_time__day) AS metric_time__day
-    , subq_4.ref_bookings AS ref_bookings
-    , subq_9.bookings AS bookings
+    , MAX(subq_4.ref_bookings) AS ref_bookings
+    , MAX(subq_9.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__day
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_8.metric_time__day
@@ -441,13 +441,7 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    (
-      subq_4.metric_time__day = subq_9.metric_time__day
-    ) OR (
-      (
-        subq_4.metric_time__day IS NULL
-      ) AND (
-        subq_9.metric_time__day IS NULL
-      )
-    )
+    subq_4.metric_time__day = subq_9.metric_time__day
+  GROUP BY
+    COALESCE(subq_4.metric_time__day, subq_9.metric_time__day)
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , subq_15.ref_bookings AS ref_bookings
-    , subq_20.bookings AS bookings
+    , MAX(subq_15.ref_bookings) AS ref_bookings
+    , MAX(subq_20.bookings) AS bookings
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__day
   ) subq_15
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -47,13 +47,7 @@ FROM (
       metric_time__day
   ) subq_20
   ON
-    (
-      subq_15.metric_time__day = subq_20.metric_time__day
-    ) OR (
-      (
-        subq_15.metric_time__day IS NULL
-      ) AND (
-        subq_20.metric_time__day IS NULL
-      )
-    )
+    subq_15.metric_time__day = subq_20.metric_time__day
+  GROUP BY
+    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , subq_4.bookings AS bookings
-    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__day
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_11.metric_time__day
@@ -541,13 +541,7 @@ FROM (
     ) subq_11
   ) subq_12
   ON
-    (
-      subq_4.metric_time__day = subq_12.metric_time__day
-    ) OR (
-      (
-        subq_4.metric_time__day IS NULL
-      ) AND (
-        subq_12.metric_time__day IS NULL
-      )
-    )
+    subq_4.metric_time__day = subq_12.metric_time__day
+  GROUP BY
+    COALESCE(subq_4.metric_time__day, subq_12.metric_time__day)
 ) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , subq_18.bookings AS bookings
-    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__day
   ) subq_18
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
@@ -51,13 +51,7 @@ FROM (
       subq_22.ds
   ) subq_26
   ON
-    (
-      subq_18.metric_time__day = subq_26.metric_time__day
-    ) OR (
-      (
-        subq_18.metric_time__day IS NULL
-      ) AND (
-        subq_26.metric_time__day IS NULL
-      )
-    )
+    subq_18.metric_time__day = subq_26.metric_time__day
+  GROUP BY
+    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
 ) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__week, subq_12.metric_time__week) AS metric_time__week
-    , subq_4.bookings AS bookings
-    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__week
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_11.metric_time__week
@@ -542,13 +542,7 @@ FROM (
     ) subq_11
   ) subq_12
   ON
-    (
-      subq_4.metric_time__week = subq_12.metric_time__week
-    ) OR (
-      (
-        subq_4.metric_time__week IS NULL
-      ) AND (
-        subq_12.metric_time__week IS NULL
-      )
-    )
+    subq_4.metric_time__week = subq_12.metric_time__week
+  GROUP BY
+    COALESCE(subq_4.metric_time__week, subq_12.metric_time__week)
 ) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
-    , subq_18.bookings AS bookings
-    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__week
   ) subq_18
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__week']
@@ -52,13 +52,7 @@ FROM (
       DATE_TRUNC('week', subq_22.ds)
   ) subq_26
   ON
-    (
-      subq_18.metric_time__week = subq_26.metric_time__week
-    ) OR (
-      (
-        subq_18.metric_time__week IS NULL
-      ) AND (
-        subq_26.metric_time__week IS NULL
-      )
-    )
+    subq_18.metric_time__week = subq_26.metric_time__week
+  GROUP BY
+    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
 ) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , subq_4.bookings AS bookings
-    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__day
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_11.metric_time__day
@@ -541,13 +541,7 @@ FROM (
     ) subq_11
   ) subq_12
   ON
-    (
-      subq_4.metric_time__day = subq_12.metric_time__day
-    ) OR (
-      (
-        subq_4.metric_time__day IS NULL
-      ) AND (
-        subq_12.metric_time__day IS NULL
-      )
-    )
+    subq_4.metric_time__day = subq_12.metric_time__day
+  GROUP BY
+    COALESCE(subq_4.metric_time__day, subq_12.metric_time__day)
 ) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , subq_18.bookings AS bookings
-    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__day
   ) subq_18
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
@@ -51,13 +51,7 @@ FROM (
       subq_22.ds
   ) subq_26
   ON
-    (
-      subq_18.metric_time__day = subq_26.metric_time__day
-    ) OR (
-      (
-        subq_18.metric_time__day IS NULL
-      ) AND (
-        subq_26.metric_time__day IS NULL
-      )
-    )
+    subq_18.metric_time__day = subq_26.metric_time__day
+  GROUP BY
+    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
 ) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__quarter, subq_12.metric_time__quarter) AS metric_time__quarter
-    , subq_4.bookings AS bookings
-    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__quarter
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_11.metric_time__quarter
@@ -541,13 +541,7 @@ FROM (
     ) subq_11
   ) subq_12
   ON
-    (
-      subq_4.metric_time__quarter = subq_12.metric_time__quarter
-    ) OR (
-      (
-        subq_4.metric_time__quarter IS NULL
-      ) AND (
-        subq_12.metric_time__quarter IS NULL
-      )
-    )
+    subq_4.metric_time__quarter = subq_12.metric_time__quarter
+  GROUP BY
+    COALESCE(subq_4.metric_time__quarter, subq_12.metric_time__quarter)
 ) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
-    , subq_18.bookings AS bookings
-    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__quarter
   ) subq_18
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__quarter']
@@ -51,13 +51,7 @@ FROM (
       DATE_TRUNC('quarter', subq_22.ds)
   ) subq_26
   ON
-    (
-      subq_18.metric_time__quarter = subq_26.metric_time__quarter
-    ) OR (
-      (
-        subq_18.metric_time__quarter IS NULL
-      ) AND (
-        subq_26.metric_time__quarter IS NULL
-      )
-    )
+    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+  GROUP BY
+    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
 ) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_7.metric_time__day, subq_15.metric_time__day) AS metric_time__day
-    , subq_7.month_start_bookings AS month_start_bookings
-    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+    , MAX(subq_7.month_start_bookings) AS month_start_bookings
+    , MAX(subq_15.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -324,7 +324,7 @@ FROM (
         subq_5.metric_time__day
     ) subq_6
   ) subq_7
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time__day
@@ -641,13 +641,7 @@ FROM (
     ) subq_14
   ) subq_15
   ON
-    (
-      subq_7.metric_time__day = subq_15.metric_time__day
-    ) OR (
-      (
-        subq_7.metric_time__day IS NULL
-      ) AND (
-        subq_15.metric_time__day IS NULL
-      )
-    )
+    subq_7.metric_time__day = subq_15.metric_time__day
+  GROUP BY
+    COALESCE(subq_7.metric_time__day, subq_15.metric_time__day)
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , subq_24.month_start_bookings AS month_start_bookings
-    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+    , MAX(subq_24.month_start_bookings) AS month_start_bookings
+    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
@@ -31,7 +31,7 @@ FROM (
     GROUP BY
       subq_20.ds
   ) subq_24
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
@@ -55,13 +55,7 @@ FROM (
       subq_28.ds
   ) subq_32
   ON
-    (
-      subq_24.metric_time__day = subq_32.metric_time__day
-    ) OR (
-      (
-        subq_24.metric_time__day IS NULL
-      ) AND (
-        subq_32.metric_time__day IS NULL
-      )
-    )
+    subq_24.metric_time__day = subq_32.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_7.metric_time__year, subq_15.metric_time__year) AS metric_time__year
-    , subq_7.month_start_bookings AS month_start_bookings
-    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+    , MAX(subq_7.month_start_bookings) AS month_start_bookings
+    , MAX(subq_15.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -325,7 +325,7 @@ FROM (
         subq_5.metric_time__year
     ) subq_6
   ) subq_7
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time__year
@@ -642,13 +642,7 @@ FROM (
     ) subq_14
   ) subq_15
   ON
-    (
-      subq_7.metric_time__year = subq_15.metric_time__year
-    ) OR (
-      (
-        subq_7.metric_time__year IS NULL
-      ) AND (
-        subq_15.metric_time__year IS NULL
-      )
-    )
+    subq_7.metric_time__year = subq_15.metric_time__year
+  GROUP BY
+    COALESCE(subq_7.metric_time__year, subq_15.metric_time__year)
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
-    , subq_24.month_start_bookings AS month_start_bookings
-    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+    , MAX(subq_24.month_start_bookings) AS month_start_bookings
+    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
@@ -32,7 +32,7 @@ FROM (
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
   ) subq_24
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__year']
@@ -56,13 +56,7 @@ FROM (
       DATE_TRUNC('year', subq_28.ds)
   ) subq_32
   ON
-    (
-      subq_24.metric_time__year = subq_32.metric_time__year
-    ) OR (
-      (
-        subq_24.metric_time__year IS NULL
-      ) AND (
-        subq_32.metric_time__year IS NULL
-      )
-    )
+    subq_24.metric_time__year = subq_32.metric_time__year
+  GROUP BY
+    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0.sql
@@ -6,9 +6,9 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_11.metric_time__day, subq_16.metric_time__day, subq_21.metric_time__day) AS metric_time__day
-    , subq_11.non_referred AS non_referred
-    , subq_16.instant AS instant
-    , subq_21.bookings AS bookings
+    , MAX(subq_11.non_referred) AS non_referred
+    , MAX(subq_16.instant) AS instant
+    , MAX(subq_21.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -18,8 +18,8 @@ FROM (
       -- Combine Metrics
       SELECT
         COALESCE(subq_4.metric_time__day, subq_9.metric_time__day) AS metric_time__day
-        , subq_4.ref_bookings AS ref_bookings
-        , subq_9.bookings AS bookings
+        , MAX(subq_4.ref_bookings) AS ref_bookings
+        , MAX(subq_9.bookings) AS bookings
       FROM (
         -- Compute Metrics via Expressions
         SELECT
@@ -236,7 +236,7 @@ FROM (
             subq_2.metric_time__day
         ) subq_3
       ) subq_4
-      INNER JOIN (
+      FULL OUTER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_8.metric_time__day
@@ -453,18 +453,12 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        (
-          subq_4.metric_time__day = subq_9.metric_time__day
-        ) OR (
-          (
-            subq_4.metric_time__day IS NULL
-          ) AND (
-            subq_9.metric_time__day IS NULL
-          )
-        )
+        subq_4.metric_time__day = subq_9.metric_time__day
+      GROUP BY
+        COALESCE(subq_4.metric_time__day, subq_9.metric_time__day)
     ) subq_10
   ) subq_11
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_15.metric_time__day
@@ -681,16 +675,8 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    (
-      subq_11.metric_time__day = subq_16.metric_time__day
-    ) OR (
-      (
-        subq_11.metric_time__day IS NULL
-      ) AND (
-        subq_16.metric_time__day IS NULL
-      )
-    )
-  INNER JOIN (
+    subq_11.metric_time__day = subq_16.metric_time__day
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.metric_time__day
@@ -907,13 +893,7 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    (
-      subq_11.metric_time__day = subq_21.metric_time__day
-    ) OR (
-      (
-        subq_11.metric_time__day IS NULL
-      ) AND (
-        subq_21.metric_time__day IS NULL
-      )
-    )
+    COALESCE(subq_11.metric_time__day, subq_16.metric_time__day) = subq_21.metric_time__day
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_16.metric_time__day, subq_21.metric_time__day)
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
@@ -6,9 +6,9 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , subq_34.non_referred AS non_referred
-    , subq_39.instant AS instant
-    , subq_44.bookings AS bookings
+    , MAX(subq_34.non_referred) AS non_referred
+    , MAX(subq_39.instant) AS instant
+    , MAX(subq_44.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -18,8 +18,8 @@ FROM (
       -- Combine Metrics
       SELECT
         COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , subq_27.ref_bookings AS ref_bookings
-        , subq_32.bookings AS bookings
+        , MAX(subq_27.ref_bookings) AS ref_bookings
+        , MAX(subq_32.bookings) AS bookings
       FROM (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -39,7 +39,7 @@ FROM (
         GROUP BY
           metric_time__day
       ) subq_27
-      INNER JOIN (
+      FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -59,18 +59,12 @@ FROM (
           metric_time__day
       ) subq_32
       ON
-        (
-          subq_27.metric_time__day = subq_32.metric_time__day
-        ) OR (
-          (
-            subq_27.metric_time__day IS NULL
-          ) AND (
-            subq_32.metric_time__day IS NULL
-          )
-        )
+        subq_27.metric_time__day = subq_32.metric_time__day
+      GROUP BY
+        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
     ) subq_33
   ) subq_34
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -90,16 +84,8 @@ FROM (
       metric_time__day
   ) subq_39
   ON
-    (
-      subq_34.metric_time__day = subq_39.metric_time__day
-    ) OR (
-      (
-        subq_34.metric_time__day IS NULL
-      ) AND (
-        subq_39.metric_time__day IS NULL
-      )
-    )
-  INNER JOIN (
+    subq_34.metric_time__day = subq_39.metric_time__day
+  FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -119,13 +105,7 @@ FROM (
       metric_time__day
   ) subq_44
   ON
-    (
-      subq_34.metric_time__day = subq_44.metric_time__day
-    ) OR (
-      (
-        subq_34.metric_time__day IS NULL
-      ) AND (
-        subq_44.metric_time__day IS NULL
-      )
-    )
+    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+  GROUP BY
+    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_4.metric_time__extract_dow, subq_12.metric_time__extract_dow) AS metric_time__extract_dow
-    , subq_4.bookings AS bookings
-    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -224,7 +224,7 @@ FROM (
         subq_2.metric_time__extract_dow
     ) subq_3
   ) subq_4
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_11.metric_time__extract_dow
@@ -541,13 +541,7 @@ FROM (
     ) subq_11
   ) subq_12
   ON
-    (
-      subq_4.metric_time__extract_dow = subq_12.metric_time__extract_dow
-    ) OR (
-      (
-        subq_4.metric_time__extract_dow IS NULL
-      ) AND (
-        subq_12.metric_time__extract_dow IS NULL
-      )
-    )
+    subq_4.metric_time__extract_dow = subq_12.metric_time__extract_dow
+  GROUP BY
+    COALESCE(subq_4.metric_time__extract_dow, subq_12.metric_time__extract_dow)
 ) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
-    , subq_18.bookings AS bookings
-    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -27,7 +27,7 @@ FROM (
     GROUP BY
       metric_time__extract_dow
   ) subq_18
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__extract_dow']
@@ -51,13 +51,7 @@ FROM (
       EXTRACT(isodow FROM subq_22.ds)
   ) subq_26
   ON
-    (
-      subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
-    ) OR (
-      (
-        subq_18.metric_time__extract_dow IS NULL
-      ) AND (
-        subq_26.metric_time__extract_dow IS NULL
-      )
-    )
+    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+  GROUP BY
+    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
 ) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -21,27 +21,35 @@
             <!-- node_id = ss_23 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
             <!--    'column_alias': 'ds__day'}                                                     -->
             <!-- col1 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'listing__country_latest'}                                     -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_784),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col3 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_785),  -->
-            <!--    'column_alias': 'views'}                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col3 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'views'}                                                  -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- join_0 =                                                   -->
             <!--   {'class': 'SqlJoinDescription',                          -->
             <!--    'right_source': SqlSelectStatementNode(node_id=ss_22),  -->
             <!--    'right_source_alias': 'subq_19',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_4)}     -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                    -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_0)}     -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'ds__day'}                                                     -->
+            <!-- group_by1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'listing__country_latest'}                                     -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_fill_nulls_for_one_input_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_fill_nulls_for_one_input_metric__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_19 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_754),  -->
-            <!--    'column_alias': 'bookings_fill_nulls_with_0'}          -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_755),  -->
-            <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_fill_nulls_with_0'}                             -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_2_weeks_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
-            <!--    'right_source_alias': 'subq_15',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),   -->
+            <!--    'right_source_alias': 'subq_15',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                            -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_15 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_658),  -->
-            <!--    'column_alias': 'ref_bookings'}                        -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_659),  -->
-            <!--    'column_alias': 'bookings'}                            -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'ref_bookings'}                                           -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
-            <!--    'right_source_alias': 'subq_9',                         -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
+            <!--    'right_source_alias': 'subq_9',                          -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                            -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_17 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
-            <!--    'column_alias': 'bookings_at_start_of_month'}          -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_at_start_of_month'}                             -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
-            <!--    'right_source_alias': 'subq_12',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+            <!--    'right_source_alias': 'subq_12',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                            -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain_and_granularity__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_17 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__week'}                                           -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
-            <!--    'column_alias': 'bookings_at_start_of_month'}          -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_at_start_of_month'}                             -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
-            <!--    'right_source_alias': 'subq_12',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+            <!--    'right_source_alias': 'subq_12',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__week'}                                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_17 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
-            <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_2_weeks_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
-            <!--    'right_source_alias': 'subq_12',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+            <!--    'right_source_alias': 'subq_12',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                            -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_granularity__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_17 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__quarter'}                                        -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
-            <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_2_weeks_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
-            <!--    'right_source_alias': 'subq_12',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+            <!--    'right_source_alias': 'subq_12',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__quarter'}                                        -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_19 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_840),  -->
-            <!--    'column_alias': 'month_start_bookings'}                -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_841),  -->
-            <!--    'column_alias': 'bookings_1_month_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'month_start_bookings'}                                   -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_1_month_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
-            <!--    'right_source_alias': 'subq_15',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),   -->
+            <!--    'right_source_alias': 'subq_15',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                            -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_19 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__year'}                                           -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_840),  -->
-            <!--    'column_alias': 'month_start_bookings'}                -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_841),  -->
-            <!--    'column_alias': 'bookings_1_month_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'month_start_bookings'}                                   -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_1_month_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
-            <!--    'right_source_alias': 'subq_15',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),   -->
+            <!--    'right_source_alias': 'subq_15',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__year'}                                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_26 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_881),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_882),  -->
         <!--    'column_alias': 'metric_time__day'}                    -->
         <!-- col1 =                                                                                             -->
         <!--   {'class': 'SqlSelectColumn',                                                                     -->
@@ -15,35 +15,39 @@
         <SqlSelectStatementNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = ss_25 -->
-            <!-- col0 =                                                                            -->
-            <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
-            <!--    'column_alias': 'metric_time__day'}                                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_875),  -->
-            <!--    'column_alias': 'non_referred'}                        -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_876),  -->
-            <!--    'column_alias': 'instant'}                             -->
-            <!-- col3 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_877),  -->
-            <!--    'column_alias': 'bookings'}                            -->
+            <!-- col0 =                                                                             -->
+            <!--   {'class': 'SqlSelectColumn',                                                     -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_11, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                             -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_8, sql_function=MAX),  -->
+            <!--    'column_alias': 'non_referred'}                                           -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_9, sql_function=MAX),  -->
+            <!--    'column_alias': 'instant'}                                                -->
+            <!-- col3 =                                                                        -->
+            <!--   {'class': 'SqlSelectColumn',                                                -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_10, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                                -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),  -->
-            <!--    'right_source_alias': 'subq_16',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_3)}     -->
-            <!-- join_1 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_24),  -->
-            <!--    'right_source_alias': 'subq_21',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_5)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),   -->
+            <!--    'right_source_alias': 'subq_16',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+            <!-- join_1 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_24),   -->
+            <!--    'right_source_alias': 'subq_21',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2)}  -->
+            <!-- group_by0 =                                                                        -->
+            <!--   {'class': 'SqlSelectColumn',                                                     -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_11, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__day'}                                             -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->
@@ -63,23 +67,27 @@
                     <!-- node_id = ss_15 -->
                     <!-- col0 =                                                                            -->
                     <!--   {'class': 'SqlSelectColumn',                                                    -->
-                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
                     <!--    'column_alias': 'metric_time__day'}                                            -->
-                    <!-- col1 =                                                    -->
-                    <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_658),  -->
-                    <!--    'column_alias': 'ref_bookings'}                        -->
-                    <!-- col2 =                                                    -->
-                    <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_659),  -->
-                    <!--    'column_alias': 'bookings'}                            -->
+                    <!-- col1 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                               -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+                    <!--    'column_alias': 'ref_bookings'}                                           -->
+                    <!-- col2 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                               -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+                    <!--    'column_alias': 'bookings'}                                               -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-                    <!-- join_0 =                                                   -->
-                    <!--   {'class': 'SqlJoinDescription',                          -->
-                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
-                    <!--    'right_source_alias': 'subq_9',                         -->
-                    <!--    'join_type': SqlJoinType.INNER,                         -->
-                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+                    <!-- join_0 =                                                    -->
+                    <!--   {'class': 'SqlJoinDescription',                           -->
+                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
+                    <!--    'right_source_alias': 'subq_9',                          -->
+                    <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+                    <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+                    <!-- group_by0 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                                    -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+                    <!--    'column_alias': 'metric_time__day'}                                            -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Compute Metrics via Expressions -->
@@ -1723,7 +1731,7 @@
                     <!--    'column_alias': 'metric_time__day'}                    -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
-                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=SUM),  -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=SUM),  -->
                     <!--    'column_alias': 'instant_bookings'}                                       -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                     <!-- group_by0 =                                               -->
@@ -2532,7 +2540,7 @@
                     <!--    'column_alias': 'metric_time__day'}                    -->
                     <!-- col1 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                               -->
-                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=SUM),  -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_6, sql_function=SUM),  -->
                     <!--    'column_alias': 'bookings'}                                               -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
                     <!-- group_by0 =                                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_offset_window_with_date_part__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_offset_window_with_date_part__plan0.xml
@@ -17,23 +17,27 @@
             <!-- node_id = ss_17 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time__extract_dow'}                                    -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
-            <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+            <!-- col1 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings'}                                               -->
+            <!-- col2 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                               -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+            <!--    'column_alias': 'bookings_2_weeks_ago'}                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                   -->
-            <!--   {'class': 'SqlJoinDescription',                          -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
-            <!--    'right_source_alias': 'subq_12',                        -->
-            <!--    'join_type': SqlJoinType.INNER,                         -->
-            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+            <!--    'right_source_alias': 'subq_12',                         -->
+            <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+            <!-- group_by0 =                                                                       -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time__extract_dow'}                                    -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
@@ -6,9 +6,9 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_11.metric_time__day, subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , subq_11.average_booking_value AS average_booking_value
-    , subq_23.bookings AS bookings
-    , subq_28.booking_value AS booking_value
+    , MAX(subq_11.average_booking_value) AS average_booking_value
+    , MAX(subq_23.bookings) AS bookings
+    , MAX(subq_28.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -398,7 +398,7 @@ FROM (
         subq_9.metric_time__day
     ) subq_10
   ) subq_11
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_22.metric_time__day
@@ -788,16 +788,8 @@ FROM (
     ) subq_22
   ) subq_23
   ON
-    (
-      subq_11.metric_time__day = subq_23.metric_time__day
-    ) OR (
-      (
-        subq_11.metric_time__day IS NULL
-      ) AND (
-        subq_23.metric_time__day IS NULL
-      )
-    )
-  INNER JOIN (
+    subq_11.metric_time__day = subq_23.metric_time__day
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_27.metric_time__day
@@ -1014,13 +1006,7 @@ FROM (
     ) subq_27
   ) subq_28
   ON
-    (
-      subq_11.metric_time__day = subq_28.metric_time__day
-    ) OR (
-      (
-        subq_11.metric_time__day IS NULL
-      ) AND (
-        subq_28.metric_time__day IS NULL
-      )
-    )
+    COALESCE(subq_11.metric_time__day, subq_23.metric_time__day) = subq_28.metric_time__day
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_23.metric_time__day, subq_28.metric_time__day)
 ) subq_29

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
@@ -6,9 +6,9 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , subq_41.average_booking_value AS average_booking_value
-    , subq_53.bookings AS bookings
-    , subq_58.booking_value AS booking_value
+    , MAX(subq_41.average_booking_value) AS average_booking_value
+    , MAX(subq_53.bookings) AS bookings
+    , MAX(subq_58.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -36,7 +36,7 @@ FROM (
     GROUP BY
       metric_time__day
   ) subq_41
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
     --   ['bookings', 'metric_time__day']
@@ -74,16 +74,8 @@ FROM (
       metric_time__day
   ) subq_53
   ON
-    (
-      subq_41.metric_time__day = subq_53.metric_time__day
-    ) OR (
-      (
-        subq_41.metric_time__day IS NULL
-      ) AND (
-        subq_53.metric_time__day IS NULL
-      )
-    )
-  INNER JOIN (
+    subq_41.metric_time__day = subq_53.metric_time__day
+  FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
@@ -98,13 +90,7 @@ FROM (
       DATE_TRUNC('day', ds)
   ) subq_58
   ON
-    (
-      subq_41.metric_time__day = subq_58.metric_time__day
-    ) OR (
-      (
-        subq_41.metric_time__day IS NULL
-      ) AND (
-        subq_58.metric_time__day IS NULL
-      )
-    )
+    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+  GROUP BY
+    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
 ) subq_59

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
@@ -6,8 +6,8 @@ FROM (
   -- Combine Metrics
   SELECT
     COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
-    , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-    , subq_11.booking_value AS booking_value
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -240,7 +240,7 @@ FROM (
         subq_4.metric_time__day
     ) subq_5
   ) subq_6
-  INNER JOIN (
+  FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time__day
@@ -457,13 +457,7 @@ FROM (
     ) subq_10
   ) subq_11
   ON
-    (
-      subq_6.metric_time__day = subq_11.metric_time__day
-    ) OR (
-      (
-        subq_6.metric_time__day IS NULL
-      ) AND (
-        subq_11.metric_time__day IS NULL
-      )
-    )
+    subq_6.metric_time__day = subq_11.metric_time__day
+  GROUP BY
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
 ) subq_12

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -1,53 +1,53 @@
--- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
-  , CAST(subq_19.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_24.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  metric_time__day
+  , CAST(booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements:
-  --   ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Combine Metrics
   SELECT
-    metric_time__day
-    , SUM(booking_value) AS booking_value_with_is_instant_constraint
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements:
+    --   ['booking_value', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(booking_value) AS booking_value_with_is_instant_constraint
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_15
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_19
+  FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
-    --   ['booking_value', 'booking__is_instant', 'metric_time__day']
+    --   ['booking_value', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
-      , is_instant AS booking__is_instant
-      , booking_value
+      , SUM(booking_value) AS booking_value
     FROM ***************************.fct_bookings bookings_source_src_10001
-  ) subq_15
-  WHERE booking__is_instant
-  GROUP BY
-    metric_time__day
-) subq_19
-INNER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements:
-  --   ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
-  FROM ***************************.fct_bookings bookings_source_src_10001
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_24
-ON
-  (
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_24
+  ON
     subq_19.metric_time__day = subq_24.metric_time__day
-  ) OR (
-    (
-      subq_19.metric_time__day IS NULL
-    ) AND (
-      subq_24.metric_time__day IS NULL
-    )
-  )
+  GROUP BY
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -4,8 +4,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    subq_4.bookings AS bookings
-    , subq_9.listings AS listings
+    MAX(subq_4.bookings) AS bookings
+    , MAX(subq_9.listings) AS listings
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_15.bookings AS DOUBLE) / CAST(NULLIF(subq_20.listings, 0) AS DOUBLE) AS bookings_per_listing
+  CAST(MAX(subq_15.bookings) AS DOUBLE) / CAST(NULLIF(MAX(subq_20.listings), 0) AS DOUBLE) AS bookings_per_listing
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
@@ -20,7 +20,8 @@
                 <CombineMetricsNode>
                     <!-- description = Combine Metrics -->
                     <!-- node_id = cbm_0 -->
-                    <!-- join type = SqlJoinType.INNER -->
+                    <!-- join type = SqlJoinType.FULL_OUTER -->
+                    <!-- de-duplication method = post-join aggregation across all dimensions -->
                     <ComputeMetricsNode>
                         <!-- description = Compute Metrics via Expressions -->
                         <!-- node_id = cm_0 -->
@@ -126,7 +127,8 @@
                 <CombineMetricsNode>
                     <!-- description = Combine Metrics -->
                     <!-- node_id = cbm_1 -->
-                    <!-- join type = SqlJoinType.INNER -->
+                    <!-- join type = SqlJoinType.FULL_OUTER -->
+                    <!-- de-duplication method = post-join aggregation across all dimensions -->
                     <ComputeMetricsNode>
                         <!-- description = Compute Metrics via Expressions -->
                         <!-- node_id = cm_3 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
@@ -65,7 +65,8 @@
                 <CombineMetricsNode>
                     <!-- description = Combine Metrics -->
                     <!-- node_id = cbm_0 -->
-                    <!-- join type = SqlJoinType.INNER -->
+                    <!-- join type = SqlJoinType.FULL_OUTER -->
+                    <!-- de-duplication method = post-join aggregation across all dimensions -->
                     <ComputeMetricsNode>
                         <!-- description = Compute Metrics via Expressions -->
                         <!-- node_id = cm_1 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_1 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_2 -->
@@ -29,7 +30,8 @@
                     <CombineMetricsNode>
                         <!-- description = Combine Metrics -->
                         <!-- node_id = cbm_0 -->
-                        <!-- join type = SqlJoinType.INNER -->
+                        <!-- join type = SqlJoinType.FULL_OUTER -->
+                        <!-- de-duplication method = post-join aggregation across all dimensions -->
                         <ComputeMetricsNode>
                             <!-- description = Compute Metrics via Expressions -->
                             <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -15,7 +15,8 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_2 -->
-                <!-- join type = SqlJoinType.INNER -->
+                <!-- join type = SqlJoinType.FULL_OUTER -->
+                <!-- de-duplication method = post-join aggregation across all dimensions -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_9 -->


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #SL-1172


### Description
- do we also want to use FULL OUTER JOIN when joining measures via group bys?
- what about joining ratio metrics?
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
