### PR TITLE
Quote DuckDB version in install command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ features = [
 ]
 # Temporary workaround for installing the dbt-duckdb adapter until it's updated to support dbt-core~=1.7.0rc1.
 post-install-commands = [
-  "pip install duckdb>=0.7.0",
+  "pip install \"duckdb>=0.7.0\"",
   "pip install --no-deps dbt-duckdb~=1.6.0",
 ]
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Tiny fix for this DuckDB install command. I noticed that lately, every time Hatch install dependencies for `dev-env`, I would end up with a rogue file called `=0.7.0`. Turns out Hatch was interpreting this command incorrectly: `pip install duckdb>=0.7.0`. It was running `pip install duckdb`, and dumping the output of that command to a new file called `=0.7.0`. This PR updates the command to `pip install "duckdb>=0.7.0"`, which appears to have the intended effect.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
