### PR TITLE
Script for populating all persistent source schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ postgresql postgres:
 regenerate-test-snapshots:
 	hatch -v run dev-env:python metricflow/test/generate_snapshots.py
 
+# Populate persistent source schemas for all relevant SQL engines.
+.PHONY: populate-persistent-source-schemas
+populate-persistent-source-schemas:
+	hatch -v run dev-env:python metricflow/test/populate_persistent_source_schemas.py
+
 # Re-generate snapshots for the default SQL engine.
 .PHONY: test-snap
 test-snap:

--- a/metricflow/test/populate_persistent_source_schemas.py
+++ b/metricflow/test/populate_persistent_source_schemas.py
@@ -1,0 +1,45 @@
+"""Script to help generate persistent source schemas with test data for all relevant engines."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.test.generate_snapshots import (
+    MetricFlowTestConfiguration,
+    run_cli,
+    run_command,
+    set_engine_env_variables,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def populate_schemas(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
+    set_engine_env_variables(test_configuration)
+
+    if test_configuration.engine is SqlEngine.DUCKDB or test_configuration.engine is SqlEngine.POSTGRES:
+        # DuckDB & Postgres don't use persistent source schema
+        return None
+    elif (
+        test_configuration.engine is SqlEngine.SNOWFLAKE
+        or test_configuration.engine is SqlEngine.BIGQUERY
+        or test_configuration.engine is SqlEngine.DATABRICKS
+        or test_configuration.engine is SqlEngine.REDSHIFT
+    ):
+        engine_name = test_configuration.engine.value.lower()
+        os.environ["MF_TEST_ADAPTER_TYPE"] = engine_name
+        hatch_env = f"{engine_name}-env"
+        run_command(
+            f"hatch -v run {hatch_env}:pytest -vv --use-persistent-source-schema "
+            "metricflow/test/source_schema_tools.py::populate_source_schema"
+        )
+    else:
+        assert_values_exhausted(test_configuration.engine)
+
+
+if __name__ == "__main__":
+    run_cli(populate_schemas)


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
I found it annoying to have to populate the persistent source schemas for each engine individually, especially since that required setting the warehouse connection env variables for each engine before you could properly run each make target. So I wrote a script / make target to populate the persistent source schemas for all relevant engines at once, making use of the logic in `generate_snapshots.py` to set those variables dynamically.

Try running `make populate-persistent-source-schemas` to test this out yourself!
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
